### PR TITLE
Fix custom labels not being displayed

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -759,7 +759,9 @@ export default {
 		 * @returns {boolean}
 		 */
 		canDisplay(property) {
-			const propModel = rfcProps.properties[property.name]
+			// Make sure we have some model for the property and check for ITEM.PROP custom label format
+			const propModel = rfcProps.properties[property.name.split('.').pop()]
+
 			const propType = propModel && propModel.force
 				? propModel.force
 				: property.getDefaultType()


### PR DESCRIPTION
Should fix #1842.

The `canDisplay` filtering was [introduced almost a year ago](https://github.com/nextcloud/contacts/commit/417448cac5e1ebac691a8fc417a578f45e9bf08e#diff-42f8560182cc1534801c80adee527b8a79c2c55308e110a799c86ccb808cdf39R384). It checks whether the property name is "registered" in [`rfcProps.js`](https://github.com/nextcloud/contacts/blob/master/src/models/rfcProps.js), and if not, it does not pass it along.

The problem is that custom labels are implemented by using two vCard fields with the same, e.g., `group1.X-ABLabel` and `group1.TEL`, where the `.` separates the prefix from the field types. [The sorting function sorts by what is after the `.`](https://github.com/nextcloud/contacts/blob/master/src/components/ContactDetails.vue#L366), since we are not interested in the prefix. By the same logic, we should only check what is after the `.` for whether it is a property we can display.

I don't have the energy to figure out how to test this change. But I'm confident enough that this is the fix that I wanted to propose it in the form of a PR.