### PR TITLE
Fix call on null in SocialApiService

### DIFF
--- a/lib/Cron/SocialUpdate.php
+++ b/lib/Cron/SocialUpdate.php
@@ -46,7 +46,7 @@ class SocialUpdate extends \OC\BackgroundJob\QueuedJob {
 		$offsetContact = $arguments['offsetContact'] ?? null;
 
 		// update contacts with first available social media profile
-		$result = $this->social->updateAddressbooks('any', $userId, $offsetBook, $offsetContact);
+		$result = $this->social->updateAddressbooks($userId, $offsetBook, $offsetContact);
 
 		if ($result->getStatus() === Http::STATUS_PARTIAL_CONTENT) {
 			// not finished; schedule a follow-up

--- a/lib/Service/Social/DiasporaProvider.php
+++ b/lib/Service/Social/DiasporaProvider.php
@@ -49,6 +49,9 @@ class DiasporaProvider implements ISocialProvider {
 	 * @return bool
 	 */
 	public function supportsContact(array $contact):bool {
+		if (!array_key_exists("X-SOCIALPROFILE",$contact)) {
+			return false;
+		}
 		$socialprofiles = $this->getProfileIds($contact);
 		return isset($socialprofiles) && count($socialprofiles) > 0;
 	}

--- a/lib/Service/Social/FacebookProvider.php
+++ b/lib/Service/Social/FacebookProvider.php
@@ -45,6 +45,9 @@ class FacebookProvider implements ISocialProvider {
 	 * @return bool
 	 */
 	public function supportsContact(array $contact):bool {
+		if (!array_key_exists("X-SOCIALPROFILE",$contact)) {
+			return false;
+		}
 		$socialprofiles = $this->getProfiles($contact);
 		return isset($socialprofiles) && count($socialprofiles) > 0;
 	}

--- a/lib/Service/Social/GravatarProvider.php
+++ b/lib/Service/Social/GravatarProvider.php
@@ -38,6 +38,9 @@ class GravatarProvider implements ISocialProvider {
 	 * @return bool
 	 */
 	public function supportsContact(array $contact):bool {
+		if (!array_key_exists("EMAIL",$contact)) {
+			return false;
+		}
 		$emails = $contact['EMAIL'];
 		return isset($emails) && count($emails);
 	}

--- a/lib/Service/Social/InstagramProvider.php
+++ b/lib/Service/Social/InstagramProvider.php
@@ -55,6 +55,9 @@ class InstagramProvider implements ISocialProvider {
 	 * @return bool
 	 */
 	public function supportsContact(array $contact):bool {
+		if (!array_key_exists("X-SOCIALPROFILE",$contact)) {
+			return false;
+		}
 		$socialprofiles = $this->getProfiles($contact);
 		return isset($socialprofiles) && count($socialprofiles) > 0;
 	}

--- a/lib/Service/Social/MastodonProvider.php
+++ b/lib/Service/Social/MastodonProvider.php
@@ -45,6 +45,9 @@ class MastodonProvider implements ISocialProvider {
 	 * @return bool
 	 */
 	public function supportsContact(array $contact):bool {
+		if (!array_key_exists("X-SOCIALPROFILE",$contact)) {
+			return false;
+		}
 		$profiles = $this->getProfileIds($contact);
 		return isset($profiles) && count($profiles) > 0;
 	}

--- a/lib/Service/Social/TumblrProvider.php
+++ b/lib/Service/Social/TumblrProvider.php
@@ -38,6 +38,9 @@ class TumblrProvider implements ISocialProvider {
 	 * @return bool
 	 */
 	public function supportsContact(array $contact):bool {
+		if (!array_key_exists("X-SOCIALPROFILE",$contact)) {
+			return false;
+		}
 		$socialprofiles = $this->getProfileIds($contact);
 		return isset($socialprofiles) && count($socialprofiles) > 0;
 	}

--- a/lib/Service/Social/TwitterProvider.php
+++ b/lib/Service/Social/TwitterProvider.php
@@ -54,6 +54,9 @@ class TwitterProvider implements ISocialProvider {
 	 * @return bool
 	 */
 	public function supportsContact(array $contact):bool {
+		if (!array_key_exists("X-SOCIALPROFILE",$contact)) {
+			return false;
+		}
 		$socialprofiles = $this->getProfileIds($contact);
 		return isset($socialprofiles) && count($socialprofiles) > 0;
 	}

--- a/lib/Service/Social/XingProvider.php
+++ b/lib/Service/Social/XingProvider.php
@@ -45,6 +45,9 @@ class XingProvider implements ISocialProvider {
 	 * @return bool
 	 */
 	public function supportsContact(array $contact):bool {
+		if (!array_key_exists("X-SOCIALPROFILE",$contact)) {
+			return false;
+		}
 		$socialprofiles = $this->getProfileIds($contact);
 		return isset($socialprofiles) && count($socialprofiles) > 0;
 	}

--- a/lib/Service/SocialApiService.php
+++ b/lib/Service/SocialApiService.php
@@ -342,12 +342,12 @@ class SocialApiService {
 	/**
 	 * Updates social profile data for all contacts of an addressbook
 	 *
-	 * @param {String} network the social network to use (fallback: take first match)
+	 * @param {String|null} network the social network to use (take first match if unset)
 	 * @param {String} userId the address book owner
 	 *
 	 * @returns {JSONResponse} JSONResponse with the list of changed and failed contacts
 	 */
-	public function updateAddressbooks(string $network, string $userId, string $offsetBook = null, string $offsetContact = null) : JSONResponse {
+	public function updateAddressbooks(string $userId, string $offsetBook = null, string $offsetContact = null, string $network = null) : JSONResponse {
 
 		// double check!
 		$syncAllowedByAdmin = $this->config->getAppValue($this->appName, 'allowSocialSync', 'yes');

--- a/tests/unit/Service/SocialApiServiceTest.php
+++ b/tests/unit/Service/SocialApiServiceTest.php
@@ -237,7 +237,7 @@ class SocialApiServiceTest extends TestCase {
 			'VERSION' => $contact['VERSION'],
 			'PHOTO;ENCODING=b;TYPE=' . $imageType . ';VALUE=BINARY' => base64_encode($body)
 		];
-		
+
 		$this->socialProvider
 			->expects($this->once())->method("getSocialConnector")->with($network);
 		$provider->expects($this->once())->method("supportsContact")->with($contact);
@@ -306,7 +306,7 @@ class SocialApiServiceTest extends TestCase {
 			'VERSION' => $contact['VERSION'],
 			'PHOTO' => "data:".$imageType.";base64," . base64_encode($body)
 		];
-		
+
 		$this->socialProvider
 			 ->expects($this->once())->method("getSocialConnector")->with($network);
 		$provider->expects($this->once())->method("supportsContact")->with($contact);
@@ -442,7 +442,17 @@ class SocialApiServiceTest extends TestCase {
 
 		$this->setupAddressbooks();
 
-		$result = $this->service->updateAddressbooks('any', 'mrstest');
+		if ($syncAllowedByAdmin === 'yes' && $bgSyncEnabledByUser === 'yes') {
+			$this->socialProvider
+				->expects($this->atLeastOnce())
+				->method('getSocialConnectors');
+		}
+
+		$this->socialProvider
+			->expects($this->never())
+			->method('getSocialConnector');
+
+		$result = $this->service->updateAddressbooks('mrstest');
 
 		$this->assertEquals($expected, $result->getStatus());
 
@@ -474,7 +484,7 @@ class SocialApiServiceTest extends TestCase {
 
 		$this->setupAddressbooks();
 
-		$result = $this->service->updateAddressbooks('any', 'msstest');
+		$result = $this->service->updateAddressbooks('msstest');
 
 		$this->assertEquals(Http::STATUS_PARTIAL_CONTENT, $result->getStatus());
 
@@ -502,7 +512,7 @@ class SocialApiServiceTest extends TestCase {
 
 		$this->setupAddressbooks();
 
-		$result = $this->service->updateAddressbooks('any', 'mrstest', 'contacts2', '22222222-2222-2222-2222-222222222222');
+		$result = $this->service->updateAddressbooks('mrstest', 'contacts2', '22222222-2222-2222-2222-222222222222');
 
 		$this->assertEquals($expected, $result->getStatus());
 


### PR DESCRIPTION
Fixes #2348 

Gets rid of the magic value `'any'` and replaces it with a default null value for the network fallback to take the first matching.