### PR TITLE
Only show delete icon on hover or focus

### DIFF
--- a/css/_details.scss
+++ b/css/_details.scss
@@ -309,7 +309,23 @@ detailsitem .icon-delete {
 	padding: 16px 10px;
 	background-color: transparent;
 	border: none;
+	opacity: 0;
+}
+
+detailsitem input:hover + .icon-delete,
+detailsitem input:focus + .icon-delete,
+detailsitem input:active + .icon-delete,
+detailsitem select:hover + .icon-delete,
+detailsitem select:focus + .icon-delete,
+detailsitem select:active + .icon-delete,
+detailsitem:hover .icon-delete {
 	opacity: .2;
+}
+
+detailsitem .icon-delete:hover,
+detailsitem .icon-delete:focus,
+detailsitem .icon-delete:active {
+	opacity: 1;
 }
 
 detailsitem .item-action {


### PR DESCRIPTION
This cleans up the interface and doesn’t make the rarely used delete function that distracting. Similar to how we do it in the theming app.

~It doesn’t work for the address set of inputs yet because the delete icon is not next to the inputs.~ FIXED