### PR TITLE
Add group and contactfilter model, implement group ordering by count

### DIFF
--- a/js/components/contactFilter/contactFilter_controller.js
+++ b/js/components/contactFilter/contactFilter_controller.js
@@ -1,0 +1,5 @@
+angular.module('contactsApp')
+.controller('contactfilterCtrl', function() {
+	// eslint-disable-next-line no-unused-vars
+	var ctrl = this;
+});

--- a/js/components/contactFilter/contactFilter_directive.js
+++ b/js/components/contactFilter/contactFilter_directive.js
@@ -1,0 +1,13 @@
+angular.module('contactsApp')
+.directive('contactFilter', function() {
+	return {
+		restrict: 'A', // has to be an attribute to work with core css
+		scope: {},
+		controller: 'contactfilterCtrl',
+		controllerAs: 'ctrl',
+		bindToController: {
+			contactFilter: '=contactFilter'
+		},
+		templateUrl: OC.linkTo('contacts', 'templates/contactFilter.html')
+	};
+});

--- a/js/components/group/group_directive.js
+++ b/js/components/group/group_directive.js
@@ -6,8 +6,7 @@ angular.module('contactsApp')
 		controller: 'groupCtrl',
 		controllerAs: 'ctrl',
 		bindToController: {
-			group: '=groupName',
-			groupCount: '=groupCount'
+			group: '=group'
 		},
 		templateUrl: OC.linkTo('contacts', 'templates/group.html')
 	};

--- a/js/components/groupList/groupList_controller.js
+++ b/js/components/groupList/groupList_controller.js
@@ -3,9 +3,14 @@ angular.module('contactsApp')
 	var ctrl = this;
 
 	ctrl.groups = [];
+	ctrl.contactFilters = [];
 
 	ContactService.getGroupList().then(function(groups) {
 		ctrl.groups = groups;
+	});
+
+	ContactService.getContactFilters().then(function(contactFilters) {
+		ctrl.contactFilters = contactFilters;
 	});
 
 	ctrl.getSelected = function() {
@@ -19,6 +24,9 @@ angular.module('contactsApp')
 				$scope.$apply(function() {
 					ContactService.getGroupList().then(function(groups) {
 						ctrl.groups = groups;
+					});
+					ContactService.getContactFilters().then(function(contactFilters) {
+						ctrl.contactFilters = contactFilters;
 					});
 				});
 			});

--- a/js/models/contactFilter_model.js
+++ b/js/models/contactFilter_model.js
@@ -1,0 +1,12 @@
+angular.module('contactsApp')
+	.factory('ContactFilter', function()
+	{
+		return function ContactFilter(data) {
+			angular.extend(this, {
+				name: '',
+				count: 0
+			});
+
+			angular.extend(this, data);
+		};
+	});

--- a/js/models/group_model.js
+++ b/js/models/group_model.js
@@ -1,0 +1,12 @@
+angular.module('contactsApp')
+	.factory('Group', function()
+	{
+		return function Group(data) {
+			angular.extend(this, {
+				name: '',
+				count: 0
+			});
+
+			angular.extend(this, data);
+		};
+	});

--- a/templates/contactFilter.html
+++ b/templates/contactFilter.html
@@ -1,0 +1,7 @@
+<a ng-href="#/{{ctrl.contactFilter.name}}">{{ ctrl.contactFilter.name }}
+	<div class="app-navigation-entry-utils">
+		<ul>
+			<li class="app-navigation-entry-utils-counter">{{ctrl.contactFilter.count | counterFormatter}}</li>
+		</ul>
+	</div>
+</a>

--- a/templates/group.html
+++ b/templates/group.html
@@ -1,7 +1,7 @@
-<a ng-href="#/{{ctrl.group}}">{{ ctrl.group }}
+<a ng-href="#/{{ctrl.group.name}}">{{ ctrl.group.name }}
 	<div class="app-navigation-entry-utils">
 		 <ul>
-			 <li class="app-navigation-entry-utils-counter">{{ctrl.groupCount | counterFormatter}}</li>
+			 <li class="app-navigation-entry-utils-counter">{{ctrl.group.count | counterFormatter}}</li>
 		 </ul>
 	</div>
 </a>

--- a/templates/groupList.html
+++ b/templates/groupList.html
@@ -1,1 +1,3 @@
-<li ng-repeat="group in ctrl.groups" group group-name="group[0]" group-count="group[1]" ng-click="ctrl.setSelected(group[0])" ng-class="{active: group[0] === ctrl.getSelected()}"></li>
+<li ng-repeat="contactFilter in ctrl.contactFilters" contact-filter="contactFilter"></li>
+
+<li ng-repeat="group in ctrl.groups | orderBy: '-count'" group="group" ng-click="ctrl.setSelected(group.name)" ng-class="{active: group.name === ctrl.getSelected()}"></li>

--- a/templates/main.php
+++ b/templates/main.php
@@ -31,7 +31,6 @@ vendor_style('select2/select2');
 		<div id="importscreen-sidebar-block" class="icon-loading" ng-show="$root.importing"></div>
 		<newContactButton></newContactButton>
 		<ul groupList></ul>
-
 		<div id="app-settings">
 			<div id="app-settings-header">
 				<button class="settings-button"


### PR DESCRIPTION
Besides implementing sorting of groups (fixes #344 ), this also adds two models:
* Group Model, which replaces the array representation of groups:
`['name', 42]` -> `new Group({name: 'name', count: 42})`
* ContactFilter

'All Contacts' and 'Not grouped' are now Contact Filters instead of groups.
This will also allow us to add additional filters in the future, which are kept separate from the groups.

Filters are always shown above the groups.