### PR TITLE
Fix typo in "Show URL"

### DIFF
--- a/js/components/addressBook/addressBook_controller.js
+++ b/js/components/addressBook/addressBook_controller.js
@@ -4,7 +4,7 @@ angular.module('contactsApp')
 
 	ctrl.t = {
 		download: t('contacts', 'Download'),
-		showURL:t('contacts', 'ShowURL'),
+		showURL:t('contacts', 'Show URL'),
 		shareAddressbook: t('contacts', 'Share Addressbook'),
 		deleteAddressbook: t('contacts', 'Delete Addressbook'),
 		shareInputPlaceHolder: t('contacts', 'Share with users or groups'),


### PR DESCRIPTION
See question at https://www.transifex.com/nextcloud/nextcloud/translate/#de/contacts/104496499

I don't think the missing space was intended?