### PR TITLE
Fix sha512 checksum for NPM dependency cdav-library (Fixes: #2362)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3861,7 +3861,7 @@
 		"node_modules/cdav-library": {
 			"version": "0.0.1",
 			"resolved": "git+ssh://git@github.com/nextcloud/cdav-library.git#0d826181fdb3958ad7ec214fc00b450edb55a866",
-			"integrity": "sha512-pa6beP0vY/exZKPOhEpqHTnkVLtksjZaPKFTmhCHvhieDxrNbpqCC2EHHZHy5x1RPFxMbpqeipTLK80m3A+MZw==",
+			"integrity": "sha512-Ndwy4++X1m1jIqoQFP882SQH+RfkDTLbYRXnePavNNlLx5vmR4sHLRWZMIlwphWtxiU+mKhGisPM10V6K6ISXA==",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"core-js": "^3.15.2",
@@ -15470,7 +15470,7 @@
 		},
 		"cdav-library": {
 			"version": "git+ssh://git@github.com/nextcloud/cdav-library.git#0d826181fdb3958ad7ec214fc00b450edb55a866",
-			"integrity": "sha512-pa6beP0vY/exZKPOhEpqHTnkVLtksjZaPKFTmhCHvhieDxrNbpqCC2EHHZHy5x1RPFxMbpqeipTLK80m3A+MZw==",
+			"integrity": "sha512-Ndwy4++X1m1jIqoQFP882SQH+RfkDTLbYRXnePavNNlLx5vmR4sHLRWZMIlwphWtxiU+mKhGisPM10V6K6ISXA==",
 			"from": "cdav-library@github:nextcloud/cdav-library#0d826181fdb3958ad7ec214fc00b450edb55a866",
 			"requires": {
 				"core-js": "^3.15.2",


### PR DESCRIPTION
The sha512 checksum for cdav-library commit 0d82618 in
`package-lock.json` was wrong.