### PR TITLE
Added four popular IM services

### DIFF
--- a/src/models/rfcProps.js
+++ b/src/models/rfcProps.js
@@ -176,6 +176,10 @@ const properties = {
 			{ id: 'TELEGRAM', name: 'Telegram' },
 			{ id: 'XMPP', name: 'XMPP' },
 			{ id: 'SIP', name: 'SIP' },
+			{ id: 'QQ', name: 'QQ' },
+			{ id: 'WECHAT', name: 'WeChat' },
+			{ id: 'LINE', name: 'Line' },
+			{ id: 'KAKAOTALK', name: 'KakaoTalk' },
 		],
 	},
 	tel: {


### PR DESCRIPTION
Cf. #1516

Added four popular IM services:
* QQ
* WeChat
* Line
* KakaoTalk

I'm not aware of any of the services having a standard/common IMPP ID so I'm using the most common and international version of the names as IDs.

@skjnldsv  Sorry about the mess before. I first submitted a clean PR but the code checker complained about --signoff which I never used or knew about and in following the instructions on a fork I didn't realise was out of sync I ended up making the mess you saw. It should be fine now.

Signed-off-by: ksl1989 <as2hwlm0eq2w@opayq.com>