### PR TITLE
Fix display name with empty last name when sorting by last name

### DIFF
--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -404,11 +404,17 @@ export default class Contact {
 			case 'firstName':
 				// Stevenson;John;Philip,Paul;Dr.;Jr.,M.D.,A.C.P.
 				// -> John Stevenson
+				if (isEmpty(n[0])) {
+					return n[1]
+				}
 				return n.slice(0, 2).reverse().join(' ')
 
 			case 'lastName':
 				// Stevenson;John;Philip,Paul;Dr.;Jr.,M.D.,A.C.P.
 				// -> Stevenson, John
+				if (isEmpty(n[0])) {
+					return n[1]
+				}
 				return n.slice(0, 2).join(', ')
 			}
 		}
@@ -420,6 +426,9 @@ export default class Contact {
 		if (n && !isEmpty(n)) {
 			// Stevenson;John;Philip,Paul;Dr.;Jr.,M.D.,A.C.P.
 			// -> John Stevenson
+			if (isEmpty(n[0])) {
+				return n[1]
+			}
 			return n.slice(0, 2).reverse().join(' ')
 		}
 		// LAST chance, use the org ir that's the only thing we have


### PR DESCRIPTION
When sorting by last name, contacts without last name result in `, Alice` because last and first name are joined with `', '` regardless of their contents. Easy fix: return only first name if last name is empty.