### PR TITLE
l10n: Error message changed

### DIFF
--- a/src/components/MembersList/MembersListItem.vue
+++ b/src/components/MembersList/MembersListItem.vue
@@ -317,8 +317,8 @@ export default {
 					memberId: this.source.id,
 				})
 			} catch (error) {
-				console.error('Could not accept member join request', this.source, error)
-				showError(t('contacts', 'Could not accept member join request'))
+				console.error('Could not accept membership request', this.source, error)
+				showError(t('contacts', 'Could not accept membership request'))
 			} finally {
 				this.loading = false
 			}


### PR DESCRIPTION
The error message as: "Could not accept membership request" is better suited as we accept the membership request.