### PR TITLE
Fix renaming a circle

### DIFF
--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -34,17 +34,19 @@
 			</template>
 
 			<!-- display name -->
-			<input
-				slot="title"
-				v-model="circle.displayName"
-				:readonly="!circle.isOwner"
-				:placeholder="t('contacts', 'Circle name')"
-				type="text"
-				autocomplete="off"
-				autocorrect="off"
-				spellcheck="false"
-				name="displayname"
-				@input="onNameChangeDebounce">
+			<template #title>
+				<input
+					v-model="circle.displayName"
+					:readonly="!circle.isOwner"
+					:placeholder="t('contacts', 'Circle name')"
+					type="text"
+					autocomplete="off"
+					autocorrect="off"
+					spellcheck="false"
+					name="displayname"
+					@input="onNameChangeDebounce">
+				<div v-if="loadingName" class="circle-name__loader icon-loading-small" />
+			</template>
 
 			<!-- org, title -->
 			<template v-if="!circle.isOwner" #subtitle>
@@ -142,6 +144,7 @@ export default {
 	data() {
 		return {
 			loadingDescription: false,
+			loadingName: false,
 		}
 	},
 
@@ -196,11 +199,14 @@ export default {
 			this.onNameChange(event.target.value)
 		}, 500),
 		async onNameChange(name) {
+			this.loadingName = true
 			try {
 				await editCircle(this.circle.id, CircleEdit.Name, name)
 			} catch (error) {
 				console.error('Unable to edit circle name', name, error)
 				showError(t('contacts', 'An error happened during name sync'))
+			} finally {
+				this.loadingName = false
 			}
 		},
 	},
@@ -208,6 +214,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.circle-name__loader {
+	margin-left: 8px;
+}
+
 .circle-details-section {
 	&:not(:first-of-type) {
 		margin-top: 24px;

--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -44,7 +44,7 @@
 				autocorrect="off"
 				spellcheck="false"
 				name="displayname"
-				@input="onDisplayNameChangeDebounce">
+				@input="onNameChangeDebounce">
 
 			<!-- org, title -->
 			<template v-if="!circle.isOwner" #subtitle>
@@ -192,18 +192,15 @@ export default {
 			}
 		},
 
-		onDisplayNameChangeDebounce: debounce(function(event) {
-			this.onDisplayNameChange(event.target.value)
+		onNameChangeDebounce: debounce(function(event) {
+			this.onNameChange(event.target.value)
 		}, 500),
-		async onDisplayNameChange(description) {
-			this.loadingDescription = true
+		async onNameChange(name) {
 			try {
-				await editCircle(this.circle.id, CircleEdit.Description, description)
+				await editCircle(this.circle.id, CircleEdit.Name, name)
 			} catch (error) {
-				console.error('Unable to edit circle description', description, error)
-				showError(t('contacts', 'An error happened during description sync'))
-			} finally {
-				this.loadingDescription = false
+				console.error('Unable to edit circle name', name, error)
+				showError(t('contacts', 'An error happened during name sync'))
 			}
 		},
 	},

--- a/src/services/circles.d.ts
+++ b/src/services/circles.d.ts
@@ -24,9 +24,9 @@ interface MemberPairs {
     id: string;
     type: MemberType;
 }
-declare type CircleEditType = 'displayName' | 'description' | 'settings' | 'config';
+declare type CircleEditType = 'name' | 'description' | 'settings' | 'config';
 export declare enum CircleEdit {
-    DisplayName = "displayName",
+    Name = "displayName",
     Description = "description",
     Settings = "settings",
     Config = "config"

--- a/src/services/circles.d.ts
+++ b/src/services/circles.d.ts
@@ -26,7 +26,7 @@ interface MemberPairs {
 }
 declare type CircleEditType = 'name' | 'description' | 'settings' | 'config';
 export declare enum CircleEdit {
-    Name = "displayName",
+    Name = "name",
     Description = "description",
     Settings = "settings",
     Config = "config"

--- a/src/services/circles.ts
+++ b/src/services/circles.ts
@@ -30,7 +30,7 @@ interface MemberPairs {
 
 type CircleEditType = 'name' | 'description' | 'settings' | 'config'
 export enum CircleEdit {
-	Name = 'displayName',
+	Name = 'name',
 	Description = 'description',
 	Settings = 'settings',
 	Config = 'config',

--- a/src/services/circles.ts
+++ b/src/services/circles.ts
@@ -28,9 +28,9 @@ interface MemberPairs {
 	type: MemberType
 }
 
-type CircleEditType = 'displayName' | 'description' | 'settings' | 'config'
+type CircleEditType = 'name' | 'description' | 'settings' | 'config'
 export enum CircleEdit {
-	DisplayName = 'displayName',
+	Name = 'displayName',
 	Description = 'description',
 	Settings = 'settings',
 	Config = 'config',


### PR DESCRIPTION
So far, attempts to rename a circle resulted in the circle description
being changed instead.

Also don't set `loadingDescription` to true while updating the circle
name.