### PR TITLE
Allow special chars for xing profile image

### DIFF
--- a/lib/Service/Social/XingProvider.php
+++ b/lib/Service/Social/XingProvider.php
@@ -85,7 +85,7 @@ class XingProvider implements ISocialProvider {
 			$result = $this->httpClient->get($profileUrl);
 			$htmlResult = $result->getBody();
 
-			$avatar = '/.*src="(https:\/\/profile-images[a-zA-Z0-9\/.\-_]+\.jpg)".*/';
+			$avatar = '/.*src="(https:\/\/profile-images[a-zA-Z0-9\/.\-_%]+\.jpg)".*/';
 			if (preg_match($avatar, $htmlResult, $matches)) {
 				return $matches[1];
 			}

--- a/tests/unit/Service/Social/XingProviderTest.php
+++ b/tests/unit/Service/Social/XingProviderTest.php
@@ -104,10 +104,10 @@ class XingProviderTest extends TestCase {
 			"https://www.xing.com/profile/username2",
 			"https://www.xing.com/profile/username3"
 		];
-		$contactWithSocialHtml = array_map(function ($profile) {
+		$contactWithSocialHtml = array_map(function ($profile) use ($contactImages) {
 			return '<img src="'.$contactImages[$profile['value']].'" />';
 		}, $contactWithSocial['X-SOCIALPROFILE']);
-		$contactWithSocialImg = array_map(function ($profile) {
+		$contactWithSocialImg = array_map(function ($profile) use ($contactImages) {
 			return $contactImages[$profile['value']];
 		}, $contactWithSocial['X-SOCIALPROFILE']);
 

--- a/tests/unit/Service/Social/XingProviderTest.php
+++ b/tests/unit/Service/Social/XingProviderTest.php
@@ -87,21 +87,28 @@ class XingProviderTest extends TestCase {
 	}
 
 	public function dataProviderGetImageUrls() {
+		$contactImages = [
+			"username1" => "https://profile-images-abcusername1.jpg",
+			"username2" => "https://profile-images-abcusername2.jpg",
+			"username3" => urlencode("https://profile-images-abc.ÄÖÜ/äöü_ß.jpg")
+		];
 		$contactWithSocial = [
 			'X-SOCIALPROFILE' => [
 				["value" => "username1", "type" => "xing"],
-				["value" => "username2", "type" => "xing"]
+				["value" => "username2", "type" => "xing"],
+				["value" => "username3", "type" => "xing"]
 			]
 		];
 		$contactWithSocialUrls = [
 			"https://www.xing.com/profile/username1",
-			"https://www.xing.com/profile/username2"
+			"https://www.xing.com/profile/username2",
+			"https://www.xing.com/profile/username3"
 		];
 		$contactWithSocialHtml = array_map(function ($profile) {
-			return '<img src="https://profile-images-abc'.$profile['value'].'.jpg" />';
+			return '<img src="'.$contactImages[$profile['value']].'" />';
 		}, $contactWithSocial['X-SOCIALPROFILE']);
 		$contactWithSocialImg = array_map(function ($profile) {
-			return 'https://profile-images-abc'.$profile['value'].".jpg";
+			return $contactImages[$profile['value']];
 		}, $contactWithSocial['X-SOCIALPROFILE']);
 
 		$contactWithoutSocial = [

--- a/tests/unit/Service/Social/XingProviderTest.php
+++ b/tests/unit/Service/Social/XingProviderTest.php
@@ -90,7 +90,7 @@ class XingProviderTest extends TestCase {
 		$contactImages = [
 			"username1" => "https://profile-images-abcusername1.jpg",
 			"username2" => "https://profile-images-abcusername2.jpg",
-			"username3" => urlencode("https://profile-images-abc.ÄÖÜ/äöü_ß.jpg")
+			"username3" => "https://".urlencode("profile-images-abc.ÄÖÜ/äöü_ß.jpg")
 		];
 		$contactWithSocial = [
 			'X-SOCIALPROFILE' => [


### PR DESCRIPTION
Hi, I just ran into the issue that the social provider for Xing wasn't able to load the profile image of a contact having some german umlauts (äöü) in their name.
After correctly url-encoding them they contain a percentage sign (%) so I just added that to the regex to enable certain special chars.
I also added a test case with some special chars.