### PR TITLE
Fix base router url

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -30,7 +30,7 @@ export default new Router({
 	mode: 'history',
 	// if index.php is in the url AND we got this far, then it's working:
 	// let's keep using index.php in the url
-	base: OC.generateUrl(OC.linkTo('contacts', '')),
+	base: OC.generateUrl('/apps/contacts'),
 	linkActiveClass: 'active',
 	routes: [
 		{


### PR DESCRIPTION
Because using OC.LinkTo will use the folder path, which includes custom apps directories :-1: 