### PR TITLE
Add exception for invalid base64 avatar strings, fix #94

### DIFF
--- a/js/models/contact_model.js
+++ b/js/models/contact_model.js
@@ -133,6 +133,9 @@ angular.module('contactsApp')
 					var property = this.getProperty('photo');
 					if(property) {
 						var type = property.meta.type;
+						if (angular.isUndefined(type)) {
+							return undefined;
+						}
 						if (angular.isArray(type)) {
 							type = type[0];
 						}

--- a/js/tests/models/contact_model.js
+++ b/js/tests/models/contact_model.js
@@ -22,6 +22,20 @@ describe('contactModel', function() {
 		expect(contact.matches('kenya')).to.equal(true);
 	});
 
+	it('should parse a valid avatar', function() {
+		var contact = new $Contact({displayName: 'test'});
+		var base64Photo = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wgARCAAEAAQDAREAAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAAB//EABUBAQEAAAAAAAAAAAAAAAAAAAQG/9oADAMBAAIQAxAAAAEuPT//xAAVEAEBAAAAAAAAAAAAAAAAAAADBP/aAAgBAQABBQKiplT/xAAYEQACAwAAAAAAAAAAAAAAAAABAwACMf/aAAgBAwEBPwGz2E7P/8QAGBEAAgMAAAAAAAAAAAAAAAAAAQIAAyH/2gAIAQIBAT8BFSLgE//EABcQAQADAAAAAAAAAAAAAAAAAAEAAgP/2gAIAQEABj8CW2is/8QAFRABAQAAAAAAAAAAAAAAAAAAAFH/2gAIAQEAAT8hq3j/2gAMAwEAAgADAAAAEN//xAAWEQADAAAAAAAAAAAAAAAAAAAAARH/2gAIAQMBAT8QumP/xAAVEQEBAAAAAAAAAAAAAAAAAAAAAf/aAAgBAgEBPxCaH//EABgQAQADAQAAAAAAAAAAAAAAAAEAIVFh/9oACAEBAAE/ECIUCwdzVn//2Q==';
+		contact.photo(base64Photo);
+		expect(contact.photo()).to.equal(base64Photo);
+	});
+
+	it('should ignore an invalid avatar', function() {
+		var contact = new $Contact({displayName: 'test'});
+		var base64Photo = 'ENCODING=b:iVBORw0KGgoAAAANSUhEUgAAAHwAAAB8CAMAAACcwCSMAAAAgVBMVEX/0QEAAAD/0QD/1wH/1AH/3QH/2QGkigE/NABPQQBSQwABIAAD/2wBDAAEQEBAAAAAAAAEBAAE/ECIUCwdzVn//2Q==';
+		contact.photo(base64Photo);
+		expect(contact.photo()).to.be.undefined;
+	});
+
 	it('should generate proper ISO.8601.2004 date string', function() {
 		var contact = new $Contact({displayName: 'test'});
 		var d = contact.getISODate(new Date('2016-09-01T09:07:05Z'));


### PR DESCRIPTION
Fix #94 
Vcf test: [Test.txt](https://github.com/nextcloud/contacts/files/728085/Test.txt)

If #85 was merged, we could easily add a warning too :)

Before 
![capture d ecran_2017-01-24_23-13-01](https://cloud.githubusercontent.com/assets/14975046/22269213/c251c198-e28a-11e6-8b75-f924c2549605.png) ![capture d ecran_2017-01-24_23-12-56](https://cloud.githubusercontent.com/assets/14975046/22269212/c24d25c0-e28a-11e6-9c5f-0687eb43428d.png)

After, no errors in log and
![capture d ecran_2017-01-24_23-13-37](https://cloud.githubusercontent.com/assets/14975046/22269233/cf94c49a-e28a-11e6-8ad6-d5696117cc8a.png)
