### PR TITLE
Add check for empty search result

### DIFF
--- a/lib/Service/SocialApiService.php
+++ b/lib/Service/SocialApiService.php
@@ -38,6 +38,7 @@ use OCP\IAddressBook;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use Psr\Log\LoggerInterface;
 
 class SocialApiService {
 	private $appName;
@@ -57,6 +58,8 @@ class SocialApiService {
 	private $davBackend;
 	/** @var ITimeFactory */
 	private $timeFactory;
+	/** @var LoggerInterface */
+	private $logger;
 
 
 	public function __construct(
@@ -67,7 +70,8 @@ class SocialApiService {
 					IL10N $l10n,
 					IURLGenerator $urlGen,
 					CardDavBackend $davBackend,
-					ITimeFactory $timeFactory) {
+					ITimeFactory $timeFactory,
+					LoggerInterface $logger) {
 		$this->appName = Application::APP_ID;
 		$this->socialProvider = $socialProvider;
 		$this->manager = $manager;
@@ -77,6 +81,7 @@ class SocialApiService {
 		$this->urlGen = $urlGen;
 		$this->davBackend = $davBackend;
 		$this->timeFactory = $timeFactory;
+		$this->logger = $logger;
 	}
 
 
@@ -183,6 +188,7 @@ class SocialApiService {
 			$contacts = $addressBook->search($contactId, ['UID'], ['types' => true]);
 
 			if (empty($contacts)) {
+				$this->logger->warning('Could not find contact in address book #' . urldecode($addressbookId) . ' with contact #' . $contactId);
 				return new JSONResponse([], Http::STATUS_PRECONDITION_FAILED);
 			}
 

--- a/lib/Service/SocialApiService.php
+++ b/lib/Service/SocialApiService.php
@@ -180,11 +180,13 @@ class SocialApiService {
 			}
 
 			// search contact in that addressbook, get social data
-			$contact = $addressBook->search($contactId, ['UID'], ['types' => true])[0];
+			$contacts = $addressBook->search($contactId, ['UID'], ['types' => true]);
 
-			if (!isset($contact)) {
+			if (empty($contacts)) {
 				return new JSONResponse([], Http::STATUS_PRECONDITION_FAILED);
 			}
+
+			$contact = $contacts[0];
 
 			if ($network) {
 				$allConnectors = [$this->socialProvider->getSocialConnector($network)];

--- a/tests/unit/Service/SocialApiServiceTest.php
+++ b/tests/unit/Service/SocialApiServiceTest.php
@@ -42,6 +42,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use Psr\Log\LoggerInterface;
 
 class SocialApiServiceTest extends TestCase {
 	private SocialApiService $service;
@@ -62,6 +63,8 @@ class SocialApiServiceTest extends TestCase {
 	private $davBackend;
 	/** @var ITimeFactory|MockObject */
 	private $timeFactory;
+	/** @var MockObject|LoggerInterface  */
+	private $logger;
 
 	public function allSocialProfileProviders(): array {
 		$body = "the body";
@@ -127,6 +130,7 @@ class SocialApiServiceTest extends TestCase {
 		$this->urlGen = $this->createMock(IURLGenerator::class);
 		$this->davBackend = $this->createMock(CardDavBackend::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->service = new SocialApiService(
 			$this->socialProvider,
 			$this->manager,
@@ -135,7 +139,8 @@ class SocialApiServiceTest extends TestCase {
 			$this->l10n,
 			$this->urlGen,
 			$this->davBackend,
-			$this->timeFactory
+			$this->timeFactory,
+			$this->logger
 		);
 	}
 
@@ -175,11 +180,10 @@ class SocialApiServiceTest extends TestCase {
 			->method('NewClient')
 			->willReturn($client);
 
-		$result = $this->service
-									 ->updateContact(
-										 'contacts',
-										 '3225c0d5-1bd2-43e5-a08c-4e65eaa406b0',
-										 null);
+		$result = $this->service->updateContact(
+			'contacts',
+			'3225c0d5-1bd2-43e5-a08c-4e65eaa406b0',
+			null);
 		$this->assertEquals($status, $result->getStatus());
 	}
 


### PR DESCRIPTION
Fixes array accessor error for #2721 

Does not fix the underlying issue of empty contacts when social data should be accessible.