### PR TITLE
Introduced 3-dot-menu in top right for Download and Delete

### DIFF
--- a/css/_details.scss
+++ b/css/_details.scss
@@ -68,15 +68,11 @@
 	width: 100%;
 }
 
-.contactdetails__header #details-actions {
-	display: flex;
-	flex-shrink: 0;
+.contactdetails__header #details-actions div.icon-more-white {
+	cursor: pointer;
 	padding: 14px;
 	width: 44px;
-}
-
-.contactdetails__header #details-actions span.icon-more-white {
-	cursor: pointer;
+	height: 44px;
 }
 
 .contactdetails__header #contact-failed-save {

--- a/css/_details.scss
+++ b/css/_details.scss
@@ -71,6 +71,8 @@
 .contactdetails__header #details-actions {
 	display: flex;
 	flex-shrink: 0;
+	padding: 14px;
+	width: 44px;
 }
 
 .contactdetails__header #contact-failed-save {
@@ -105,22 +107,6 @@
 .contactdetails__header .contactdetails__title:placeholder-shown { /* Standard (https://drafts.csswg.org/selectors-4/#placeholder) */
 	color: #fff; /* No vars used on purpose since we use custom BGs */
 	opacity: .8;
-}
-
-.contactdetails__header #details-actions a,
-.contactdetails__header #details-actions button {
-	padding: 15px;
-	background-color: transparent;
-	border: none;
-	opacity: .5;
-	margin: 3px;
-}
-
-.contactdetails__header #details-actions a:hover,
-.contactdetails__header #details-actions button:hover,
-.contactdetails__header #details-actions a:focus,
-.contactdetails__header #details-actions button:focus {
-	opacity: .7;
 }
 
 avatar {

--- a/css/_details.scss
+++ b/css/_details.scss
@@ -75,6 +75,10 @@
 	width: 44px;
 }
 
+.contactdetails__header #details-actions span.icon-more-white {
+	cursor: pointer;
+}
+
 .contactdetails__header #contact-failed-save {
 	animation: pulse 1.5s infinite;
 	border-radius: 50%;

--- a/js/components/contactDetails/contactDetails_controller.js
+++ b/js/components/contactDetails/contactDetails_controller.js
@@ -98,4 +98,21 @@ angular.module('contactsApp')
 	ctrl.updateContact = function() {
 		ContactService.queueUpdate(ctrl.contact);
 	};
+
+	ctrl.closeMenus = function() {
+		ctrl.openedMenu = false;
+	};
+
+	ctrl.openMenu = function(index) {
+		ctrl.closeMenus();
+		ctrl.openedMenu = index;
+	};
+
+	ctrl.toggleMenu = function(index) {
+		if (ctrl.openedMenu === index) {
+			ctrl.closeMenus();
+		} else {
+			ctrl.openMenu(index);
+		}
+	};
 });

--- a/templates/contactDetails.html
+++ b/templates/contactDetails.html
@@ -34,11 +34,34 @@
 				</div>
 			</div>
 			<div id="details-actions">
-				<button id="contact-failed-save" ng-click="ctrl.updateContact()" class="icon-checkmark-white" ng-if="ctrl.contact.failedProps.length>0" title="{{ctrl.t.save}}"></button>
-				<a href="{{ctrl.contact.data.url}}" id="contact-export-link"
-				   class="icon-download-white" title="{{ctrl.t.download}}"
-				   download="{{ ctrl.contact.readableFilename() }}"></a>
-				<button ng-click="ctrl.deleteContact()" ng-if="!ctrl.addressBook.readOnly" class="icon-delete-white" title="{{ctrl.t.delete}}"></button>
+				<span class="icon-more-white openMenuButton" ng-click="ctrl.toggleMenu('options')">
+				</span>
+				<div class="popovermenu bubble menu"
+					ng-class="{open: ctrl.openedMenu === 'options'}"
+					click-outside="ctrl.closeMenus()"
+					outside-if-not="openMenuButton,popovermenu">
+					<ul>
+						<li ng-if="ctrl.contact.failedProps.length>0">
+							<a id="contact-failed-save" ng-click="ctrl.updateContact()" uib-tooltip="Contact failed to save please update">
+								<span class="icon-checkmark"></span>
+								<span>Update</span>
+							</a>
+						</li>
+						<li>
+							<a href="{{ctrl.contact.data.url}}" id="contact-export-link"
+								download="{{ ctrl.contact.readableFilename() }}">
+								<span class="icon-download"></span>
+								<span>Download</span>
+							</a>
+						</li>
+						<li ng-if="!ctrl.addressBook.readOnly">
+							<a ng-click="ctrl.deleteContact()">
+								<span class="icon-delete"></span>
+								<span>Delete</span>
+							</a>
+						</li>
+					</ul>
+				</div>
 			</div>
 		</header>
 		<section>

--- a/templates/contactDetails.html
+++ b/templates/contactDetails.html
@@ -42,21 +42,17 @@
 					outside-if-not="openMenuButton,popovermenu">
 					<ul>
 						<li ng-if="ctrl.contact.failedProps.length>0">
-							<a id="contact-failed-save" ng-click="ctrl.updateContact()" uib-tooltip="Contact failed to save please update">
-								<span class="icon-checkmark"></span>
+							<a id="contact-failed-save" ng-click="ctrl.updateContact()" uib-tooltip="Contact failed to save please update" class="icon-checkmark">
 								<span>Update</span>
 							</a>
 						</li>
 						<li>
-							<a href="{{ctrl.contact.data.url}}" id="contact-export-link"
-								download="{{ ctrl.contact.readableFilename() }}">
-								<span class="icon-download"></span>
+							<a href="{{ctrl.contact.data.url}}" id="contact-export-link" download="{{ ctrl.contact.readableFilename() }}" class="icon-download">
 								<span>Download</span>
 							</a>
 						</li>
 						<li ng-if="!ctrl.addressBook.readOnly">
-							<a ng-click="ctrl.deleteContact()">
-								<span class="icon-delete"></span>
+							<a ng-click="ctrl.deleteContact()" class="icon-delete">
 								<span>Delete</span>
 							</a>
 						</li>

--- a/templates/contactDetails.html
+++ b/templates/contactDetails.html
@@ -34,8 +34,8 @@
 				</div>
 			</div>
 			<div id="details-actions">
-				<span class="icon-more-white openMenuButton" ng-click="ctrl.toggleMenu('options')">
-				</span>
+				<div class="icon-more-white openMenuButton" ng-click="ctrl.toggleMenu('options')">
+				</div>
 				<div class="popovermenu bubble menu"
 					ng-class="{open: ctrl.openedMenu === 'options'}"
 					click-outside="ctrl.closeMenus()"


### PR DESCRIPTION
Fix #354 
Closes #500

I've added the 3 dot menu for the Contact Details header, please check my solution, particularly the styling as I want to tackle #106 with a similar technique. I removed the titles for these symbols as I gave them text spans to mirror the addressbook popover menu. I gave the update option a tooltip to explain that the contact has not been saved and needs to be updated. Please let me know if this explains the situation ok for you.

I wondered if the 3 dot menu should also have a tool tip or if this is too much?

One thing I have noted is that the bin icon only turns red when it is hovered over and not when it's corresponding text is hovered over - I could add a solution for this if desired? @skjnldsv @jancborchardt 