### PR TITLE
Allow to use any name for Group creation

### DIFF
--- a/src/components/Properties/PropertyGroups.vue
+++ b/src/components/Properties/PropertyGroups.vue
@@ -169,14 +169,9 @@ export default {
 		 * @returns {boolean}
 		 */
 		validateGroup(groupName) {
-			// Only allow characters without vcard special chars
-			const groupRegex = /^[^;,:]+$/gmi
-			if (groupName.match(groupRegex)) {
-				this.addContactToGroup(groupName)
-				this.localValue.push(groupName)
-				return true
-			}
-			return false
+			this.addContactToGroup(groupName)
+			this.localValue.push(groupName)
+			return true
 		},
 	},
 }


### PR DESCRIPTION
The Group name is already escaped by the underlying vCard library, there is no need to verify things here.
Fixes #1563