### PR TITLE
Fix content details container height

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -768,6 +768,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+// Container height fix for dropdowns
+.app-content-details {
+	min-height: calc(100vh - var(--header-height));
+}
+
 // List of all properties
 section.contact-details {
 	margin: 0 auto;


### PR DESCRIPTION
The ContactDetails container's height currently shrinks down to the height of the content if it is smaller than the viewport area. This cuts off dropdowns that appear on the page and results in a scrollable area smaller than the viewport area. Can be seen here, with the container element highlighted:

**Before:**
![nc-contacts-before](https://user-images.githubusercontent.com/860852/155829026-e2124c5b-ccf9-4afd-adde-0a36d493b595.png)

I've fixed this by setting a minimum height on the details container, calculated the same way as done with for the contact list pane. The result shown below, with the same container element highlighted:

**After:**
![nc-contacts-after-highlighted](https://user-images.githubusercontent.com/860852/155829247-f366af2d-a596-49e6-b72d-3ae84815122d.png)


(Also there's an additional commit to fix two tiny style warnings caught & fixed by eslint)