### PR TITLE
Fix contact deletion from addressbook

### DIFF
--- a/src/store/addressbooks.js
+++ b/src/store/addressbooks.js
@@ -178,7 +178,7 @@ const mutations = {
 	 */
 	deleteContactFromAddressbook(state, contact) {
 		const addressbook = state.addressbooks.find(search => search.id === contact.addressbook.id)
-		Vue.delete(addressbook, contact.uid)
+		Vue.delete(addressbook.contacts, contact.uid)
 	},
 
 	/**


### PR DESCRIPTION
I'm not sure why this haven't caused any issue before! :fearful: 

https://github.com/nextcloud/contacts/blob/5bac2a13014c57328abd60bc519f56e41343beda/src/store/addressbooks.js#L170

This is used when moving a contact to an addressbook
https://github.com/nextcloud/contacts/blob/5bac2a13014c57328abd60bc519f56e41343beda/src/store/addressbooks.js#L518

Maybe this will fix issues like https://github.com/nextcloud/contacts/issues/2021