### PR TITLE
Partial fix #333 - Select all contacts group when deleting last contact of a group

### DIFF
--- a/js/components/contactList/contactList_controller.js
+++ b/js/components/contactList/contactList_controller.js
@@ -263,8 +263,8 @@ angular.module('contactsApp')
 	ctrl.selectNearestContact = function(contactId) {
 		if (ctrl.filteredContacts.length === 1) {
 			$route.updateParams({
-				gid: $routeParams.gid,
-				uid: undefined
+				gid: t('contacts', 'All contacts'),
+				uid: ctrl.filteredContacts.length !== 0 ? ctrl.filteredContacts[0].uid() : undefined
 			});
 		} else {
 			for (var i = 0, length = ctrl.filteredContacts.length; i < length; i++) {


### PR DESCRIPTION
Partial fix #333 - Select all contacts group when deleting last contact of a group instead of showing no contacts page. Still displays 'contact not found' notification.