### PR TITLE
Workaround for bug that prevented editing vCards with commas in the address

### DIFF
--- a/src/mixins/PropertyMixin.js
+++ b/src/mixins/PropertyMixin.js
@@ -21,7 +21,7 @@
  */
 import debounce from 'debounce'
 import Contact from '../models/contact'
-import ICAL from 'ical.js'
+import { setPropertyAlias } from '../services/updateDesignSet'
 
 export default {
 	props: {
@@ -142,14 +142,7 @@ export default {
 			this.localContact.vCard.addPropertyWithValue(`${group}.x-ablabel`, label)
 
 			// force update the main design sets
-			if (ICAL.design.vcard.property[name]) {
-				ICAL.design.vcard.property[propGroup]
-					= ICAL.design.vcard.property[name]
-			}
-			if (ICAL.design.vcard3.property[name]) {
-				ICAL.design.vcard3.property[propGroup]
-					= ICAL.design.vcard3.property[name]
-			}
+			setPropertyAlias(name, propGroup)
 
 			this.$emit('update')
 		},

--- a/src/mixins/PropertyMixin.js
+++ b/src/mixins/PropertyMixin.js
@@ -21,7 +21,7 @@
  */
 import debounce from 'debounce'
 import Contact from '../models/contact'
-import { setPropertyAlias } from '../services/updateDesignSet'
+import setPropertyAlias from '../services/updateDesignSet'
 
 export default {
 	props: {

--- a/src/mixins/PropertyMixin.js
+++ b/src/mixins/PropertyMixin.js
@@ -21,7 +21,7 @@
  */
 import debounce from 'debounce'
 import Contact from '../models/contact'
-import setPropertyAlias from '../services/updateDesignSet'
+import { setPropertyAlias } from '../services/updateDesignSet'
 
 export default {
 	props: {

--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -83,6 +83,15 @@ export default class Contact {
 			throw new Error('Invalid vCard')
 		}
 
+		// Fixes nextcloud/contacts#1009 that prevented editing of contacts if
+		// their address contained a comma. This is actually a bug in ical.js
+		// but it has not been fixed for some time now.
+		//
+		// This can be removed once https://github.com/mozilla-comm/ical.js/issues/386
+		// has been resolved.
+		ICAL.design.vcard.param.label = { multiValue: false }
+		ICAL.design.vcard3.param.label = { multiValue: false }
+
 		let jCal = ICAL.parse(vcard)
 		if (jCal[0] !== 'vcard') {
 			throw new Error('Only one contact is allowed in the vcard data')

--- a/src/services/updateDesignSet.js
+++ b/src/services/updateDesignSet.js
@@ -1,5 +1,6 @@
 /**
  * @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
+ * @copyright Copyright (c) 2020 Christian Kraus <hanzi@hanzi.cc>
  *
  * @author John Molakvoæ <skjnldsv@protonmail.com>
  * @author Christian Kraus <hanzi@hanzi.cc>

--- a/src/services/updateDesignSet.js
+++ b/src/services/updateDesignSet.js
@@ -1,5 +1,4 @@
 /**
- * @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
  * @copyright Copyright (c) 2020 Christian Kraus <hanzi@hanzi.cc>
  *
  * @author John Molakvoæ <skjnldsv@protonmail.com>

--- a/src/services/updateDesignSet.js
+++ b/src/services/updateDesignSet.js
@@ -1,0 +1,111 @@
+/**
+ * @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ * @author Christian Kraus <hanzi@hanzi.cc>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import ICAL from 'ical.js'
+
+/**
+ * Fixes nextcloud/contacts#1009 that prevented editing of contacts if
+ * their address contained a comma. This is actually a bug in ical.js
+ * but it has not been fixed for some time now.
+ *
+ * This can be removed once https://github.com/mozilla-comm/ical.js/issues/386
+ * has been resolved.
+ *
+ * @returns {Boolean} Whether or not the design set has been altered.
+ */
+const setLabelAsSingleValue = () => {
+	if (
+		!ICAL.design.vcard.param.label
+		|| ICAL.design.vcard.param.label.multiValue !== false
+		|| !ICAL.design.vcard3.param.label
+		|| ICAL.design.vcard3.param.label.multiValue !== false
+	) {
+		ICAL.design.vcard.param.label = { multiValue: false }
+		ICAL.design.vcard3.param.label = { multiValue: false }
+
+		return true
+	}
+
+	return false
+}
+
+/**
+ * Some clients group properties by naming them something like 'ITEM1.URL'.
+ * These should be treated the same as their original (i.e. 'URL' in this
+ * example), so we iterate through the vCard to find these properties and
+ * add them to the ical.js design set.
+ *
+ * @link https://github.com/nextcloud/contacts/issues/42
+ *
+ * @param {Array} vCard The ical.js vCard
+ * @returns {Boolean} Whether or not the design set has been altered.
+ */
+const addGroupedProperties = vCard => {
+	let madeChanges = false
+	vCard[1].forEach(prop => {
+		const propGroup = prop[0].split('.')
+
+		// if this is a grouped property, update the designSet
+		if (propGroup.length === 2) {
+			madeChanges = setPropertyAlias(propGroup[1], prop[0])
+		}
+	})
+	return madeChanges
+}
+
+/**
+ * Check whether the ical.js design sets need updating (and if so, do it)
+ *
+ * @param {Array} vCard The ical.js vCard
+ * @returns {boolean} Whether or not the design set has been altered.
+ */
+export default function(vCard) {
+	let madeChanges = false
+
+	madeChanges |= setLabelAsSingleValue()
+	madeChanges |= addGroupedProperties(vCard)
+
+	return madeChanges
+}
+
+/**
+ * @param {String} original Name of the property whose settings should be copied
+ * @param {String} alias Name of the new property
+ * @returns {boolean} Whether or not the design set has been altered.
+ */
+export function setPropertyAlias(original, alias) {
+	let madeChanges = false
+	original = original.toLowerCase()
+	alias = alias.toLowerCase()
+
+	if (ICAL.design.vcard.property[original]) {
+		ICAL.design.vcard.property[alias] = ICAL.design.vcard.property[original]
+		madeChanges = true
+	}
+
+	if (ICAL.design.vcard3.property[original]) {
+		ICAL.design.vcard3.property[alias] = ICAL.design.vcard3.property[original]
+		madeChanges = true
+	}
+
+	return madeChanges
+}


### PR DESCRIPTION
This is a workaround that fixes #1009 
(also fixes #1313)

Without it, contacts whose address contains a comma (quite common in Asian addresses) cannot be edited in the web interface.

I am aware that this is actually an upstream bug (mozilla-comm/ical.js#386) and should be fixed there... but that PR is about 10 months old and it is unclear when it might be merged and tagged. Meanwhile, this leads to very poor user experience in the Contacts app.

This fix would not conflict with that upstream PR since it merely makes it explicit that `LABEL` cannot contain multiple values.