### PR TITLE
Fix social api service null url

### DIFF
--- a/lib/ContactsMenu/Providers/DetailsProvider.php
+++ b/lib/ContactsMenu/Providers/DetailsProvider.php
@@ -75,10 +75,10 @@ class DetailsProvider implements IProvider {
 	}
 
 	/**
-	 * Get (and load when needed) the address book for $key
+	 * Get (and load when needed) the address book URI for $key
 	 *
 	 * @param string $addressBookKey
-	 * @return \OCP\IAddressBook
+	 * @return string
 	 */
 	protected function getAddressBookUri($addressBookKey) {
 		$addressBooks = $this->getAddressBooksUris();

--- a/lib/Service/SocialApiService.php
+++ b/lib/Service/SocialApiService.php
@@ -200,7 +200,9 @@ class SocialApiService {
 			}
 
 			foreach ($connectors as $connector) {
-				$urls = array_merge($connector->getImageUrls($contact), $urls);
+				$urls = array_filter(array_merge($connector->getImageUrls($contact), $urls), function ($url) {
+					return filter_var($url, FILTER_VALIDATE_URL) !== false;
+				});
 			}
 
 			if (count($urls) == 0) {

--- a/tests/unit/Service/SocialApiServiceTest.php
+++ b/tests/unit/Service/SocialApiServiceTest.php
@@ -44,7 +44,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 
 class SocialApiServiceTest extends TestCase {
-	private $service;
+	private SocialApiService $service;
 
 	/** @var CompositeSocialProvider|MockObject */
 	private $socialProvider;
@@ -63,7 +63,7 @@ class SocialApiServiceTest extends TestCase {
 	/** @var ITimeFactory|MockObject */
 	private $timeFactory;
 
-	public function allSocialProfileProviders() {
+	public function allSocialProfileProviders(): array {
 		$body = "the body";
 		$imageType = "jpg";
 		$contact = [
@@ -72,7 +72,7 @@ class SocialApiServiceTest extends TestCase {
 		];
 		$connector = $this->createMock(ISocialProvider::class);
 		$connector->method('supportsContact')->willReturn(true);
-		$connector->method('getImageUrls')->willReturn(["url1"]);
+		$connector->method('getImageUrls')->willReturn(["https://https://url1.com/an-url/an-url"]);
 
 		$connectorNoSupport = $this->createMock(ISocialProvider::class);
 		$connectorNoSupport->method('supportsContact')->willReturn(false);
@@ -107,7 +107,7 @@ class SocialApiServiceTest extends TestCase {
 		];
 	}
 
-	public function updateAddressbookProvider() {
+	public function updateAddressbookProvider(): array {
 		return [
 			'not user enabled' => ['yes',	'no',	Http::STATUS_FORBIDDEN],
 			'not admin allowed' => ['no',	'yes',	Http::STATUS_FORBIDDEN],
@@ -195,7 +195,7 @@ class SocialApiServiceTest extends TestCase {
 		];
 		$provider = $this->createMock(ISocialProvider::class);
 		$provider->method('supportsContact')->willReturn(true);
-		$provider->method('getImageUrls')->willReturn(["url1"]);
+		$provider->method('getImageUrls')->willReturn(["https://url1.com/an-url"]);
 
 		$addressbook = $this->createMock(IAddressBook::class);
 		$addressbook
@@ -264,7 +264,7 @@ class SocialApiServiceTest extends TestCase {
 		];
 		$provider = $this->createMock(ISocialProvider::class);
 		$provider->method('supportsContact')->willReturn(true);
-		$provider->method('getImageUrls')->willReturn(["url1"]);
+		$provider->method('getImageUrls')->willReturn(["https://url1.com/an-url"]);
 
 		$addressbook = $this->createMock(IAddressBook::class);
 		$addressbook
@@ -389,10 +389,10 @@ class SocialApiServiceTest extends TestCase {
 		];
 
 		$providerUrlMap = [
-			[$validContact1, ["url1"]],
+			[$validContact1, ["https://url1.com/an-url"]],
 			[$emptyContact, []],
 			[$invalidContact, []],
-			[$validContact2, ["url1"]]
+			[$validContact2, ["https://url1.com/an-url"]]
 		];
 
 		$provider = $this->createMock(ISocialProvider::class);


### PR DESCRIPTION
We can't make sure every provider will return valid URLs, so let's at least validate them before doing the fetching.

Avoid issues like
```
TypeError: Argument 1 passed to OC\Http\Client\Client::get() must be of the type string, null given, called in /var/www/nextcloud/apps/contacts/lib/Service/SocialApiService.php on line 212 and defined in /var/www/nextcloud/lib/private/Http/Client/Client.php:221
Stack trace:
#0 /var/www/nextcloud/apps/contacts/lib/Service/SocialApiService.php(212): OC\Http\Client\Client->get(NULL)
#1 /var/www/nextcloud/apps/contacts/lib/Service/SocialApiService.php(410): OCA\Contacts\Service\SocialApiService->updateContact('addressbook-name', 'uid', NULL)
#2 /var/www/nextcloud/apps/contacts/lib/Cron/SocialUpdate.php(56): OCA\Contacts\Service\SocialApiService->updateAddressbooks('uid', NULL, NULL)
#3 /var/www/nextcloud/lib/public/BackgroundJob/Job.php(79): OCA\Contacts\Cron\SocialUpdate->run(Array)
#4 /var/www/nextcloud/lib/public/BackgroundJob/QueuedJob.php(47): OCP\BackgroundJob\Job->execute(Object(OC\BackgroundJob\JobList), Object(OC\Log))
#5 /var/www/nextcloud/cron.php(149): OCP\BackgroundJob\QueuedJob->execute(Object(OC\BackgroundJob\JobList), Object(OC\Log))
#6 {main}
```

See also https://github.com/nextcloud/contacts/issues/2149#issuecomment-813404732