### PR TITLE
Missing border in Contacts

### DIFF
--- a/css/public/style.css
+++ b/css/public/style.css
@@ -435,6 +435,7 @@ contactlist .tooltip {
 	height: 100%;
 	overflow-x: hidden;
 	overflow-y: auto;
+	border-right: 1px solid #eee;
 }
 
 .app-content-detail {


### PR DESCRIPTION
I use your demo of NextCloud and founded a missing border. On the left is a grey border for the sidebar. On the next 2 divs is no border anymore. It would be good, if a border is here too to seperate it.

![unbenannt-1](https://cloud.githubusercontent.com/assets/1473674/23582222/fd0546ac-0125-11e7-979e-253d3e4447d4.png)
