### PR TITLE
Select first contact after import if available

### DIFF
--- a/js/components/contactList/contactList_controller.js
+++ b/js/components/contactList/contactList_controller.js
@@ -56,6 +56,13 @@ angular.module('contactsApp')
 	ctrl.loading = true;
 
 	ContactService.registerObserverCallback(function(ev) {
+		/* after import at first refresh the contactList */
+		if (ev.event === 'importend') {
+			$scope.$apply(function() {
+				ctrl.contactList = ev.contacts;
+			});
+		}
+		/* update route parameters */
 		$timeout(function() {
 			$scope.$apply(function() {
 				switch(ev.event) {
@@ -69,10 +76,12 @@ angular.module('contactsApp')
 					});
 					break;
 				case 'importend':
+					/* after import select 'All contacts' group and first contact */
 					$route.updateParams({
-						gid: t('contacts', 'All contacts')
+						gid: t('contacts', 'All contacts'),
+						uid: ctrl.filteredContacts.length !== 0 ? ctrl.filteredContacts[0].uid() : undefined
 					});
-					break;
+					return;
 				case 'getFullContacts' || 'update':
 					break;
 				default:

--- a/js/services/contact_service.js
+++ b/js/services/contact_service.js
@@ -260,7 +260,7 @@ angular.module('contactsApp')
 				}
 				num++;
 				/* Import is over, let's notify */
-				if(num >= singleVCards.length) {
+				if (num === singleVCards.length + 1) {
 					notifyObservers('importend');
 				}
 			});


### PR DESCRIPTION
Should fix #343

- In callback, the contactList gets refreshed if 'importend' was notified, in order to select the first contact
- If import was successful we should have at least one contact, otherwise the routeParams UID is set to undefined
- 'importend' now only gets notified once - it was done twice before the change

Edit: May need #365 to correctly work!