### PR TITLE
Fix dev setup errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,10 @@ source_package_name=$(source_build_directory)/$(app_name)
 appstore_build_directory=$(CURDIR)/build/artifacts
 appstore_package_name=$(appstore_build_directory)/$(app_name)
 
-all: dev-setup lint build-js-production install-composer-deps-dev test-php
+all: dev-setup lint build-js-production install-composer-deps-dev
 
 # Dev env management
 dev-setup: clean clean-dev install-npm-deps-dev
-
-npm-update:
-	npm update
 
 composer.phar:
 	curl -sS https://getcomposer.org/installer | php
@@ -31,33 +28,8 @@ install-composer-deps: composer.phar
 install-composer-deps-dev: composer.phar
 	php composer.phar install -o
 
-# Building
-build-js:
-	npm run dev
-
-build-js-production:
-	npm run build
-
-watch-js:
-	npm run watch
-
-# Testing
-test:
-	npm run test
-
 test-watch:
 	npm run test:watch
-
-test-coverage:
-	npm run test:coverage
-
-test-php:
-	php composer.phar run test:unit
-	php composer.phar run test:integration
-
-test-php-coverage:
-	php composer.phar run test:unit -- --coverage-clover=coverage-unit.xml
-	php composer.phar run test:integration -- --coverage-clover=coverage-integration.xml
 
 # Linting
 lint:

--- a/README.md
+++ b/README.md
@@ -36,26 +36,31 @@ If you'd like to join, just go through the [issue list](https://github.com/nextc
 
 ``` bash
 # set up and build for production
-make
+npm ci
+npm run build
 
 # install dependencies
-make dev-setup
+npm ci
 
 # build for dev and watch changes
-make watch-js
+npm run watch
 
 # build for dev
-make build-js
+npm run dev
 
 # build for production with minification
-make build-js-production
+npm run build
 
 ```
 ## Running tests
-You can use the provided Makefile to run all tests by using:
+You can run all front-end tests by using:
 
 ```
-make test
+# run tests once
+npm run test
+
+# run tests continuously after every change
+npm run test:watch
 ```
 
 ## :v: Code of conduct


### PR DESCRIPTION
* Drop non-existent phpunit integration tests
* Do not run php tests for a dev setup
* Replace Makefile one-line commands with the simple npm command. Ref https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/npm.html for our conventions.

Fixes https://github.com/nextcloud/contacts/issues/2588
Ref https://help.nextcloud.com/t/beginner-compile-question-for-contacts-app/130118/3