### PR TITLE
Fix screenshot link in appstore

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -35,7 +35,7 @@
 	<website>https://github.com/nextcloud/contacts#readme</website>
 	<bugs>https://github.com/nextcloud/contacts/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/contacts.git</repository>
-	<screenshot>https://raw.githubusercontent.com/nextcloud/screenshots/main/apps/Contacts/contacts.png</screenshot>
+	<screenshot>https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Contacts/contacts.png</screenshot>
 
 	<dependencies>
 		<php min-version="7.3" max-version="8.1" />


### PR DESCRIPTION
See missing screenshot on https://apps.nextcloud.com/apps/contacts

After merging a new version needs to be published for the image to show up