### PR TITLE
Fix communication of enabled/disabled addressbook (#1927)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 
 * 🚀 **Integration with other Nextcloud apps!** Currently Mail and Calendar – more to come.
 * 🎉 **Never forget a birthday!** You can sync birthdays and other recurring events with your Nextcloud Calendar.
-* 👥 **Sharing of Adressbooks!** You want to share your contacts with your friends or coworkers? No problem!
+* 👥 **Sharing of Addressbooks!** You want to share your contacts with your friends or coworkers? No problem!
 * 🙈 **We’re not reinventing the wheel!** Based on the great and open SabreDAV library.
 	</description>
 

--- a/src/components/Settings/SettingsAddressbook.vue
+++ b/src/components/Settings/SettingsAddressbook.vue
@@ -71,11 +71,11 @@
 				<ActionCheckbox v-if="!toggleEnabledLoading"
 					:checked="enabled"
 					@change.stop.prevent="toggleAddressbookEnabled">
-					{{ enabled ? t('contacts', 'Enabled') : t('contacts', 'Disabled') }}
+					{{ t('contacts', 'Enabled') }}
 				</ActionCheckbox>
 				<ActionButton v-else
 					icon="icon-loading-small">
-					{{ enabled ? t('contacts', 'Enabled') : t('contacts', 'Disabled') }}
+					{{ t('contacts', 'Enabled') }}
 				</ActionButton>
 			</template>
 


### PR DESCRIPTION
Not super sure how to tackle removing the "Disabled" translation, since as far as I can tell, it isn't used anywhere else

Fix #1927