### PR TITLE
Fix issue 445 to display number of contacts in tooltips.

### DIFF
--- a/js/filters/counterTooltipDisplay_filter.js
+++ b/js/filters/counterTooltipDisplay_filter.js
@@ -1,0 +1,12 @@
+angular.module('contactsApp')
+.filter('counterTooltipDisplay', function () {
+	'use strict';
+	return function (count) {
+		if (count > 9999) {
+			return count;
+		}
+		return '';
+	};
+});
+
+

--- a/js/tests/filters/counterTooltipDisplay_filter.js
+++ b/js/tests/filters/counterTooltipDisplay_filter.js
@@ -1,0 +1,20 @@
+describe('counterTooltipDisplay filter', function() {
+
+	var $filter;
+
+	beforeEach(module('contactsApp'));
+
+	beforeEach(inject(function(_$filter_){
+		$filter = _$filter_;
+	}));
+
+	it('should return the empty string if less than 10000 and the actual number if greater than 9999', function() {
+        var counterTooltipDisplay = $filter('counterTooltipDisplay');
+        expect(counterTooltipDisplay(Number.NaN)).to.equal('');
+        expect(counterTooltipDisplay(15)).to.equal('');
+		expect(counterTooltipDisplay(0)).to.equal('');
+		expect(counterTooltipDisplay(-5)).to.equal('');
+		expect(counterTooltipDisplay(9999)).to.equal('');
+		expect(counterTooltipDisplay(10000)).to.equal(10000);
+	});
+});

--- a/templates/contactFilter.html
+++ b/templates/contactFilter.html
@@ -1,6 +1,9 @@
 <a ng-href="#/{{ctrl.contactFilter.name}}">{{ ctrl.contactFilter.name }}</a>
 <div class="app-navigation-entry-utils">
 	<ul>
-		<li class="app-navigation-entry-utils-counter">{{ctrl.contactFilter.count | counterFormatter}}</li>
+		<li class="app-navigation-entry-utils-counter" tooltip-placement="right" 
+		uib-tooltip="{{ctrl.contactFilter.count | counterTooltipDisplay}}" tooltip-append-to-body="true">
+			{{ctrl.contactFilter.count | counterFormatter}}
+		</li>
 	</ul>
 </div>


### PR DESCRIPTION
(#445 ) Worked with @sleepypioneer as Team Popcorn, RGSoC 2018 applicants.

We enabled tooltips for group contact numbers above 9999 to display the actual number instead of 9999+. We created a new filter for this (counterTooltipDisplay) as well as a test to go along with it.

As a next step, we propose to implement this feature for all groups in contacts, not just the default groups. @jancborchardt @skjnldsv please let us know what you think of this solution and if we should go ahead with it.