### PR TITLE
Disable form validation for text properties

### DIFF
--- a/src/components/Properties/PropertyText.vue
+++ b/src/components/Properties/PropertyText.vue
@@ -58,7 +58,6 @@
 				id="textarea"
 				ref="textarea"
 				v-model.trim="localValue"
-				:type="type"
 				:inputmode="inputmode"
 				:readonly="isReadOnly"
 				class="property__value"
@@ -69,10 +68,10 @@
 			<!-- OR default to input -->
 			<input v-else
 				v-model.trim="localValue"
-				:type="type"
 				:inputmode="inputmode"
 				:readonly="isReadOnly"
 				:class="{'property__value--with-ext': haveExtHandler}"
+				type="text"
 				class="property__value"
 				@input="updateValue">
 
@@ -139,19 +138,15 @@ export default {
 			// length is one & add one space at the end
 			return hasTitle + 1 + isLast + noteHeight
 		},
-		type() {
+		inputmode() {
 			if (this.propName === 'tel') {
 				return 'tel'
 			} else if (this.propName === 'email') {
 				return 'email'
-			}
-			return 'text'
-		},
-		inputmode() {
-			if (this.propName === 'uri') {
+			} else if (this.propType === 'uri') {
 				return 'url'
 			}
-			return ''
+			return false
 		},
 		URLScheme() {
 			if (this.propName === 'tel') {

--- a/src/components/Properties/PropertyText.vue
+++ b/src/components/Properties/PropertyText.vue
@@ -59,6 +59,7 @@
 				ref="textarea"
 				v-model.trim="localValue"
 				:type="type"
+				:inputmode="inputmode"
 				:readonly="isReadOnly"
 				class="property__value"
 				@input="updateValueNoDebounce"
@@ -69,6 +70,7 @@
 			<input v-else
 				v-model.trim="localValue"
 				:type="type"
+				:inputmode="inputmode"
 				:readonly="isReadOnly"
 				:class="{'property__value--with-ext': haveExtHandler}"
 				class="property__value"
@@ -142,10 +144,14 @@ export default {
 				return 'tel'
 			} else if (this.propName === 'email') {
 				return 'email'
-			} else if (this.propType === 'uri') {
-				return 'url'
 			}
 			return 'text'
+		},
+		inputmode() {
+			if (this.propName === 'uri') {
+				return 'url'
+			}
+			return ''
 		},
 		URLScheme() {
 			if (this.propName === 'tel') {


### PR DESCRIPTION
fixes #1214 
relates to #1324 
relates to #1395 

Currently, we mark some input fields as `type="url"`, `type="tel"` and `type="email"` depending on the property name and sometimes depending on what ical.js expects those fields to contain.

This triggers form validation in some browsers which will then highlight the field as erroneous if the contents don't match the type.

Reasons against this behaviour:

1. Some affected fields such as `RELATED` or `IMPP` might genuinely need to contain values that do not match the usual URL pattern. (For `RELATED` the RFC even explicitely allows arbitrary text values, for `IMPP` see #1214)
2. Other clients such as Android's Contacts app allow arbitrary values here, which Nextcloud Server happily accepts and which would then be flagged as erroneous in Nextcloud Contacts.
3. Most importantly: While this field is marked red in the UI, we _still_ save the value anyway. So there's a discrepancy between what Contacts actually does and what it displays to the user.

In order to keep specialised keyboards in mobile browsers, I used the `inputmode` attribute instead.