### PR TITLE
Change formatter prop from :format to :formatter

### DIFF
--- a/src/components/Properties/PropertyDateTime.vue
+++ b/src/components/Properties/PropertyDateTime.vue
@@ -60,7 +60,7 @@
 				:first-day-of-week="firstDay"
 				:type="inputType"
 				:readonly="isReadOnly"
-				:format="dateFormat"
+				:formatter="dateFormat"
 				class="property__value"
 				confirm
 				@confirm="debounceUpdateValue" />


### PR DESCRIPTION
In vue2-datepicker 3.6.3 the `format` got renamed to `formatter`

See https://github.com/nextcloud/nextcloud-vue/pull/1495#issuecomment-989730285

Closes #2551