### PR TITLE
Automatic repair of duplicate types

### DIFF
--- a/src/services/checks/duplicateTypes.js
+++ b/src/services/checks/duplicateTypes.js
@@ -1,0 +1,62 @@
+/**
+ * @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+export default {
+	name: 'duplicate types',
+	run: contact => {
+		try {
+			const props = contact.vCard.getAllProperties()
+				.map(prop => prop.getParameter('type'))
+				.filter(prop => prop)
+			const fixed = props.map(prop => [...new Set(prop)])
+			if (props
+				&& Array.isArray(props)
+				&& props.length > 0
+				&& props.join('') !== fixed.join('')) {
+				return true
+			}
+		} catch (error) {
+			return false
+		}
+		return false
+	},
+	fix: contact => {
+		let results = false
+		try {
+			const props = contact.vCard.getAllProperties()
+			props.forEach(prop => {
+				// ['WORK', 'pref', 'pref'] => ['WORK', 'pref']
+				const param = prop.getParameter('type')
+				const fixed = [...new Set(param)]
+				if (param
+					&& Array.isArray(param)
+					&& param.join('') !== fixed.join('')) {
+					prop.setParameter('type', fixed)
+					results = true
+				}
+			})
+		} catch (error) {
+			console.error(error)
+		}
+		return results
+	}
+}

--- a/src/services/checks/index.js
+++ b/src/services/checks/index.js
@@ -21,11 +21,13 @@
  */
 
 import badGenderType from './badGenderType'
+import duplicateTypes from './duplicateTypes'
 import invalidREV from './invalidREV'
 import missingFN from './missingFN'
 
 export default [
 	badGenderType,
+	duplicateTypes,
 	invalidREV,
 	missingFN
 ]


### PR DESCRIPTION
Fix #1030 

@j-ed

``` vcard
BEGIN:VCARD
VERSION:3.0
N:Doe;John;;;
FN:John Doe
UID:06070024-a509-42c7-a4x4-b08135d7183b
EMAIL;TYPE=WORK,WORK,pref:address@nowhere.com
END:VCARD
```

Once opened and edited, the vcard should be fixed and the EMAIL TYPE should be `"WORK,pref"`

Test release: 
[contacts.tar.gz](https://github.com/nextcloud/contacts/files/3050418/contacts.tar.gz)
