### PR TITLE
fix overlapping of contacts-list with app-navigation-toogle

### DIFF
--- a/src/components/ContactsList.vue
+++ b/src/components/ContactsList.vue
@@ -22,6 +22,7 @@
 
 <template>
 	<AppContentList>
+		<div class="contacts-list__header"></div>
 		<VirtualList ref="scroller"
 			class="contacts-list"
 			data-key="key"
@@ -154,7 +155,12 @@ export default {
 <style lang="scss" scoped>
 // Make virtual scroller scrollable
 .contacts-list {
-	max-height: calc(100vh - var(--header-height));
+	max-height: calc(100vh - var(--header-height) - 48px);
 	overflow: auto;
+}
+
+// Add empty header to contacts-list that solves overlapping of contacts with app-navigation-toogle
+.contacts-list__header {
+	min-height: 48px;
 }
 </style>


### PR DESCRIPTION
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/146604319-a434d82c-de5a-41f3-b5e1-0134fcd1b47a.png) | ![image](https://user-images.githubusercontent.com/42591237/146604262-21e596b8-307e-451a-9f48-726579e46861.png) | 


Ref https://github.com/nextcloud/groupware/issues/2

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e CONTACTS_BRANCH=enh/noid/fix-overlapping \
-e SERVER_BRANCH=stable23 \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>