### PR TITLE
Use correct syntax for vCard version when saving

### DIFF
--- a/src/services/updateDesignSet.js
+++ b/src/services/updateDesignSet.js
@@ -49,6 +49,24 @@ const setLabelAsSingleValue = () => {
 }
 
 /**
+ * Prevents ical.js from adding 'VALUE=PHONE-NUMBER' in vCard 3.0.
+ * While not wrong according to the RFC, there's a bug in sabreio/vobject (used
+ * by Nextcloud Server) that prevents saving vCards with this parameters.
+ *
+ * @link https://github.com/nextcloud/contacts/pull/1393#issuecomment-570945735
+ *
+ * @returns {Boolean} Whether or not the design set has been altered.
+ */
+const removePhoneNumberValueType = () => {
+	if (ICAL.design.vcard3.property.tel) {
+		delete ICAL.design.vcard3.property.tel
+		return true
+	}
+
+	return false
+}
+
+/**
  * Some clients group properties by naming them something like 'ITEM1.URL'.
  * These should be treated the same as their original (i.e. 'URL' in this
  * example), so we iterate through the vCard to find these properties and
@@ -82,6 +100,7 @@ export default function(vCard) {
 	let madeChanges = false
 
 	madeChanges |= setLabelAsSingleValue()
+	madeChanges |= removePhoneNumberValueType()
 	madeChanges |= addGroupedProperties(vCard)
 
 	return madeChanges

--- a/src/store/contacts.js
+++ b/src/store/contacts.js
@@ -330,7 +330,7 @@ const actions = {
 		rev.fromUnixTime(Date.now() / 1000)
 		contact.rev = rev
 
-		const vData = ICAL.stringify(contact.vCard.jCal)
+		const vData = contact.vCard.toString()
 
 		// if no dav key, contact does not exists on server
 		if (!contact.dav) {


### PR DESCRIPTION
This changes the API used for serialising the vCard object into a string.

The previous method called `ical.stringify` on the underlying jCal object directly, which would always use vCard 4.x syntax regardless of the actual version used in the object.

If the vCard was still in 3.0 format, that would lead to invalid syntax being used. While clients seem to tolerate this most of the time, it breaks DAVx5 photo import.

Here's how the new call is being implemented in ical.js:
https://github.com/mozilla-comm/ical.js/blob/master/lib/ical/component.js#L487

fixes #1312 