### PR TITLE
adjust the space between avatar and name in the contacts list

### DIFF
--- a/css/_app-content-list.scss
+++ b/css/_app-content-list.scss
@@ -31,6 +31,7 @@
 	height: 68px;
 	border-top: 1px solid nc-darken($color-main-background, 8%);
 	cursor: pointer;
+	padding-left: 7px;
 }
 
 .app-content-list-item:hover,


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/9008509/30720505-0e09e426-9f28-11e7-8057-5a9eb8a22c1c.jpg)
After:
![after](https://user-images.githubusercontent.com/9008509/30720506-0e0b0234-9f28-11e7-8f31-f24d393cfd78.jpg)


