### PR TITLE
Fix 'duplicate types' check for properties with a single type

### DIFF
--- a/src/services/checks/duplicateTypes.js
+++ b/src/services/checks/duplicateTypes.js
@@ -26,12 +26,9 @@ export default {
 		try {
 			const props = contact.vCard.getAllProperties()
 				.map(prop => prop.getParameter('type'))
-				.filter(prop => prop)
+				.filter(prop => Array.isArray(prop))
 			const fixed = props.map(prop => [...new Set(prop)])
-			if (props
-				&& Array.isArray(props)
-				&& props.length > 0
-				&& props.join('') !== fixed.join('')) {
+			if (props.join('') !== fixed.join('')) {
 				return true
 			}
 		} catch (error) {


### PR DESCRIPTION
fixes #1263 

The 'duplicate types' check would fail if properties with single-value `TYPE` parameters were present, 

### Background

`prop.getParameter('type')` would return an _Array_ if multiple types are present, but a _String_  if there's only one type:

```
TEL;TYPE="HOME,VOICE":+12345
```
Here, `prop` is going to be `[ 'HOME', 'VOICE' ]`. This works.


```
EMAIL;TYPE=HOME:john.doe@example.com
```
Whereas here, `prop` will end up as just `'HOME'`. If you pass a string into `new Set()`, it will create an array containing all the individual characters of the string. So the check ends up effectively doing:

```js
[ [ 'home' ] ].join('') === [ [ 'h', 'o', 'm', 'e' ] ].join('')
// returns false, because 'home' !== 'h,o,m,e'
```

This is fixed by moving the `Array.isArray` check into the `filter` call, so that only properties with multiple types are compared to begin with.

I removed some other checks that were unnecessary: `Array.filter` and `Array.map` always return an array, so `props` is already guaranteed to be one, and there's no harm in comparing empty arrays.