### PR TITLE
adjust the padding of the app-content-details

### DIFF
--- a/css/contacts.scss
+++ b/css/contacts.scss
@@ -49,7 +49,7 @@ $grid-input-height-with-margin: $grid-height-unit - $grid-input-margin * 2;
 }
 
 .app-content-details {
-	padding: 0 40px 80px 40px;
+	padding: 0 44px 80px 44px;
 }
 
 .app-content-list {


### PR DESCRIPTION
Otherwise the back button in the app-content-details overlaps by 4px on mobile
Signed-off-by: szaimen <szaimen@e.mail.de>