### PR TITLE
Fix groups addition and new contact instertion into groups

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -307,12 +307,7 @@ export default {
 				return this.contact.groups
 			},
 			set: function(data) {
-				let property = this.contact.vCard.getFirstProperty('categories')
-				if (!property) {
-					// Ical.js store comma separated by an Array of array of string
-					property = this.contact.vCard.addPropertyWithValue('categories', [data])
-				}
-				property.setValues(data)
+				this.contact.groups = data
 				this.updateContact()
 			}
 		},

--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -179,7 +179,14 @@ export default class Contact {
 	 */
 	set groups(groups) {
 		if (Array.isArray(groups)) {
-			this.vCard.updatePropertyWithValue('uid', groups)
+			let property = this.vCard.getFirstProperty('categories')
+			if (!property) {
+				// Init with empty group since we set everything afterwise
+				property = this.vCard.addPropertyWithValue('categories', '')
+			}
+			property.setValues(groups)
+		} else {
+			throw new Error('groups data is not an Array')
 		}
 	}
 

--- a/src/store/contacts.js
+++ b/src/store/contacts.js
@@ -261,7 +261,7 @@ const actions = {
 	},
 
 	/**
-	 * Add a contact to the list and to the associated addressbook
+	 * Add a contact to the list, the associated addressbook and to the groups
 	 *
 	 * @param {Object} context the store mutations
 	 * @param {Contact} contact the contact to delete
@@ -269,6 +269,7 @@ const actions = {
 	async addContact(context, contact) {
 		await context.commit('addContact', contact)
 		await context.commit('addContactToAddressbook', contact)
+		await context.commit('extractGroupsFromContacts', [contact])
 	},
 
 	/**

--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -258,7 +258,7 @@ export default {
 	},
 
 	methods: {
-		newContact() {
+		async newContact() {
 			let contact = new Contact('BEGIN:VCARD\nVERSION:4.0\nEND:VCARD', this.defaultAddressbook)
 			contact.fullName = t('contacts', 'New contact')
 			// itterate over all properties (filter is not usable on objects and we need the key of the property)
@@ -274,19 +274,23 @@ export default {
 					}
 				}
 			}
+			// set group if it's selected already
 			if (this.selectedGroup !== t('contacts', 'All contacts')) {
-				contact.vCard.addPropertyWithValue('categories', this.selectedGroup)
+				contact.groups = [ this.selectedGroup ]
 			}
-			this.$store.dispatch('addContact', contact)
-				.then(() => {
-					this.$router.push({
-						name: 'contact',
-						params: {
-							selectedGroup: this.selectedGroup,
-							selectedContact: contact.key
-						}
-					})
+			try {
+				// this will trigger the proper commits to groups, contacts and addressbook
+				await this.$store.dispatch('addContact', contact)
+				await this.$router.push({
+					name: 'contact',
+					params: {
+						selectedGroup: this.selectedGroup,
+						selectedContact: contact.key
+					}
 				})
+			} catch (error) {
+				OC.Notification.showTemporary(t('contacts', 'Unable to create the contact.'))
+			}
 		},
 
 		/**


### PR DESCRIPTION
Fix #777

To reproduce:
1. add a group
2. click the new contact button
3. the `New contact` appear and have the selected group by default


To review @whisperdancer
[contacts.tar.gz](https://github.com/nextcloud/contacts/files/2693939/contacts.tar.gz)
