### PR TITLE
Stop overwritting the name of the new contact by the company text

### DIFF
--- a/src/services/checks/missingFN.js
+++ b/src/services/checks/missingFN.js
@@ -46,18 +46,6 @@ export default {
 				return true
 			}
 			return false
-		} else if (contact.vCard.hasProperty('org')) {
-			const org = contact.vCard.getFirstPropertyValue('org')
-			// ABC, Inc.;North American Division;Marketing
-			// -> ABC, Inc.
-			if (Array.isArray(org) && org[0].trim() !== '') {
-				contact.fullName = org[0]
-				return true
-			} else if (org && org.trim() !== '') {
-				contact.fullName = org
-				return true
-			}
-			return false
 		}
 		return false
 	},


### PR DESCRIPTION
Delete the condition of missingfn that add the company text to the name field when it's missing

Fixes https://github.com/nextcloud/contacts/issues/2408