### PR TITLE
Remove italic style from import feedback

### DIFF
--- a/css/_settings.scss
+++ b/css/_settings.scss
@@ -255,7 +255,6 @@ contactimport input[type='search']::-webkit-search-cancel-button {
 }
 
 #importscreen-user {
-	font-style: italic;
 	opacity: 0.5;
 	padding-top: 5px;
 }


### PR DESCRIPTION
We never ever use italic in any interface. :) The contact names shown on import progress were italic, quick fix & review @nextcloud/contacts @nextcloud/designers 