### PR TITLE
allow to scroll the app-content-details

### DIFF
--- a/css/contacts.scss
+++ b/css/contacts.scss
@@ -50,6 +50,7 @@ $grid-input-height-with-margin: $grid-height-unit - $grid-input-margin * 2;
 
 .app-content-details {
 	padding: 0 44px 80px 44px;
+	overflow: auto;
 }
 
 .app-content-list {


### PR DESCRIPTION
Sometimes on mobile the screen might not be wide enough so scrolling is needed.

## Before
https://user-images.githubusercontent.com/42591237/127544926-dc22f5d5-78b9-4a8c-867d-35f4b883cd7b.mp4

## After
https://user-images.githubusercontent.com/42591237/127544803-cf007fcd-bba5-490a-a367-ceba5f1cec92.mp4

Signed-off-by: szaimen <szaimen@e.mail.de>