### PR TITLE
Always refresh contactList

### DIFF
--- a/js/components/contactList/contactList_controller.js
+++ b/js/components/contactList/contactList_controller.js
@@ -72,9 +72,7 @@ angular.module('contactsApp')
 						gid: t('contacts', 'All contacts')
 					});
 				}
-				if(ev.contacts.length !== 0) {
-					ctrl.contactList = ev.contacts;
-				}
+				ctrl.contactList = ev.contacts;
 			});
 		});
 	});


### PR DESCRIPTION
Deleting the last contact leads to the following issue:

![2017-09-21-153550_825x147](https://user-images.githubusercontent.com/8360698/30698605-c0e5c272-9ee2-11e7-9f18-ba5b22fd65fd.png)

@skjnldsv Is there a reason we only update the list if `length !== 0`?