### PR TITLE
Hide configs if personal

### DIFF
--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -91,7 +91,7 @@
 				@update:value="onDescriptionChangeDebounce" />
 		</section>
 
-		<section v-if="circle.isOwner" class="circle-details-section">
+		<section v-if="circle.isOwner && !circle.isPersonal" class="circle-details-section">
 			<CircleConfigs class="circle-details-section__configs" :circle="circle" />
 		</section>
 

--- a/src/models/circle.d.ts
+++ b/src/models/circle.d.ts
@@ -107,6 +107,10 @@ export default class Circle {
      */
     set config(config: number);
     /**
+     * Circle is personal
+     */
+    get isPersonal(): boolean;
+    /**
      * Circle requires invite to be confirmed by moderator or above
      */
     get requireJoinAccept(): boolean;

--- a/src/models/circle.ts
+++ b/src/models/circle.ts
@@ -216,6 +216,13 @@ export default class Circle {
 	}
 
 	/**
+	 * Circle is personal
+	 */
+	get isPersonal() {
+		return (this._data.config & CircleConfigs.PERSONAL) !== 0
+	}
+
+	/**
 	 * Circle requires invite to be confirmed by moderator or above
 	 */
 	get requireJoinAccept() {

--- a/src/models/constants.d.ts
+++ b/src/models/constants.d.ts
@@ -63,6 +63,7 @@ export declare enum MemberTypes {
     CONTACT
 }
 export declare enum CircleConfigs {
+    PERSONAL,
     SYSTEM,
     VISIBLE,
     OPEN,

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -65,6 +65,7 @@ const MEMBER_TYPE_CIRCLE: MemberType = 16
 export const CIRCLE_DESC = t('contacts', 'Circles allow you to create groups with other users on a Nextcloud instance and share with them.')
 
 // Circles config flags
+const CIRCLE_CONFIG_PERSONAL: CircleConfig = 2				// Personal circle, only the owner can see it.
 const CIRCLE_CONFIG_SYSTEM: CircleConfig = 4				// System Circle (not managed by the official front-end). Meaning some config are limited
 const CIRCLE_CONFIG_VISIBLE: CircleConfig = 8				// Visible to everyone, if not visible, people have to know its name to be able to find it
 const CIRCLE_CONFIG_OPEN: CircleConfig = 16					// Circle is open, people can join
@@ -195,6 +196,7 @@ export enum MemberTypes {
 }
 
 export enum CircleConfigs {
+	PERSONAL = CIRCLE_CONFIG_PERSONAL,
 	SYSTEM = CIRCLE_CONFIG_SYSTEM,
 	VISIBLE = CIRCLE_CONFIG_VISIBLE,
 	OPEN = CIRCLE_CONFIG_OPEN,


### PR DESCRIPTION
Fix #2301

Create personal circle with the following command:
`occ circles:manage:create userid "Personal circle" --type user --personal`