### PR TITLE
Notify on contact not found

### DIFF
--- a/js/services/contact_service.js
+++ b/js/services/contact_service.js
@@ -144,17 +144,22 @@ angular.module('contactsApp')
 			}
 		}).call(this)
 			.then(function (contact) {
-				var addressBook = _.find(addressBooks, function(book) {
-					return book.displayName === contact.addressBookId;
-				});
-				return addressBook
-					? DavClient.getContacts(addressBook, {}, [ contact.data.url ]).then(
-						function (vcards) { return new Contact(addressBook, vcards[0]); }
-					).then(function (contact) {
-						contacts.put(contact.uid(), contact);
-						notifyObservers('getFullContacts', contact.uid());
-						return contact;
-					}) : contact;
+				if(angular.isUndefined(contact)) {
+					OC.Notification.showTemporary(t('contacts', 'Contact not found.'));
+					return;
+				} else {
+					var addressBook = _.find(addressBooks, function(book) {
+						return book.displayName === contact.addressBookId;
+					});
+					return addressBook
+						? DavClient.getContacts(addressBook, {}, [ contact.data.url ]).then(
+							function (vcards) { return new Contact(addressBook, vcards[0]); }
+						).then(function (contact) {
+							contacts.put(contact.uid(), contact);
+							notifyObservers('getFullContacts', contact.uid());
+							return contact;
+						}) : contact;
+				}
 			});
 	};
 


### PR DESCRIPTION
Show a notification if the requested uid does not match any contact.
If failure, redirect to first contact of the group.


Testing: click a contact, change the uid in the url by something you made up: see the notification and the redirect.

Fix #269