### PR TITLE
Support contacts member type

### DIFF
--- a/src/components/MemberList.vue
+++ b/src/components/MemberList.vue
@@ -151,11 +151,15 @@ export default {
 				.map(type => parseInt(type, 10))
 				// Map populated types to the group entry
 				.map(type => CIRCLES_MEMBER_GROUPING.find(group => group.type === type))
+				// Removed undefined group
+				.filter(group => group !== undefined)
 				// Injecting headings
-				.map(group => [{
-					heading: true,
-					...group,
-				}, ...(this.groupedList[group.type] || [])])
+				.map(group => {
+					return [{
+						heading: true,
+						...group,
+					}, ...(this.groupedList[group.type] || [])]
+				})
 				// Merging sub-arrays
 				.flat()
 		},

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -156,11 +156,21 @@ export const CIRCLES_MEMBER_GROUPING = [
 		share: OC.Share.SHARE_TYPE_EMAIL,
 		type: MEMBER_TYPE_MAIL
 	},
+	// TODO: implement SHARE_TYPE_CONTACT
+	{
+		id: `picker-contact`,
+		label: t('contacts', 'Contacts'),
+		share: OC.Share.SHARE_TYPE_EMAIL,
+		type: MEMBER_TYPE_CONTACT
+	},
 ]
 
 // Generating a map between share types and circle member types 
 export const SHARES_TYPES_MEMBER_MAP = CIRCLES_MEMBER_GROUPING.reduce((list, entry) => {
-	list[entry.share] = entry.type
+	// ! Ignore duplicate share types
+	if (!list[entry.share]) {
+		list[entry.share] = entry.type
+	}
 	return list
 }, {})
 


### PR DESCRIPTION
To reproduce:
1. Add a member type contacts from occ
   `occ circles:mem:add ADgqG5w9ixrAUh3 'admin/contacts/9788480a-d95f-45b6-bd8d-b0989563938c'`
   format is `USER/ADDRESSBOOK/UID`
2. Open the circle on contacts
3. See a red error


This fixes the display, but we still cannot add contacts through the UI for now.
Needs to be addressed later (either add a new `SHARE_TYPE_CONTACT`, or find something else)
