### PR TITLE
more robust social ids for social sync

### DIFF
--- a/lib/Service/Social/FacebookProvider.php
+++ b/lib/Service/Social/FacebookProvider.php
@@ -78,17 +78,11 @@ class FacebookProvider implements ISocialProvider {
 			if ($result->getStatusCode() !== 200) {
 				return $profileName;
 			}
-			$htmlResult = new \DOMDocument();
-			$htmlResult->loadHTML($result->getBody());
-			$metas = $htmlResult->getElementsByTagName('meta');
-			foreach ($metas as $meta) {
-				foreach ($meta->attributes as $attr) {
-					$value = $attr->nodeValue;
-					if (strpos($value, "/profile/")) {
-						$value = str_replace('fb://profile/', '', $value);
-						return($value);
-					}
-				}
+			$htmlResult = $result->getBody();
+
+			$entity_id = '/.*"entity_id":"([0-9]+)".*/';
+			if (preg_match($entity_id, $htmlResult, $matches)) {
+				return($matches[1]);
 			}
 			// keyword not found - page changed?
 			return $profileName;

--- a/lib/Service/Social/InstagramProvider.php
+++ b/lib/Service/Social/InstagramProvider.php
@@ -42,6 +42,7 @@ class InstagramProvider implements ISocialProvider {
 	 * @return string
 	 */
 	public function cleanupId(string $candidate):string {
+		$candidate = preg_replace('/^' . preg_quote('x-apple:', '/') . '/', '', $candidate);
 		return basename($candidate);
 	}
 

--- a/lib/Service/Social/MastodonProvider.php
+++ b/lib/Service/Social/MastodonProvider.php
@@ -42,10 +42,11 @@ class MastodonProvider implements ISocialProvider {
 	 * @return string
 	 */
 	public function cleanupId(string $candidate):?string {
+		$candidate = preg_replace('/^' . preg_quote('x-apple:', '/') . '/', '', $candidate);
 		try {
-			if (strpos($candidate, '@') === 0) {
+			if (strpos($candidate, 'http') !== 0) {
 				$user_server = explode('@', $candidate);
-				$candidate = 'https://' . $user_server[2] . '/@' . $user_server[1];
+				$candidate = 'https://' . array_pop($user_server) . '/@' . array_pop($user_server);
 			}
 		} catch (Exception $e) {
 			$candidate = null;

--- a/lib/Service/Social/TumblrProvider.php
+++ b/lib/Service/Social/TumblrProvider.php
@@ -35,6 +35,7 @@ class TumblrProvider implements ISocialProvider {
 	 * @return string
 	 */
 	public function cleanupId(string $candidate):?string {
+		$candidate = preg_replace('/^' . preg_quote('x-apple:', '/') . '/', '', $candidate);
 		$subdomain = '/(?:http[s]*\:\/\/)*(.*?)\.(?=[^\/]*\..{2,5})/i'; // subdomain
 		if (preg_match($subdomain, $candidate, $matches)) {
 			$candidate = $matches[1];


### PR DESCRIPTION
- resolve facebook-id from usernames
- accept mastodon userids without leading 'at'
- ignore apple markers as in https://github.com/nextcloud/contacts/issues/1107#issuecomment-706518724