### PR TITLE
harmonize avatars

### DIFF
--- a/src/components/ContactDetails/ContactDetailsAvatar.vue
+++ b/src/components/ContactDetails/ContactDetailsAvatar.vue
@@ -475,7 +475,7 @@ export default {
 		// White background for avatars with transparency, also in dark theme
 		background-color: #fff;
 		background-repeat: no-repeat;
-		background-position: center;
+		background-position: top;
 		background-size: cover;
 	}
 


### PR DESCRIPTION
refers to https://github.com/nextcloud/contacts/issues/1662#issuecomment-643137544

I find it confusing that the contact list on the left shows the top part of the picture, while the selected contact's avatar is showing the center part of the image; so you have the same picture side by side being cropped differently:

![before](https://user-images.githubusercontent.com/687129/84608825-cc4b8a80-ae79-11ea-85d1-6bccde6fd2dc.png)

This small change harmonizes both thumbnails by taking the top part of the avatar.

Signed-off-by: call-me-matt <nextcloud@matthiasheinisch.de>