### PR TITLE
vcard should only have 1 photo field when adding/removing photos

### DIFF
--- a/lib/Service/SocialApiService.php
+++ b/lib/Service/SocialApiService.php
@@ -118,7 +118,7 @@ class SocialApiService {
 			$contact['PHOTO;ENCODING=b;TYPE=' . $imageType . ';VALUE=BINARY'] = $photo;
 
 			// remove previous photo (necessary as new attribute is not equal to 'PHOTO')
-			$contact['PHOTO'] = '';
+			unset($contact['PHOTO']);
 		}
 	}
 

--- a/src/components/ContactDetails/ContactDetailsAvatar.vue
+++ b/src/components/ContactDetails/ContactDetailsAvatar.vue
@@ -368,7 +368,7 @@ export default {
 		 */
 		removePhoto() {
 			this.maximizeAvatar = false
-			this.contact.vCard.removeProperty('photo')
+			this.contact.vCard.removeAllProperties('photo')
 			this.$store.dispatch('updateContact', this.contact)
 		},
 


### PR DESCRIPTION
when adding photo fields through the social api service, an extra photo
field is created for vcard version 3.0 due to setting a field as empty
instead of unsetting it all together

when removing photo fields, this empty photo field is left untouched

thus, syncing photos to address book clients can be buggy as most
address book clients do not properly iterate through all photo fields to
display the contact photo

closes: https://github.com/nextcloud/contacts/issues/1820