### PR TITLE
Fix Don't show groups in share placeholder if group sharing is disabled #2242

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -106,7 +106,10 @@ class PageController extends Controller {
 		$isCirclesEnabled = $this->appManager->isEnabledForUser('circles') === true;
 		// if circles is not installed, we use 0.0.0
 		$isCircleVersionCompatible = $this->compareVersion->isCompatible($circleVersion ? $circleVersion : '0.0.0', 22);
+		// Check whether group sharing is enabled or not
+		$isGroupSharingEnabled = $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes') === 'yes';
 
+		$this->initialStateService->provideInitialState(Application::APP_ID, 'isGroupSharingEnabled', $isGroupSharingEnabled);
 		$this->initialStateService->provideInitialState(Application::APP_ID, 'locales', $locales);
 		$this->initialStateService->provideInitialState(Application::APP_ID, 'defaultProfile', $defaultProfile);
 		$this->initialStateService->provideInitialState(Application::APP_ID, 'supportedNetworks', $supportedNetworks);

--- a/src/components/AppNavigation/Settings/SettingsAddressbookShare.vue
+++ b/src/components/AppNavigation/Settings/SettingsAddressbookShare.vue
@@ -49,6 +49,7 @@
 <script>
 import { NcSelect } from '@nextcloud/vue'
 import client from '../../../services/cdav.js'
+import isGroupSharingEnabled from '../../../services/isGroupSharingEnabled.js'
 
 import addressBookSharee from './SettingsAddressbookSharee.vue'
 import debounce from 'debounce'
@@ -79,7 +80,11 @@ export default {
 	},
 	computed: {
 		placeholder() {
-			return t('contacts', 'Share with users or groups')
+			if (isGroupSharingEnabled) {
+				return t('contacts', 'Share with users or groups')
+			} else {
+				return t('contacts', 'Share with users')
+			}
 		},
 		noResult() {
 			return t('contacts', 'No users or groups')

--- a/src/services/isGroupSharingEnabled.js
+++ b/src/services/isGroupSharingEnabled.js
@@ -1,0 +1,26 @@
+/**
+ * @copyright Copyright (c) 2020 John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { loadState } from '@nextcloud/initial-state'
+
+const isGroupSharingEnabled = loadState('contacts', 'isGroupSharingEnabled', false)
+export default isGroupSharingEnabled


### PR DESCRIPTION
Fix #2242 by checking group sharing enabled or not then updating the value of placeholder based on that value