### PR TITLE
Add Tooltips for non default groups

### DIFF
--- a/templates/group.html
+++ b/templates/group.html
@@ -1,6 +1,8 @@
 <a ng-href="#/{{ctrl.group.name}}">{{ ctrl.group.name }}</a>
 <div class="app-navigation-entry-utils">
 	<ul>
-		<li class="app-navigation-entry-utils-counter">{{ctrl.group.count | counterFormatter}}</li>
+		<li class="app-navigation-entry-utils-counter" tooltip-placement="right" uib-tooltip="{{ctrl.group.count | counterTooltipDisplay}}"
+			tooltip-append-to-body="true">{{ctrl.group.count | counterFormatter}}
+		</li>
 	</ul>
 </div>


### PR DESCRIPTION
(#445) Worked with @suntala  as Team Popcorn, RGSoC 2018 applicants.

We enabled tooltips for group contact numbers for groups that are not default to complete this issue.
