### PR TITLE
short company field only if empty

### DIFF
--- a/css/ContactDetails.scss
+++ b/css/ContactDetails.scss
@@ -60,7 +60,7 @@
 					color: #fff !important;
 				}
 			}
-			#contact-org {
+			#contact-org:placeholder-shown {
 				max-width: 20%;
 			}
 		}


### PR DESCRIPTION
Long company names were chopped off way to much. This fixes this while avoiding spread input fields when org field is empty.