### PR TITLE
Fix usage of IgnorePlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,10 @@ const webpackConfig = require('@nextcloud/webpack-vue-config')
 webpackConfig.entry['files-action'] = path.join(__dirname, 'src', 'files-action.js')
 webpackConfig.entry['admin-settings'] = path.join(__dirname, 'src', 'admin-settings.js')
 webpackConfig.plugins.push(...[
-	new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+	new webpack.IgnorePlugin({
+		resourceRegExp: /^\.\/locale$/,
+		contextRegExp: /moment$/,
+	}),
 ])
 
 webpackConfig.module.rules.push({


### PR DESCRIPTION
Ref https://github.com/nextcloud/calendar/pull/3913

Required for https://github.com/nextcloud/contacts/pull/2615

The constructor of `IgnorePlugin` has changed since webpack v5.

Ref https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales