### PR TITLE
Fix alignment of header content to input fields

### DIFF
--- a/css/_details.scss
+++ b/css/_details.scss
@@ -15,7 +15,7 @@
 
 .contactdetails__header {
 	height: 100px;
-	padding-left: 20px;
+	padding-left: 44px;
 	display: flex;
 	font-weight: bold;
 	align-items: center;


### PR DESCRIPTION
The text used to be left-aligned, must have gotten lost at some point. Fixed. :)

Before & after (disregard the invalid text in the input fields, was just to align it)
![screenshot from 2017-09-21 16-59-34](https://user-images.githubusercontent.com/925062/30704009-a095dd9a-9ef1-11e7-8666-6e3e5f94f061.png) ![screenshot from 2017-09-21 16-55-27](https://user-images.githubusercontent.com/925062/30704010-a09dce2e-9ef1-11e7-9de7-15f6b998e5ed.png)


Please review @nextcloud/contacts @nextcloud/designers 