### PR TITLE
Nvm to 5.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
 before_install:
     - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start
-    - nvm install 5.6
+    - nvm install 5.10
     - npm install -g npm@latest
     - make
     - make appstore


### PR DESCRIPTION
Fix our failing builds on travis

```
npm ERR! Buffer.alloc is not a function
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/travis/.npm/_logs/2017-09-03T14_03_28_215Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! contacts@1.5.3 prebuild: `npm install && npm update && node_modules/bower/bin/bower install && node_modules/bower/bin/bower update`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the contacts@1.5.3 prebuild script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/travis/.npm/_logs/2017-09-03T14_03_28_321Z-debug.log
make[1]: *** [npm] Error 1
make[1]: Leaving directory `/home/travis/build/nextcloud/contacts'
make: *** [build] Error 2
The command "make" failed and exited with 2 during .
```