### PR TITLE
Addressbook deletion update contacts list and groups

### DIFF
--- a/js/components/addressBookList/addressBookList_controller.js
+++ b/js/components/addressBookList/addressBookList_controller.js
@@ -1,5 +1,5 @@
 angular.module('contactsApp')
-.controller('addressbooklistCtrl', function($scope, $timeout, AddressBookService) {
+.controller('addressbooklistCtrl', function($scope, AddressBookService) {
 	var ctrl = this;
 
 	ctrl.loading = true;

--- a/js/components/addressBookList/addressBookList_controller.js
+++ b/js/components/addressBookList/addressBookList_controller.js
@@ -1,5 +1,5 @@
 angular.module('contactsApp')
-.controller('addressbooklistCtrl', function($scope, AddressBookService) {
+.controller('addressbooklistCtrl', function($scope, $timeout, AddressBookService) {
 	var ctrl = this;
 
 	ctrl.loading = true;

--- a/js/components/contactList/contactList_controller.js
+++ b/js/components/contactList/contactList_controller.js
@@ -56,41 +56,45 @@ angular.module('contactsApp')
 	ctrl.loading = true;
 
 	ContactService.registerObserverCallback(function(ev) {
-		$timeout(function() { $scope.$apply(function() {
-			if (ev.event === 'delete') {
-				ctrl.getFirstContact(ev.uid);
-			}
-			else if (ev.event === 'create') {
-				$route.updateParams({
-					gid: $routeParams.gid,
-					uid: ev.uid
-				});
-			}
-			else if (ev.event === 'importend') {
-				$route.updateParams({
-					gid: t('contacts', 'All contacts')
-				});
-			}
-			if(ev.contacts.length !== 0) {
-				ctrl.contacts = ev.contacts;
-			}
-		}); });
+		$timeout(function() {
+			$scope.$apply(function() {
+				if (ev.event === 'delete') {
+					ctrl.getFirstContact(ev.uid);
+				}
+				else if (ev.event === 'create') {
+					$route.updateParams({
+						gid: $routeParams.gid,
+						uid: ev.uid
+					});
+				}
+				else if (ev.event === 'importend') {
+					$route.updateParams({
+						gid: t('contacts', 'All contacts')
+					});
+				}
+				if(ev.contacts.length !== 0) {
+					ctrl.contacts = ev.contacts;
+				}
+			});
+		});
 	});
 
 	AddressBookService.registerObserverCallback(function(ev) {
-		$timeout(function() { $scope.$apply(function() {
-			if (ev.event === 'delete') {
-				// Get contacts
-				ctrl.loading = true;
-				ContactService.updateDeletedAddressbook(function() {
-					ContactService.getAll().then(function(contacts) {
-						ctrl.contacts = contacts;
-						ctrl.loading = false;
-						ctrl.getFirstContact(ctrl.getSelectedId());
+		$timeout(function() {
+			$scope.$apply(function() {
+				if (ev.event === 'delete') {
+					// Get contacts
+					ctrl.loading = true;
+					ContactService.updateDeletedAddressbook(function() {
+						ContactService.getAll().then(function(contacts) {
+							ctrl.contacts = contacts;
+							ctrl.loading = false;
+							ctrl.getFirstContact(ctrl.getSelectedId());
+						});
 					});
-				});
-			}
-		}); });
+				}
+			});
+		});
 	});
 
 	// Get contacts

--- a/js/components/contactList/contactList_controller.js
+++ b/js/components/contactList/contactList_controller.js
@@ -113,10 +113,10 @@ angular.module('contactsApp')
 		var elHeight = $('.contacts-list').children().outerHeight(true);
 		var listHeight = $('.app-content-list').height();
 
-		var topContact = Math.round(scrolled/elHeight-1);
-		var contactsCount = Math.round(listHeight/elHeight+1);
+		var topContact = Math.round(scrolled/elHeight);
+		var contactsCount = Math.round(listHeight/elHeight);
 
-		return ctrl.contactList.slice(topContact, topContact+contactsCount);
+		return ctrl.contactList.slice(topContact-1, topContact+contactsCount+1);
 	};
 
 	var timeoutId = null;

--- a/js/components/contactList/contactList_controller.js
+++ b/js/components/contactList/contactList_controller.js
@@ -108,37 +108,23 @@ angular.module('contactsApp')
 		}
 	});
 
-	var getVisibleNames = function getVisibleNames() {
-		function isScrolledIntoView(el) {
-			var elemTop = el.getBoundingClientRect().top;
-			var elemBottom = el.getBoundingClientRect().bottom;
+	var getVisibleContacts = function() {
+		var scrolled = $('.app-content-list').scrollTop();
+		var elHeight = $('.contacts-list').children().outerHeight(true);
+		var listHeight = $('.app-content-list').height();
 
-			var bothAboveViewport = elemBottom < 0;
-			var bothBelowViewPort = elemTop > window.innerHeight;
-			var isVisible = !bothAboveViewport && !bothBelowViewPort;
-			return isVisible;
-		}
+		var topContact = Math.round(scrolled/elHeight-1);
+		var contactsCount = Math.round(listHeight/elHeight+1);
 
-		var elements = Array.prototype.slice.call(document.querySelectorAll('.contact__icon:not(.ng-hide)'));
-		var names = elements
-				.filter(isScrolledIntoView)
-				.map(function (el) {
-					var siblings = Array.prototype.slice.call(el.parentElement.children);
-					var nameElement = siblings.find(function (sibling) {
-						return sibling.getAttribute('class').indexOf('content-list-item-line-one') !== -1;
-					});
-					return nameElement.innerText;
-
-				});
-		return names;
+		return ctrl.contactList.slice(topContact, topContact+contactsCount);
 	};
 
 	var timeoutId = null;
 	document.querySelector('.app-content-list').addEventListener('scroll', function () {
 		clearTimeout(timeoutId);
 		timeoutId = setTimeout(function () {
-			var names = getVisibleNames();
-			ContactService.getFullContacts(names);
+			var contacts = getVisibleContacts();
+			ContactService.getFullContacts(contacts);
 		}, 250);
 	});
 

--- a/js/components/contactList/contactList_controller.js
+++ b/js/components/contactList/contactList_controller.js
@@ -58,22 +58,7 @@ angular.module('contactsApp')
 	ContactService.registerObserverCallback(function(ev) {
 		$timeout(function() { $scope.$apply(function() {
 			if (ev.event === 'delete') {
-				if (ctrl.contactList.length === 1) {
-					$route.updateParams({
-						gid: $routeParams.gid,
-						uid: undefined
-					});
-				} else {
-					for (var i = 0, length = ctrl.contactList.length; i < length; i++) {
-						if (ctrl.contactList[i].uid() === ev.uid) {
-							$route.updateParams({
-								gid: $routeParams.gid,
-								uid: (ctrl.contactList[i+1]) ? ctrl.contactList[i+1].uid() : ctrl.contactList[i-1].uid()
-							});
-							break;
-						}
-					}
-				}
+				ctrl.getFirstContact(ev.uid);
 			}
 			else if (ev.event === 'create') {
 				$route.updateParams({
@@ -98,7 +83,11 @@ angular.module('contactsApp')
 				// Get contacts
 				ctrl.loading = true;
 				ContactService.updateDeletedAddressbook(function() {
-					ctrl.loading = false;
+					ContactService.getAll().then(function(contacts) {
+						ctrl.contacts = contacts;
+						ctrl.loading = false;
+						ctrl.getFirstContact(ctrl.getSelectedId());
+					});
 				});
 			}
 		}); });
@@ -245,6 +234,26 @@ angular.module('contactsApp')
 
 	ctrl.getSelectedId = function() {
 		return $routeParams.uid;
+	};
+
+	ctrl.getFirstContact = function(contactId) {
+		if (ctrl.contactList.length === 1) {
+			$route.updateParams({
+				gid: $routeParams.gid,
+				uid: undefined
+			});
+		} else {
+			for (var i = 0, length = ctrl.contactList.length; i < length; i++) {
+				// Get nearest contact
+				if (ctrl.contactList[i].uid() === contactId) {
+					$route.updateParams({
+						gid: $routeParams.gid,
+						uid: (ctrl.contactList[i+1]) ? ctrl.contactList[i+1].uid() : ctrl.contactList[i-1].uid()
+					});
+					break;
+				}
+			}
+		}
 	};
 
 });

--- a/js/components/contactList/contactList_controller.js
+++ b/js/components/contactList/contactList_controller.js
@@ -56,7 +56,7 @@ angular.module('contactsApp')
 	ctrl.loading = true;
 
 	ContactService.registerObserverCallback(function(ev) {
-		$timeout(function () { $scope.$apply(function() {
+		$timeout(function() { $scope.$apply(function() {
 			if (ev.event === 'delete') {
 				if (ctrl.contactList.length === 1) {
 					$route.updateParams({
@@ -93,7 +93,7 @@ angular.module('contactsApp')
 	});
 
 	AddressBookService.registerObserverCallback(function(ev) {
-		$timeout(function () { $scope.$apply(function() {
+		$timeout(function() { $scope.$apply(function() {
 			if (ev.event === 'delete') {
 				// Get contacts
 				ctrl.loading = true;

--- a/js/components/contactList/contactList_controller.js
+++ b/js/components/contactList/contactList_controller.js
@@ -59,7 +59,7 @@ angular.module('contactsApp')
 		$timeout(function() {
 			$scope.$apply(function() {
 				if (ev.event === 'delete') {
-					ctrl.getFirstContact(ev.uid);
+					ctrl.selectNearestContact(ev.uid);
 				}
 				else if (ev.event === 'create') {
 					$route.updateParams({
@@ -89,7 +89,7 @@ angular.module('contactsApp')
 						ContactService.getAll().then(function(contacts) {
 							ctrl.contacts = contacts;
 							ctrl.loading = false;
-							ctrl.getFirstContact(ctrl.getSelectedId());
+							ctrl.selectNearestContact(ctrl.getSelectedId());
 						});
 					});
 				}
@@ -240,7 +240,7 @@ angular.module('contactsApp')
 		return $routeParams.uid;
 	};
 
-	ctrl.getFirstContact = function(contactId) {
+	ctrl.selectNearestContact = function(contactId) {
 		if (ctrl.contactList.length === 1) {
 			$route.updateParams({
 				gid: $routeParams.gid,

--- a/js/components/contactList/contactList_controller.js
+++ b/js/components/contactList/contactList_controller.js
@@ -160,8 +160,8 @@ angular.module('contactsApp')
 			if(ctrl.loading && $(window).width() > 768) {
 				ctrl.setSelectedId(ctrl.contactList[0].uid());
 			}
-			var firstNames = ctrl.contactList.slice(0, 20).map(function (c) { return c.displayName(); });
-			ContactService.getFullContacts(firstNames);
+			// Get full data for the first 20 contacts of the list
+			ContactService.getFullContacts(ctrl.contactList.slice(0, 20));
 			ctrl.loading = false;
 			unbindListWatch();
 		}

--- a/js/components/contactList/contactList_controller.js
+++ b/js/components/contactList/contactList_controller.js
@@ -1,5 +1,5 @@
 angular.module('contactsApp')
-.controller('contactlistCtrl', function($scope, $filter, $route, $routeParams, $timeout, ContactService, SortByService, vCardPropertiesService, SearchService) {
+.controller('contactlistCtrl', function($scope, $filter, $route, $routeParams, $timeout, AddressBookService, ContactService, SortByService, vCardPropertiesService, SearchService) {
 	var ctrl = this;
 
 	ctrl.routeParams = $routeParams;
@@ -88,6 +88,18 @@ angular.module('contactsApp')
 			}
 			if(ev.contacts.length !== 0) {
 				ctrl.contacts = ev.contacts;
+			}
+		}); });
+	});
+
+	AddressBookService.registerObserverCallback(function(ev) {
+		$timeout(function () { $scope.$apply(function() {
+			if (ev.event === 'delete') {
+				// Get contacts
+				ctrl.loading = true;
+				ContactService.updateDeletedAddressbook(function() {
+					ctrl.loading = false;
+				});
 			}
 		}); });
 	});

--- a/js/components/groupList/groupList_controller.js
+++ b/js/components/groupList/groupList_controller.js
@@ -12,7 +12,7 @@ angular.module('contactsApp')
 		return $routeParams.gid;
 	};
 
-	// Update groupList on contact add/delete/update
+	// Update groupList on contact add/delete/update/groupsUpdate
 	ContactService.registerObserverCallback(function(ev) {
 		if (ev.event !== 'getFullContacts') {
 			$timeout(function () { $scope.$apply(function() {

--- a/js/components/groupList/groupList_controller.js
+++ b/js/components/groupList/groupList_controller.js
@@ -15,11 +15,13 @@ angular.module('contactsApp')
 	// Update groupList on contact add/delete/update/groupsUpdate
 	ContactService.registerObserverCallback(function(ev) {
 		if (ev.event !== 'getFullContacts') {
-			$timeout(function () { $scope.$apply(function() {
-				ContactService.getGroupList().then(function(groups) {
-					ctrl.groups = groups;
+			$timeout(function () {
+				$scope.$apply(function() {
+					ContactService.getGroupList().then(function(groups) {
+						ctrl.groups = groups;
+					});
 				});
-			}); });
+			});
 		}
 	});
 

--- a/js/services/addressBook_service.js
+++ b/js/services/addressBook_service.js
@@ -4,6 +4,18 @@ angular.module('contactsApp')
 	var addressBooks = [];
 	var loadPromise = undefined;
 
+	var observerCallbacks = [];
+
+	var notifyObservers = function(eventName) {
+		var ev = {
+			event: eventName,
+			addressBooks: addressBooks
+		};
+		angular.forEach(observerCallbacks, function(callback) {
+			callback(ev);
+		});
+	};
+
 	var loadAll = function() {
 		if (addressBooks.length > 0) {
 			return $q.when(addressBooks);
@@ -20,6 +32,10 @@ angular.module('contactsApp')
 	};
 
 	return {
+		registerObserverCallback: function(callback) {
+			observerCallbacks.push(callback);
+		},
+
 		getAll: function() {
 			return loadAll().then(function() {
 				return addressBooks;
@@ -64,6 +80,7 @@ angular.module('contactsApp')
 				return DavClient.deleteAddressBook(addressBook).then(function() {
 					var index = addressBooks.indexOf(addressBook);
 					addressBooks.splice(index, 1);
+					notifyObservers('delete');
 				});
 			});
 		},

--- a/js/services/contact_service.js
+++ b/js/services/contact_service.js
@@ -1,5 +1,5 @@
 angular.module('contactsApp')
-.service('ContactService', function(DavClient, AddressBookService, Contact, $q, CacheFactory, uuid4) {
+.service('ContactService', function(DavClient, AddressBookService, Contact, $q, $filter, CacheFactory, uuid4) {
 
 	var cacheFilled = false;
 
@@ -292,4 +292,22 @@ angular.module('contactsApp')
 			notifyObservers('delete', contact.uid());
 		});
 	};
+
+	this.updateDeletedAddressbook = function(callback) {
+		// Delete contacts which addressbook has been removed from cache
+		AddressBookService.getAll().then(function (enabledAddressBooks) {
+			var addressBooksIds = [];
+			angular.forEach(enabledAddressBooks, function(addressBook) {
+				addressBooksIds.push(addressBook.displayName);
+			});
+			angular.forEach(contacts.values(), function(contact) {
+				if (addressBooksIds.indexOf(contact.addressBookId) === -1) {
+					contacts.remove(contact.uid());
+					notifyObservers('delete', contact.uid());
+				}
+			});
+			callback();
+		});
+	};
+
 });

--- a/js/services/contact_service.js
+++ b/js/services/contact_service.js
@@ -4,7 +4,6 @@ angular.module('contactsApp')
 	var cacheFilled = false;
 
 	var contacts = CacheFactory('contacts');
-	var urlsByDisplayname = CacheFactory('urlsByDisplayname');
 
 	var observerCallbacks = [];
 
@@ -25,25 +24,34 @@ angular.module('contactsApp')
 		});
 	};
 
-	this.getFullContacts = function getFullContacts(names) {
+	this.getFullContacts = function(contacts) {
 		AddressBookService.getAll().then(function (enabledAddressBooks) {
 			var promises = [];
-			enabledAddressBooks.forEach(function (addressBook) {
-				var urlLists = names.map(function (name) { return urlsByDisplayname.get(name); });
-				var urls = [].concat.apply([], urlLists);
-				var promise = DavClient.getContacts(addressBook, {}, urls)
-						.then(
-							function (vcards) {
-								return vcards.map(function (vcard) {
-									return new Contact(addressBook, vcard);
-								});
-							})
-						.then(function (contacts_) {
+			var xhrAddressBooks = [];
+			contacts.forEach(function (contact) {
+				// Regroup urls by addressbooks
+				if(enabledAddressBooks.indexOf(contact.data.addressBook) !== -1) {
+					// Initiate array if no exists
+					xhrAddressBooks[contact.addressBookId] = xhrAddressBooks[contact.addressBookId] || [];
+					xhrAddressBooks[contact.addressBookId].push(contact.data.url);
+				}
+			});
+			// Get our full vCards
+			enabledAddressBooks.forEach(function(addressBook) {
+				if(angular.isArray(xhrAddressBooks[addressBook.displayName])) {
+					console.log('Contacts found for: '+addressBook.displayName);
+					var promise = DavClient.getContacts(addressBook, {}, xhrAddressBooks[addressBook.displayName]).then(
+						function (vcards) {
+							return vcards.map(function (vcard) {
+								return new Contact(addressBook, vcard);
+							});
+						}).then(function (contacts_) {
 							contacts_.map(function (contact) {
 								contacts.put(contact.uid(), contact);
 							});
 						});
-				promises.push(promise);
+					promises.push(promise);
+				}
 			});
 			$q.all(promises).then(function () {
 				notifyObservers('getFullContacts', '');
@@ -62,8 +70,6 @@ angular.module('contactsApp')
 								if (addressBook.objects[i].addressData) {
 									var contact = new Contact(addressBook, addressBook.objects[i]);
 									contacts.put(contact.uid(), contact);
-									var oldList = urlsByDisplayname.get(contact.displayName()) || [];
-									urlsByDisplayname.put(contact.displayName(), oldList.concat(contact.data.url));
 								} else {
 									// eslint-disable-next-line no-console
 									console.log('Invalid contact received: ' + addressBook.objects[i].url);

--- a/js/services/contact_service.js
+++ b/js/services/contact_service.js
@@ -1,5 +1,5 @@
 angular.module('contactsApp')
-.service('ContactService', function(DavClient, AddressBookService, Contact, $q, $filter, CacheFactory, uuid4) {
+.service('ContactService', function(DavClient, AddressBookService, Contact, $q, CacheFactory, uuid4) {
 
 	var cacheFilled = false;
 

--- a/js/services/contact_service.js
+++ b/js/services/contact_service.js
@@ -303,10 +303,10 @@ angular.module('contactsApp')
 			angular.forEach(contacts.values(), function(contact) {
 				if (addressBooksIds.indexOf(contact.addressBookId) === -1) {
 					contacts.remove(contact.uid());
-					notifyObservers('delete', contact.uid());
 				}
 			});
 			callback();
+			notifyObservers('groupsUpdate');
 		});
 	};
 

--- a/js/services/contact_service.js
+++ b/js/services/contact_service.js
@@ -39,7 +39,6 @@ angular.module('contactsApp')
 			// Get our full vCards
 			enabledAddressBooks.forEach(function(addressBook) {
 				if(angular.isArray(xhrAddressBooks[addressBook.displayName])) {
-					console.log('Contacts found for: '+addressBook.displayName);
 					var promise = DavClient.getContacts(addressBook, {}, xhrAddressBooks[addressBook.displayName]).then(
 						function (vcards) {
 							return vcards.map(function (vcard) {


### PR DESCRIPTION
Fix #287 

- [x] Working if the selected contact doesn't belong to the ab we deleted
- [x] Fix: update uid in url after deletion
- [x] Fix: too many request in background on contact deletion
- [x] Fix: update groups as well
- [x] Fix: lazy loading getContacts addressbooks

**Testing**:
 1. Add contacts to various addressbooks
 2. Delete one addressbook
 3. See everything being updated to left only the existing contacts