### PR TITLE
Improve Compatibily with macOS Contacts

### DIFF
--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -37,6 +37,12 @@ const isEmpty = value => {
 	return (Array.isArray(value) && value.join('') === '') || (!Array.isArray(value) && value === '')
 }
 
+export const ContactKindProperties = ['KIND', 'X-ADDRESSBOOKSERVER-KIND']
+
+export const MinimalContactProperties = [
+	'EMAIL', 'UID', 'CATEGORIES', 'FN', 'ORG', 'N', 'X-PHONETIC-FIRST-NAME', 'X-PHONETIC-LAST-NAME',
+].concat(ContactKindProperties)
+
 export default class Contact {
 
 	/**
@@ -79,7 +85,6 @@ export default class Contact {
 			const rev = new ICAL.VCardTime(null, null, 'date-time')
 			rev.fromUnixTime(Date.now() / 1000)
 			this.vCard.addPropertyWithValue('rev', rev)
-
 		}
 	}
 
@@ -300,7 +305,13 @@ export default class Contact {
 	 * @memberof Contact
 	 */
 	get kind() {
-		return this.firstIfArray(this.vCard.getFirstPropertyValue('kind'))
+		return this.firstIfArray(
+			ContactKindProperties
+				.map(s => s.toLowerCase())
+				.map(s => this.vCard.getFirstPropertyValue(s))
+				.flat()
+				.filter(k => k)
+		)
 	}
 
 	/**

--- a/src/store/addressbooks.js
+++ b/src/store/addressbooks.js
@@ -25,7 +25,7 @@ import { showError } from '@nextcloud/dialogs'
 import pLimit from 'p-limit'
 import Vue from 'vue'
 
-import Contact from '../models/contact'
+import Contact, { MinimalContactProperties } from '../models/contact'
 
 import client from '../services/cdav'
 import parseVcf from '../services/parseVcf'
@@ -346,8 +346,7 @@ const actions = {
 	 */
 	async getContactsFromAddressBook(context, { addressbook }) {
 		return addressbook.dav
-			.findAllAndFilterBySimpleProperties(['EMAIL', 'UID', 'CATEGORIES', 'FN', 'ORG', 'N',
-				'X-PHONETIC-FIRST-NAME', 'X-PHONETIC-LAST-NAME'])
+			.findAllAndFilterBySimpleProperties(MinimalContactProperties)
 			.then((response) => {
 				// We don't want to lose the url information
 				// so we need to parse one by one

--- a/src/store/contacts.js
+++ b/src/store/contacts.js
@@ -27,6 +27,23 @@ import Vue from 'vue'
 import Contact from '../models/contact'
 import validate from '../services/validate'
 
+/*
+ * Currently ical.js does not serialize parameters with multiple values correctly. This is
+ * especially problematic for the type parmeter which frequently is used with multiple values
+ * (e.g. "HOME" and "VOICE"). A phone number for example shoud be serialized as
+ * 'TEL;TYPE=HOME,VOICE:0815 123456' OR 'TEL;TYPE="HOME","VOICE":0815 123456' according to
+ * https://tools.ietf.org/html/rfc2426#section-4. Unfortunately currently it is serialized as
+ * 'TEL;TYPE="HOME,VOICE":0815 123456', which makes the value appear as a single value
+ * containing a comma instead of two separate values. By forcing all values being escaped by
+ * double quotes the string serialization can be fixed.
+ *
+ * However there is a pull request (https://github.com/mozilla-comm/ical.js/pull/460) waiting
+ * to be merged for ical.js. Until this fix is merged and released the following configuration
+ * changes apply the workaround described above.
+ */
+ICAL.design.vcard3.param.type.multiValueSeparateDQuote = true
+ICAL.design.vcard.param.type.multiValueSeparateDQuote = true
+
 const sortData = (a, b) => {
 	const nameA = typeof a.value === 'string'
 		? a.value.toUpperCase() // ignore upper and lowercase


### PR DESCRIPTION
I would like to use nextcloud contacts as a replacement to storing my contacts in iCloud. Unfortunately there are some things that don't work as expected and while some issues require fundamental changes (like [#609](https://github.com/nextcloud/contacts/issues/609)) there are some which I was able to fix with only a few small changes.

One thing I found out was that there already is support for hiding contact groups (as defined by [https://tools.ietf.org/html/rfc6350#section-6.1.4](https://tools.ietf.org/html/rfc6350#section-6.1.4)). macOS Contacts still uses vCard 3.0 and because of that cannot relay on the vCard kind property defined by vCard 4.0. But there is a proprietary attribute which does the same thing (X-ADDRESSBOOKSERVER-KIND). I updated the contacts app to also respect this Apple specific property and added an easy way to add further proprietary "kind"-properties. 

There is also a problem (at least I think so) with the underlying vCard serialization which leads to strange property names. See my comment in [src/store/contacts.js](https://github.com/zlajo/contacts/blob/e87629a46721a54c1ac50d7441ff87673e5a961d/src/store/contacts.js#L30) for a detailed description of the problem and a potential workaround. 

Please let me know if my update works and contact me if further changes/discussions are required.