### PR TITLE
Support for more TEL labels

### DIFF
--- a/js/components/detailsItem/detailsItem_controller.js
+++ b/js/components/detailsItem/detailsItem_controller.js
@@ -1,5 +1,5 @@
 angular.module('contactsApp')
-.controller('detailsItemCtrl', function($templateRequest, vCardPropertiesService, ContactService) {
+.controller('detailsItemCtrl', function($templateRequest, $filter, vCardPropertiesService, ContactService) {
 	var ctrl = this;
 
 	ctrl.meta = vCardPropertiesService.getMeta(ctrl.name);
@@ -46,6 +46,14 @@ angular.module('contactsApp')
 
 		// Remove duplicate entry
 		ctrl.availableOptions = _.uniq(ctrl.availableOptions, function(option) { return option.name; });
+		if (ctrl.availableOptions.filter(function(option) { return option.id === ctrl.type; }).length === 0) {
+			// Our default value has been thrown out by the uniq function, let's find a replacement
+			var optionName = ctrl.meta.options.filter(function(option) { return option.id === ctrl.type; })[0].name;
+			ctrl.type = ctrl.availableOptions.filter(function(option) { return option.name === optionName; })[0].id;
+			// We don't want to override the default keys. Compatibility > standardization
+			// ctrl.data.meta.type[0] = ctrl.type;
+			// ctrl.model.updateContact();
+		}
 	}
 	if (!_.isUndefined(ctrl.data) && !_.isUndefined(ctrl.data.namespace)) {
 		if (!_.isUndefined(ctrl.model.contact.props['X-ABLABEL'])) {

--- a/js/components/detailsItem/detailsItem_controller.js
+++ b/js/components/detailsItem/detailsItem_controller.js
@@ -43,6 +43,9 @@ angular.module('contactsApp')
 		if (!ctrl.availableOptions.some(function(e) { return e.id === ctrl.type; } )) {
 			ctrl.availableOptions = ctrl.availableOptions.concat([{id: ctrl.type, name: displayName}]);
 		}
+
+		// Remove duplicate entry
+		ctrl.availableOptions = _.uniq(ctrl.availableOptions, function(option) { return option.name; });
 	}
 	if (!_.isUndefined(ctrl.data) && !_.isUndefined(ctrl.data.namespace)) {
 		if (!_.isUndefined(ctrl.model.contact.props['X-ABLABEL'])) {
@@ -56,6 +59,7 @@ angular.module('contactsApp')
 			}
 		}
 	}
+
 	ctrl.availableGroups = [];
 
 	ContactService.getGroups().then(function(groups) {

--- a/js/services/vCardProperties.js
+++ b/js/services/vCardProperties.js
@@ -114,13 +114,20 @@ angular.module('contactsApp')
 			},
 			options: [
 				{id: 'HOME,VOICE', name: t('contacts', 'Home')},
+				{id: 'HOME', name: t('contacts', 'Home')},
 				{id: 'WORK,VOICE', name: t('contacts', 'Work')},
+				{id: 'WORK', name: t('contacts', 'Work')},
 				{id: 'CELL', name: t('contacts', 'Mobile')},
+				{id: 'CELL,VOICE', name: t('contacts', 'Mobile')},
+				{id: 'WORK,CELL', name: t('contacts', 'Work mobile')},
 				{id: 'FAX', name: t('contacts', 'Fax')},
 				{id: 'HOME,FAX', name: t('contacts', 'Fax home')},
 				{id: 'WORK,FAX', name: t('contacts', 'Fax work')},
 				{id: 'PAGER', name: t('contacts', 'Pager')},
-				{id: 'VOICE', name: t('contacts', 'Voice')}
+				{id: 'VOICE', name: t('contacts', 'Voice')},
+				{id: 'CAR', name: t('contacts', 'Car')},
+				{id: 'PAGER', name: t('contacts', 'Pager')},
+				{id: 'WORK,PAGER', name: t('contacts', 'Work pager')}
 			]
 		},
 		'X-SOCIALPROFILE': {

--- a/js/services/vCardProperties.js
+++ b/js/services/vCardProperties.js
@@ -8,6 +8,9 @@ angular.module('contactsApp')
 	 * 		readableName: [String], // internationalized readable name of prop
 	 * 		template: [String], // template name found in /templates/detailItems
 	 * 		[...] // optional additional information which might get used by the template
+	 *
+	 *		options: If multiple options have the same name, the first will be used as default.
+	 *				 Others will be merge, but still supported. Order is important!
 	 * }
 	 */
 	this.vCardMeta = {


### PR DESCRIPTION
Refs: https://github.com/nextcloud/contacts/issues/32#issuecomment-269648038 http://docs.oracle.com/cd/E88140_01/books/DisConnMobApps/connmobapps_carddavmap009.htm

Default test: [a9c8bda0-9f70-4b57-a6ea-e1a1a4b96be0.txt](https://github.com/nextcloud/contacts/files/1355639/a9c8bda0-9f70-4b57-a6ea-e1a1a4b96be0.txt)
 - Should display correct string as label
 - Should not change the default `home` key on save


