### PR TITLE
Avoid qrcode getting cropped

### DIFF
--- a/css/ContactDetails.scss
+++ b/css/ContactDetails.scss
@@ -137,5 +137,8 @@
 		display: flex;
 		padding: 10px;
 		background-color: #fff;
+		.qrcode {
+			max-width: 100%;
+		}
 	}
 }

--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -90,8 +90,7 @@
 				<!-- qrcode -->
 				<modal v-if="qrcode" id="qrcode-modal" :title="contact.displayName"
 					@close="closeQrModal">
-					<img :src="`data:image/svg+xml;base64,${qrcode}`" class="qrcode" width="300"
-						height="300">
+					<img :src="`data:image/svg+xml;base64,${qrcode}`" class="qrcode" width="400">
 				</modal>
 			</header>
 


### PR DESCRIPTION
increase image width for better scanning

remove height to avoid white padding over and under qrcode
(modal box uses the height for content size, but css resize gets ignored)

| Before | After |
|---|---|
| ![Screen Shot 2019-04-09 at 15 29 27](https://user-images.githubusercontent.com/1266260/55839415-a2137580-5adc-11e9-80a2-78a11ce512fe.png) | ![Screen Shot 2019-04-09 at 15 28 46](https://user-images.githubusercontent.com/1266260/55839418-a5a6fc80-5adc-11e9-8e3c-7bdbc198790a.png) |
