### PR TITLE
Removing default name for new contact and leaving it blank

### DIFF
--- a/js/services/contact_service.js
+++ b/js/services/contact_service.js
@@ -223,9 +223,6 @@ angular.module('contactsApp')
 		newContact.uid(newUid);
 		newContact.setUrl(addressBook, newUid);
 		newContact.addressBookId = addressBook.displayName;
-		if (_.isUndefined(newContact.fullName()) || newContact.fullName() === '') {
-			newContact.fullName(newContact.displayName());
-		}
 
 		return DavClient.createCard(
 			addressBook,


### PR DESCRIPTION
Removing the check that puts the default name 'New Contact' in case the contact field is new