### PR TITLE
Better readability on bright header background colors, fix #90

### DIFF
--- a/css/_details.scss
+++ b/css/_details.scss
@@ -46,6 +46,7 @@
 	font-size: inherit;
 	/* Override focus, active & hover! */
 	color: #fff !important; /* No vars used on purpose since we use custom BGs */
+	text-shadow: 0 0 2px rgba(0, 0, 0, .2); // better readability on bright background colors
 	background: transparent;
 	border: none;
 	text-overflow: ellipsis;


### PR DESCRIPTION
Before / after:
![screenshot from 2017-09-20 22-50-49](https://user-images.githubusercontent.com/925062/30666952-36f9cf72-9e56-11e7-82e1-1669d2f3636f.png) ![screenshot from 2017-09-20 22-50-33](https://user-images.githubusercontent.com/925062/30666951-36f979f0-9e56-11e7-8597-f8bed8b05dbb.png)

Fix #90 by adding a slight text-shadow. This separates the text from the background ever so slightly and increases the readability on bright colors greatly.

Please review @nextcloud/contacts @nextcloud/designers @axelsimon
