### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/command-rebase.yml
+++ b/.github/workflows/command-rebase.yml
@@ -9,8 +9,13 @@ on:
   issue_comment:
     types: created
 
+permissions:
+  contents: read
+
 jobs:
   rebase:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
 
     # On pull requests and if the comment starts with `/rebase`

--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -11,8 +11,13 @@ on:
       - main
       - stable*
 
+permissions:
+  contents: read
+
 jobs:
   auto-merge:
+    permissions:
+      pull-requests: write  # for hmarr/auto-approve-action to approve PRs
     runs-on: ubuntu-latest
     steps:
       # Default github action approve

--- a/.github/workflows/lint-info-xml.yml
+++ b/.github/workflows/lint-info-xml.yml
@@ -12,6 +12,9 @@ on:
       - main
       - stable*
 
+permissions:
+  contents: read
+
 jobs:
   xml-linters:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-php-cs.yml
+++ b/.github/workflows/lint-php-cs.yml
@@ -12,6 +12,9 @@ on:
       - main
       - stable*
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -12,6 +12,9 @@ on:
       - main
       - stable*
 
+permissions:
+  contents: read
+
 jobs:
   php-lint:
     runs-on: ubuntu-latest
@@ -35,6 +38,8 @@ jobs:
         run: composer run lint
 
   summary:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     needs: php-lint
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,6 +10,9 @@ on:
 env:
   APP_NAME: contacts
 
+permissions:
+  contents: read
+
 jobs:
   php:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
