### PR TITLE
Fix getAddressBook in addressBook_service

### DIFF
--- a/js/services/addressBook_service.js
+++ b/js/services/addressBook_service.js
@@ -58,12 +58,16 @@ angular.module('contactsApp')
 
 		getAddressBook: function(displayName) {
 			return DavService.then(function(account) {
-				return DavClient.getAddressBook({displayName:displayName, url:account.homeUrl}).then(function(addressBook) {
-					addressBook = new AddressBook({
+				return DavClient.getAddressBook({displayName:displayName, url:account.homeUrl}).then(function(res) {
+					var addressBook = new AddressBook({
+						account: account,
+						ctag: res[0].props.getctag,
 						url: account.homeUrl+displayName+'/',
-						data: addressBook[0]
+						data: res[0],
+						displayName: res[0].props.displayname,
+						resourcetype: res[0].props.resourcetype,
+						syncToken: res[0].props.syncToken
 					});
-					addressBook.displayName = displayName;
 					return addressBook;
 				});
 			});


### PR DESCRIPTION
- fixes bug described by @skjnldsv in #366
- fixes a bug:
1. have an address book and at least two contact in that address book
2. create a new address book
3. move one contact into the new address book
4. select contact from first address book
5. select the moved contact from the new address book
6. **endless spinner**

(do we already have an issue for that? *harhar*)

This bug seems to have been here for a long time, since more or less it is a faulty implementation of getAddressBook in dav.js we are using (and patched over the time).