### PR TITLE
Remove myself from maintainers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ If you need assistance or want to ask a question about Contacts, you are welcome
 
 - [Hendrik Leppelsack](https://github.com/Henni)
 - [Jan-Christoph Borchardt](https://github.com/jancborchardt)
-- [Alexander Weidinger](https://github.com/irgendwie)
 - [John Molakvoæ](https://github.com/skjnldsv)
 
 If you'd like to join, just go through the [issue list](https://github.com/nextcloud/contacts/issues) and fix some. :)


### PR DESCRIPTION
Hello nextcloud/contacts,

with this PR I'm removing myself from the list of (active) maintainers.
Unfortunately I don't have the time to work on this project anymore
and additionally lost my interest over the time.

I started working on the contacts app with @Henni in October 2015 and it was a nice journey for me.
I learned a lot over the time and enjoyed every minute of it,
esp. meeting a lot of people from the community over the time
and visiting the Nextcloud headquarter last year.

I won't be completely gone and will be available for potential questions regarding the code
and issues in the transition time.
I wish this project the best of luck for the future! 👋 

New publisher for the contacts app in the app store will be @Henni - for ref. https://github.com/nextcloud/app-certificate-requests/pull/132

@Henni @jancborchardt @skjnldsv and everyone else -  がんばって!