### PR TITLE
Fix issue 445 to increase range of number of contacts shown.

### DIFF
--- a/css/_navigation.scss
+++ b/css/_navigation.scss
@@ -6,6 +6,10 @@
 	height: calc(100% - 68px);
 }
 
+#app-navigation .app-navigation-entry-utils .app-navigation-entry-utils-counter {
+	padding: 0 12px 0 0;
+}
+
 /* Contacts List */
 #new-contact-button {
 	margin: 14px auto; /* to have the same height than a contact */

--- a/js/filters/counterFormatter_filter.js
+++ b/js/filters/counterFormatter_filter.js
@@ -3,8 +3,8 @@ angular.module('contactsApp')
 .filter('counterFormatter', function () {
 	'use strict';
 	return function (count) {
-		if (count > 999) {
-			return '999+';
+		if (count > 9999) {
+			return '9999+';
 		}
 		if (count === 0) {
 			return '';

--- a/js/tests/filters/counterFormatter_filter.js
+++ b/js/tests/filters/counterFormatter_filter.js
@@ -9,13 +9,13 @@ describe('counterFormatter filter', function() {
 		$filter = _$filter_;
 	}));
 
-	it('should return the same number or 999+ if greater than 999', function() {
+	it('should return the same number or 9999+ if greater than 9999', function() {
 		var counterFormatter = $filter('counterFormatter');
 		expect(counterFormatter(Number.NaN)).to.be.Nan;
 		expect(counterFormatter(15)).to.equal(15);
 		expect(counterFormatter(0)).to.equal('');
 		expect(counterFormatter(-5)).to.equal(-5);
-		expect(counterFormatter(999)).to.equal(999);
-		expect(counterFormatter(1000)).to.equal('999+');
+		expect(counterFormatter(9999)).to.equal(9999);
+		expect(counterFormatter(10000)).to.equal('9999+');
 	});
 });


### PR DESCRIPTION
(#445 ) Worked with @suntala as Team Popcorn for RGSoC 2018 application.

We increased the counter logic to only show a static number from above 9999 contacts of 9999+ instead of the original 999+ We changed the padding in the css so that there was none on the left hand side, which causes a number of this size to go outside of the element.

We also changed the test file counterFormatter_filter.js, to reflect the above change in the script.js file.

We are aware that above 9999+ you no longer see the real number and would propose to implement a hover over function to show the full number. @jancborchardt @skjnldsv please let us know what you think of this solution and if we should go ahead with the hover over feature.