### PR TITLE
Fix and set definitive browser support

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -5,8 +5,9 @@ module.exports = {
 			'@babel/preset-env',
 			{
 				targets: {
-					browsers: ['last 2 versions', 'ie >= 11']
-				}
+					browsers: ['> 0.5%', 'not IE 11', 'not dead']
+				},
+				useBuiltIns: 'usage'
 			}
 		]
 	]

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -3,10 +3,5 @@ const common = require('./webpack.common.js')
 
 module.exports = merge(common, {
 	mode: 'development',
-	devServer: {
-		historyApiFallback: true,
-		noInfo: true,
-		overlay: true
-	},
 	devtool: '#cheap-source-map'
 })


### PR DESCRIPTION
Since we don't want to support ie11, (well, it's too difficult) we should at least find proper browser support!
This is what I'm suggesting: `> 0.5%`, `not dead`, `not ie 11`

```
~% npx browserslist '> 0.5%, not dead, not ie 11'
and_chr 70
and_uc 11.8
chrome 70
chrome 69
chrome 49
edge 17
firefox 63
ios_saf 12.0-12.1
ios_saf 11.3-11.4
ios_saf 11.0-11.2
op_mini all
opera 56
safari 12
samsung 4
```

I feel like it's pretty good. It uses proper stats and supporting browsers that are AT LEAST used by 0.5% of all users is a pretty descent stat. What do you think?
@ChristophWurst @raimund-schluessler @georgehrke @tcitworld @juliushaertl and @rullzer (you mentioned this recently)
