### PR TITLE
Fix issue that prevented new contacts from being saved

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -401,8 +401,8 @@ export default {
 	},
 
 	watch: {
-		contact: function() {
-			if (this.contactKey) {
+		contact: function(newContact, oldContact) {
+			if (this.contactKey && newContact !== oldContact) {
 				this.selectContact(this.contactKey)
 			}
 		},


### PR DESCRIPTION
Whenever I would compile the JavaScript sources myself, I would run into an issue when creating a new contact:

1. I would create a new contact and fill out some of its fields.
2. The contact wouldn't save, the exclamation mark icon would just stay. If I reload the page at this point, the new contact is gone.
3. If I then selected another contact and returned to the new one, all my previous changes were gone. But if I filled out some fields now, the contact finally got saved.

I can't reproduce this bug with the released version -- though it would still happen if I compiled the JavaScript from the `v3.1.7`, `v3.1.6` or `v3.1.5` tags myself. So I'm not sure whether this might be an issue with some dependency or I'm just doing something wrong.

Anyway, the issue as far as I could tell is that the `contact` watcher of the `ContactDetails` component fires _twice_ when a new contact is added: once with the new contact and once with the old one. This eventually leads to `localContact` being overwritten with the old one, so that all save actions actually just save the old contact.

This PR fixes this behaviour by adding a check whether the new contact (inside the watcher) is actually different from the old one. I don't really like this fix because it only attacks the symptom and I still don't have any idea why the watcher is fired twice to begin with.

But at least this way the app is usable again for me.