### PR TITLE
Fix contacts group download due to missing store variable

### DIFF
--- a/src/components/AppNavigation/GroupNavigationItem.vue
+++ b/src/components/AppNavigation/GroupNavigationItem.vue
@@ -72,6 +72,9 @@ export default {
 	},
 
 	computed: {
+		contacts() {
+			return this.$store.getters.getContacts
+		},
 	},
 
 	methods: {


### PR DESCRIPTION
`downloadGroup` accesses the `contacts` computed store property that was
accidentally dropped in https://github.com/nextcloud/contacts/commit/d6030761c32d047b2208376a99d75b72c7c57987

Fixes https://github.com/nextcloud/contacts/issues/2345