### PR TITLE
Fix contacts group split and added contact failure notification

### DIFF
--- a/css/public/style.css
+++ b/css/public/style.css
@@ -71,18 +71,18 @@
 	opacity: .8;
 }
 
-.contactdetails__header #details-actions .icon-delete-white,
-.contactdetails__header #details-actions #contact-export-link {
+.contactdetails__header #details-actions a,
+.contactdetails__header #details-actions button {
 	padding: 15px;
 	background-color: transparent;
 	border: none;
 	opacity: .5;
 	margin: 3px;
 }
-.contactdetails__header #details-actions .icon-delete-white:hover,
-.contactdetails__header .icon-delete-white:focus,
-.contactdetails__header #details-actions #contact-export-link:hover,
-.contactdetails__header #details-actions #contact-export-link:focus {
+.contactdetails__header #details-actions a:hover,
+.contactdetails__header #details-actions button:hover,
+.contactdetails__header #details-actions a:focus,
+.contactdetails__header #details-actions button:focus {
 	opacity: .7
 }
 
@@ -282,6 +282,11 @@ detailsitem.details-item-note label {
 	vertical-align: top;
 }
 
+detailsitem.failed > label,
+detailsitem.failed > select {
+	border-left: 2px solid red;
+}
+
 /* Prevent delete for last adr/mail/tel item  */
 .last-details > detailsitem.details-item-adr .icon-delete,
 .last-details > detailsitem.details-item-email .icon-delete,
@@ -392,6 +397,28 @@ li.addressBook-share-item span.shareeIdentifier {
 	text-align: left;
 	padding-left: 34px;
 	background-position: 10px center;
+}
+
+contactlist .tooltip {
+	max-width: 75%;
+}
+
+.app-content-list-item-failed {
+	position: absolute;
+	right: 15px;
+	top: 50%;
+	margin-top: -15px;
+	opacity: 0.2;
+	width: 30px;
+	height: 30px;
+	z-index: 50;
+}
+.app-content-list-item-failed:hover {
+	opacity: 0.5;
+}
+.app-content-list-item-failed ~ .app-content-list-item-line-one,
+.app-content-list-item-failed ~ .app-content-list-item-line-two {
+	padding-right: 50px;
 }
 
 

--- a/js/components/contact/contact_controller.js
+++ b/js/components/contact/contact_controller.js
@@ -2,6 +2,10 @@ angular.module('contactsApp')
 .controller('contactCtrl', function($route, $routeParams) {
 	var ctrl = this;
 
+	ctrl.t = {
+		errorMessage : t('contacts', 'This card is corrupted and has been fixed. Please check the data and trigger a save to make the changes permanent.'),
+	};
+
 	ctrl.openContact = function() {
 		$route.updateParams({
 			gid: $routeParams.gid,

--- a/js/components/contactDetails/contactDetails_controller.js
+++ b/js/components/contactDetails/contactDetails_controller.js
@@ -23,7 +23,8 @@ angular.module('contactsApp')
 		placeholderTitle : t('contacts', 'Title'),
 		selectField : t('contacts', 'Add field ...'),
 		download : t('contacts', 'Download'),
-		delete : t('contacts', 'Delete')
+		delete : t('contacts', 'Delete'),
+		save : t('contacts', 'Save changes')
 	};
 
 	ctrl.fieldDefinitions = vCardPropertiesService.fieldDefinitions;

--- a/js/models/contact_model.js
+++ b/js/models/contact_model.js
@@ -157,9 +157,14 @@ angular.module('contactsApp')
 						return [];
 					}
 					if (angular.isArray(property.value)) {
+						// Avoid and fix unescaped commas
+						if(property.value.join(';').indexOf(',') !== -1) {
+							property.value = property.value.join(',').split(',');
+							this.setProperty('categories', { value: property.value });
+						}
 						return property.value;
 					}
-					return [property.value];
+					return property.value.split(',');
 				}
 			},
 

--- a/js/models/contact_model.js
+++ b/js/models/contact_model.js
@@ -320,9 +320,6 @@ angular.module('contactsApp')
 						}
 					}
 					break;
-
-				default:
-					break;
 				}
 				return property;
 			}
