### PR TITLE
MD5 invalid uids

### DIFF
--- a/js/models/contact_model.js
+++ b/js/models/contact_model.js
@@ -1,5 +1,5 @@
 angular.module('contactsApp')
-.factory('Contact', function($filter, MimeService) {
+.factory('Contact', function($filter, MimeService, uuid4) {
 	return function Contact(addressBook, vCard) {
 		angular.extend(this, {
 
@@ -28,7 +28,9 @@ angular.module('contactsApp')
 					return model.setProperty('uid', { value: value });
 				} else {
 					// getter
-					return model.getProperty('uid').value;
+					var uid = model.getProperty('uid').value;
+					/* global md5 */
+					return uuid4.validate(uid) ? uid : md5(uid);
 				}
 			},
 


### PR DESCRIPTION
Fix #487

If not saved, vcard with fixed uid is not sent to server. But for better handling we use our own md5 if not valid uid. It should not cause any issues.

vcard test 
[2EAF6525-17ADC861-38D6BB1D.vcf.txt](https://github.com/nextcloud/contacts/files/1780604/2EAF6525-17ADC861-38D6BB1D.vcf.txt)
