### PR TITLE
Fix processing of vCards with empty name

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "jquery-timepicker": "^1.3.3",
     "ngclipboard": "^1.1.2",
     "ui-select": "^0.19.8",
-    "vcard-parser": "^0.2.7"
+    "vcard-parser": "^0.3.0"
   }
 }


### PR DESCRIPTION
Upgrades vcard-parser to a version, which contains a fix for processing vCards with an empty FN field.

Fixes #413