### PR TITLE
Update info.xml authors with new maintainers and co-maintainers

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,8 +14,8 @@
 	<version>4.1.0-alpha.1</version>
 	<licence>agpl</licence>
 
-	<author>John Molakvoæ</author>
-	<author>Team Popcorn</author>
+	<author>Christoph Wurst</author>
+	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>
 
 	<!-- required for dav plugins registration -->
 	<types>


### PR DESCRIPTION
Ref https://github.com/nextcloud/groupware/issues/6#issuecomment-975367771

Ideally `<author>` was named `<maintainer>`. Obviously we are all still authors. But there is now one main person to maintain the app, the rest of us are co-maintainers.