### PR TITLE
Auto focus and select

### DIFF
--- a/js/services/contact_service.js
+++ b/js/services/contact_service.js
@@ -107,6 +107,7 @@ angular.module('contactsApp')
 			newContact.setETag(xhr.getResponseHeader('ETag'));
 			contacts.put(newUid, newContact);
 			notifyObservers('create', newUid);
+			$('#details-fullName').select();
 			return newContact;
 		}).catch(function() {
 			OC.Notification.showTemporary(t('contacts', 'Contact could not be created.'));


### PR DESCRIPTION
When creating a new contact, the name input is automatically selected and focused for instant edition.

Fix #52
