### PR TITLE
support different rev value types depending on vcard version

### DIFF
--- a/src/services/checks/invalidREV.js
+++ b/src/services/checks/invalidREV.js
@@ -40,7 +40,7 @@ export default {
 					return false
 				}
 
-				if (contact.version === '4.0' && type === 'icaltime') {
+				if (version === '4.0' && type === 'icaltime') {
 					return false
 				}
 			}

--- a/src/services/checks/invalidREV.js
+++ b/src/services/checks/invalidREV.js
@@ -28,10 +28,21 @@ export default {
 	name: 'invalid REV',
 	run: contact => {
 		try {
-			if (contact.vCard.hasProperty('rev')
-				&& contact.vCard.getFirstProperty('rev').getFirstValue()
-				&& contact.vCard.getFirstProperty('rev').getFirstValue().icalclass === 'vcardtime') {
-				return false
+			const hasRev = contact.vCard.hasProperty('rev')
+			const rev = hasRev && contact.vCard.getFirstProperty('rev')
+			const revValue = rev && rev.getFirstValue()
+
+			if (revValue) {
+				const version = contact.version
+				const type = revValue.icalclass
+
+				if (version === '3.0' && type === 'vcardtime') {
+					return false
+				}
+
+				if (contact.version === '4.0' && type === 'icaltime') {
+					return false
+				}
 			}
 		} catch (error) {
 			return true


### PR DESCRIPTION
attempts to resolve #1352 by supporting two `icalclass` types, depending on the vcard version.

i can confirm this change avoids the "contact is broken" message that pops up when editing a contact in a DAVx5 client, but then later viewing it in the nextcloud contact app.

