### PR TITLE
Fix the width for the sharee name label

### DIFF
--- a/src/components/AppNavigation/Settings/SettingsAddressbookShare.vue
+++ b/src/components/AppNavigation/Settings/SettingsAddressbookShare.vue
@@ -140,3 +140,9 @@ export default {
 	},
 }
 </script>
+<style lang="scss" scoped>
+.addressbook-shares__list {
+	margin-left: -8px;
+	width: 282px;
+}
+</style>

--- a/src/components/AppNavigation/Settings/SettingsAddressbookSharee.vue
+++ b/src/components/AppNavigation/Settings/SettingsAddressbookSharee.vue
@@ -28,7 +28,8 @@
 				'icon-user': !sharee.isGroup && !loading
 			}"
 			class="icon" />
-		<span class="addressbook-sharee__identifier">
+		<span class="addressbook-sharee__identifier"
+			:title="sharee.displayName">
 			{{ sharee.displayName }}
 		</span>
 		<span class="addressbook-sharee__utils">
@@ -40,7 +41,8 @@
 				name="editable"
 				type="checkbox"
 				@change="editSharee">
-			<label :for="uid">
+			<label :for="uid"
+				:title="t('contacts', 'can edit')">
 				{{ t('contacts', 'can edit') }}
 			</label>
 			<a :class="{'addressbook-sharee__utils--disabled': loading}"
@@ -126,3 +128,14 @@ export default {
 	},
 }
 </script>
+<style lang="scss" scoped>
+.addressbook-sharee__utils {
+	text-overflow: ellipsis;
+}
+
+.addressbook-sharee__utils label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	width: 107px;
+}
+</style>


### PR DESCRIPTION
This PR fixes the width and adds a popover with the full sharee name.
before
![shareebefore](https://user-images.githubusercontent.com/12728974/141140867-5e009e72-7c12-477b-bb9d-82c98e1ac9d3.png)


after
![shareee](https://user-images.githubusercontent.com/12728974/141140870-e0d26e6b-823d-42d7-878c-9295abb01401.png)
fixes #2473  #2495