### PR TITLE
Fix spelling mistake in error message

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -419,7 +419,7 @@ export default {
 							this.loadingData = false
 						})
 						.catch((error) => {
-							OC.Notification.showTemporary(t('contacts', 'The contact doesn\'t exists anymore on the server.'))
+							OC.Notification.showTemporary(t('contacts', 'The contact doesn\'t exist anymore on the server.'))
 							console.error(error)
 							// trigger a local deletion from the store only
 							this.$store.dispatch('deleteContact', { contact: this.contact, dav: false })


### PR DESCRIPTION
Wrong: `The contact doesn\'t exists anymore on the server.`
Should: `The contact doesn\'t exist anymore on the server.`

This will require adaption of the translation source string.