### PR TITLE
Fix url-link icon position.

### DIFF
--- a/css/public/style.css
+++ b/css/public/style.css
@@ -261,7 +261,6 @@ detailsitem .icon-delete {
 detailsitem .url-link {
 	position: absolute;
 	padding: 8px 10px;
-	margin-left: -30px;
 	opacity: .5;
 }
 


### PR DESCRIPTION
Previously, the url-link icon would overlap the delete icon (.icon-delete). This change moves the url-link icon to the right.