### PR TITLE
Fix "412 precondition failed" when response has no ETag, but OC-ETag …

### DIFF
--- a/js/services/contact_service.js
+++ b/js/services/contact_service.js
@@ -234,7 +234,7 @@ angular.module('contactsApp')
 				filename: newUid + '.vcf'
 			}
 		).then(function(xhr) {
-			newContact.setETag(xhr.getResponseHeader('ETag'));
+			newContact.setETag(xhr.getResponseHeader('OC-ETag') || xhr.getResponseHeader('ETag'));
 			contactsCache.put(newUid, newContact);
 			AddressBookService.addContact(addressBook, newContact);
 			if (fromImport !== true) {
@@ -329,7 +329,7 @@ angular.module('contactsApp')
 
 		// update contact on server
 		return DavClient.updateCard(contact.data, {json: true}).then(function(xhr) {
-			var newEtag = xhr.getResponseHeader('ETag');
+			var newEtag = xhr.getResponseHeader('OC-ETag') || xhr.getResponseHeader('ETag');
 			contact.setETag(newEtag);
 			notifyObservers('update', contact.uid());
 		}).catch(function() {


### PR DESCRIPTION
A customer of our webhosting service www.lima-city.de (I'll shemlessly plug it here) complained about the issue described in #257 and #135. We had a look at the issue and it seems like @xenithorb was correct: there is another issue underlying. It looks like Apache modified the ETag header. Luckily we have the OC-ETag header that from this patch forward the JS is going to use. Bang, problem solved.

Please review. I'm not sure if there are other solutions that adress this already.