### PR TITLE
Only show input border on hover/focus

### DIFF
--- a/css/_details.scss
+++ b/css/_details.scss
@@ -265,6 +265,13 @@ detailsitem textarea,
 .add-field {
 	width: 245px;
 	flex-grow: 1;
+	border-color: transparent;
+
+	&:hover,
+	&:focus,
+	&:active {
+		border-color: $color-primary;
+	}
 }
 
 .add-field {
@@ -372,6 +379,17 @@ avatar:not(.maximized) .icon-error + img {
 /* SELECT2 styling */
 detailsitem .select2-container {
 	width: 245px;
+}
+
+detailsitem .select2-container-multi .select2-choices,
+detailsitem .select2-container-multi.select2-container-active .select2-choices {
+	border-color: transparent;
+
+	&:hover,
+	&:focus,
+	&:active {
+		border-color: $color-primary;
+	}
 }
 
 /* Fix for #81 */


### PR DESCRIPTION
Also cleaning the interface a bit. It looks as simple as an interface which only show data, but it’s also super quick to edit.

Before & after:
![screenshot from 2017-09-21 01-39-33](https://user-images.githubusercontent.com/925062/30672651-045cb0b2-9e6e-11e7-859c-ac01cf69e296.png)
![screenshot from 2017-09-21 01-35-47](https://user-images.githubusercontent.com/925062/30672652-046487ce-9e6e-11e7-9c85-73503893d153.png)

Please review @nextcloud/contacts 