### PR TITLE
Set FN as ORG, if ORG is present but neither FN nor N is given.

### DIFF
--- a/js/models/contact_model.js
+++ b/js/models/contact_model.js
@@ -420,7 +420,7 @@ angular.module('contactsApp')
 		} else {
 			angular.extend(this.props, {
 				version: [{value: '3.0'}],
-				fn: [{value: ''}]
+				fn: [{value: t('contacts', 'New contact')}]
 			});
 			this.data.addressData = $filter('JSON2vCard')(this.props);
 		}

--- a/js/services/contact_service.js
+++ b/js/services/contact_service.js
@@ -190,7 +190,7 @@ angular.module('contactsApp')
 		newContact.setUrl(addressBook, newUid);
 		newContact.addressBookId = addressBook.displayName;
 		if (_.isUndefined(newContact.fullName()) || newContact.fullName() === '') {
-			newContact.fullName(t('contacts', 'New contact'));
+			newContact.fullName(newContact.displayName());
 		}
 
 		return DavClient.createCard(


### PR DESCRIPTION
Fixes #241 by setting FN to ORG, if neither FN nor N present (and ORG is present).

Some remarks:
- Currently if FN isn't present but N is, then the FN property doesn't get set
- We need to come up with a better way of name handling in general --> how do we handle updates to FN and N properties?

Edit: I'd also like to handle the FN/N/ORG stuff in a nicer way -> should we integrate the change in the contact_model?