### PR TITLE
window.firstDay is zero based, vue2-timepickers first of of week is not

### DIFF
--- a/src/components/Properties/PropertyDateTime.vue
+++ b/src/components/Properties/PropertyDateTime.vue
@@ -160,7 +160,7 @@ export default {
 
 			// locale and lang data
 			locale: 'en',						// temporary value, see mounted
-			firstDay: window.firstDay,			// provided by nextcloud
+			firstDay: window.firstDay + 1,			// provided by nextcloud
 			lang: {
 				days: window.dayNamesShort,		// provided by nextcloud
 				months: window.monthNamesShort,	// provided by nextcloud


### PR DESCRIPTION
`window.firstDay` is zero based, like javascript's `Date.prototype.getDay()`
vue2-timepickers's first of of week is not for whatever reason:

![38365a29-7d47-4110-946d-c7f23d77675c](https://user-images.githubusercontent.com/1250540/48580256-fd22b100-e91e-11e8-89f5-108c83d15aad.png)

https://www.npmjs.com/package/vue2-datepicker