@@ -342,7 +339,7 @@ angular.module('contactsApp')
 
 		var property = this.getProperty('categories');
 		if(!property) {
-			this.categories('');
+			this.categories([]);
 		} else {
 			if (angular.isString(property.value)) {
 				this.categories([property.value]);

--- a/js/tests/models/contact_model.js
+++ b/js/tests/models/contact_model.js
@@ -27,4 +27,11 @@ describe('contactModel', function() {
 		var d = contact.getISODate(new Date('2016-09-01T09:07:05Z'));
 		expect(d).to.equal('20160901T090705Z');
 	});
+
+	it('should fix invalid group array', function() {
+		var contact = new $Contact({displayName: 'test'});
+		contact.categories(['Test 1', 'Test 2\,Test 3']);
+		var categories = contact.categories();
+		expect(categories).to.deep.equal(['Test 1', 'Test 2', 'Test 3']);
+	});
 });

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -2,6 +2,7 @@
     <img class="app-content-list-item-icon contact__icon" ng-show="ctrl.contact.photo()!==undefined" data-ng-src="{{ctrl.contact.photo()}}" />
     <div class="app-content-list-item-icon contact__icon" ng-show="ctrl.contact.photo()===undefined" ng-style="{'background-color': (ctrl.contact.uid() | contactColor) }">{{ ctrl.contact.displayName() | firstCharacter }}</div>
     <div class="app-content-list-item-star icon-star" data-starred="false"></div>
+    <div class="app-content-list-item-failed icon-error" tooltip-placement="auto left" ng-if="ctrl.contact.failedProps.length>0" uib-tooltip="{{ ctrl.t.errorMessage }}"></div>
     <div class="app-content-list-item-line-one" ng-class="{'no-line-two':!ctrl.contact.email()}">{{ ctrl.contact.displayName() | newContact }}</div>
     <div class="app-content-list-item-line-two">{{ctrl.contact.email()}}</div>
 </a>

--- a/templates/contactDetails.html
+++ b/templates/contactDetails.html
@@ -24,6 +24,7 @@
 				</div>
 			</div>
 			<div id="details-actions">
+				<button id="contact-failed-save" ng-click="ctrl.updateContact()" class="icon-checkmark-white" ng-if="ctrl.contact.failedProps.length>0" title="{{ctrl.t.save}}"></button>
 				<a href="{{ctrl.contact.data.url}}" id="contact-export-link"
 				   class="icon-download-white" title="{{ctrl.t.download}}"
 				   download="{{ ctrl.contact.readableFilename() }}"></a>
@@ -32,7 +33,8 @@
 		</header>
 		<section>
 			<div ng-repeat="prop in ctrl.contact.props | toArray | orderDetailItems:'$key'">
-				<detailsItem ng-repeat="propData in prop" name="prop.$key" data="propData" model="ctrl" index="$index" ng-class="[ 'details-item-' + prop.$key ]"></detailsItem>
+				<detailsItem ng-repeat="propData in prop" name="prop.$key" data="propData" model="ctrl" index="$index"
+							 class="details-item-{{prop.$key}}" ng-class="{ 'failed': ctrl.contact.failedProps.indexOf(prop.$key) !== -1 }"></detailsItem>
 			</div>
 			<div class="select-addressbook" ng-if="ctrl.addressBooks.length > 1">
 				<select ng-model="ctrl.addressBook" ng-change="ctrl.changeAddressBook(ctrl.addressBook)" ng-options="book.displayName for book in ctrl.addressBooks">
@@ -45,3 +47,4 @@
 		</section>
 	</div>
 </div>
+


### PR DESCRIPTION
- Remove the ability to add comma into groups name for better readability
- Automatically split unescaped comma into groups to repair broken vcard groups
- Added notification for failed vcard
- Added a save button in case of corrupted vcard
- Added function for future vcard correction with automatic error notification

Broken vcard for review: 
[6cc082f2-17a7-4730-99e1-c9870f072d9d.txt](https://github.com/nextcloud/contacts/files/723757/6cc082f2-17a7-4730-99e1-c9870f072d9d.txt)

(should have three groups, broken master show 2 with one not separated by the comma)
![capture d ecran_2017-02-02_07-40-41](https://cloud.githubusercontent.com/assets/14975046/22539533/ee535996-e91a-11e6-8799-63a3d3f6888f.png)


----------------------

![capture d ecran_2017-01-05_12-33-48](https://cloud.githubusercontent.com/assets/14975046/21679249/4d783128-d343-11e6-9dff-4a7213d8a7cf.png)
![capture d ecran_2017-01-05_12-34-06](https://cloud.githubusercontent.com/assets/14975046/21679250/4d8edda6-d343-11e6-863f-a17bcb54326e.png)
![capture d ecran_2017-01-05_12-34-19](https://cloud.githubusercontent.com/assets/14975046/21679251/4d9c224a-d343-11e6-9b64-1cdc92d35d54.png)
