### PR TITLE
Revert "Add uncategorised group (Not grouped) on the app navigation #874"

### DIFF
--- a/src/store/groups.js
+++ b/src/store/groups.js
@@ -35,7 +35,7 @@ const mutations = {
 	extractGroupsFromContacts(state, contacts) {
 		// iterate contacts
 		contacts.forEach(contact => {
-			if (contact.groups.length !== 0) {
+			if (contact.groups) {
 				contact.groups.forEach(groupName => {
 					let group = state.groups.find(search => search.name === groupName)
 					// nothing? create a new one
@@ -48,18 +48,6 @@ const mutations = {
 					}
 					group.contacts.push(contact.key)
 				})
-			} else {
-				const notGroupedName = t('contacts', 'Not grouped')
-				let group = state.groups.find(search => search.name === notGroupedName)
-				// the group does not exists lets create it
-				if (!group) {
-					state.groups.push({
-						name: notGroupedName,
-						contacts: []
-					})
-					group = state.groups.find(search => search.name === notGroupedName)
-				}
-				group.contacts.push(contact.key)
 			}
 		})
 	},


### PR DESCRIPTION
Reverts nextcloud/contacts#905

@zero-24 sorry, I just realised you edited the store and not the place where the fake groups are generated.
I guess I Was tired :(

The `All contacts` group is not a real group and is not present in the store. See :
https://github.com/nextcloud/contacts/blob/f173199bff169c4a7042ab979806f97915f8b506/src/views/Contacts.vue#L169-L215

https://github.com/nextcloud/contacts/blob/f173199bff169c4a7042ab979806f97915f8b506/src/views/Contacts.vue#L157-L166
