### PR TITLE
Fix :active background for contactdetails header input fields.

### DIFF
--- a/css/public/style.css
+++ b/css/public/style.css
@@ -19,6 +19,9 @@
 	display: flex;
 	flex-wrap: wrap;
 }
+.contactdetails__header input[type=text]:active {
+	background: transparent !important; /* remove :active effect */
+}
 .contactdetails__header .contactdetails__name,
 .contactdetails__header .contactdetails__org,
 .contactdetails__header .contactdetails__title {


### PR DESCRIPTION
When **clicking** on an input field in the contactdetails header, the background becomes white (Nextcloud, current master).

![2017-04-22-162454_436x105](https://cloud.githubusercontent.com/assets/8360698/25305271/6bc4a66e-2778-11e7-88f5-88d61df5d799.png)

This PR fixes this, by setting the background to transparent when `:active`.