### PR TITLE
new contact event fix

### DIFF
--- a/src/components/AppContent/ContactsContent.vue
+++ b/src/components/AppContent/ContactsContent.vue
@@ -157,7 +157,7 @@ export default {
 		 * Forward the newContact event to the parent
 		 */
 		newContact() {
-			this.$emit('newContact')
+			this.$emit('new-contact')
 		},
 
 		/**

--- a/src/components/AppContent/ContactsContent.vue
+++ b/src/components/AppContent/ContactsContent.vue
@@ -157,7 +157,7 @@ export default {
 		 * Forward the newContact event to the parent
 		 */
 		newContact() {
-			this.$emit('new-contact')
+			this.$emit('newContact')
 		},
 
 		/**

--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -44,7 +44,7 @@
 		<ContactsContent v-else
 			:contacts-list="contactsList"
 			:loading="loadingContacts"
-			@newContact="newContact" />
+			@new-contact="newContact" />
 
 		<!-- Import modal -->
 		<Modal v-if="isImporting"


### PR DESCRIPTION
There is typo error for "newContact" event. That has been fixed in this pull request.