### PR TITLE
Fix: Show display name in group dropdown selection

### DIFF
--- a/src/components/AppNavigation/Settings/SettingsAddressbookShare.vue
+++ b/src/components/AppNavigation/Settings/SettingsAddressbookShare.vue
@@ -34,7 +34,7 @@
 			:user-select="true"
 			open-direction="bottom"
 			track-by="user"
-			label="user"
+			label="displayName"
 			@search-change="findSharee"
 			@input="shareAddressbook" />
 		<!-- list of user or groups addressbook is shared with -->


### PR DESCRIPTION
Fixes one aspect of #2411.

The dropdown box to select groups/users for sharing now shows the display names (not identifiers).