### PR TITLE
Additional link to picture menu

### DIFF
--- a/css/ContactDetailsAvatar.scss
+++ b/css/ContactDetailsAvatar.scss
@@ -57,6 +57,9 @@
 		background-size: cover;
 		// White background for avatars with transparency, also in dark theme
 		background-color: #fff;
+		&:hover + .contact-avatar-options__popovermenubtn {
+			opacity: .25;
+		}
 	}
 	&__options {
 		position: absolute;
@@ -68,7 +71,6 @@
 		display: block;
 		width: 100%;
 		height: 100%;
-		opacity: .5;
 		background-color: rgba(0, 0, 0, .2);
 		&:hover,
 		&:active,
@@ -78,6 +80,24 @@
 		&__popovermenu {
 			// center
 			margin: calc((100% - 44px) / 2);
+		}
+		&__popovermenubtn {
+			height: 45px;
+			width: 45px;
+			border-radius: 50%;
+			z-index: 11;
+			background: rgba(0, 0, 0, .2);
+			opacity: 0;
+			&:hover,
+			&:active,
+			&:focus {
+				opacity: 1;
+			}
+			// bottom right
+			margin: calc((100% + 5px) / 2);
+		}
+		&__popovermenu,
+		&__popovermenubtn {
 			& .action-item__menutoggle {
 				// hide three dot menu, in favour of icon-picture-force-white
 				z-index: -1;


### PR DESCRIPTION
It took me a while to find the menu where I can delete contact pictures, so here is a proposal to add an overlay and make it more visible to users. Also: moved and merged the menu from the modal, which currently has different menu entries than the button.

![hidden-icon](https://user-images.githubusercontent.com/34400929/82848300-3c0dcb80-9ef3-11ea-8be0-38676542ab92.gif)

Related issues: #1513

Implementation is very rudimentary, just to give you an idea. Next steps would be to optimize the style (edit or photo icon instead of text, chose color/transparency) and then implement it well in the scss.