### PR TITLE
When delete last member from group, it is not update data on server

### DIFF
--- a/src/components/Properties/PropertyGroups.vue
+++ b/src/components/Properties/PropertyGroups.vue
@@ -166,6 +166,11 @@ export default {
 				contact: this.contact,
 				groupName,
 			})
+			const group = this.$store.getters.getGroups.find(search => search.name === groupName)
+			if (group.contacts.length === 0) {
+				this.$emit('update:value', [])
+			}
+
 		},
 
 		/**


### PR DESCRIPTION
Fixes https://github.com/nextcloud/contacts/issues/1813

Good afternoon! There is a bug, when I am in the selected group and delete the last contact from it, no data is sent to the server to update a contact.

Corrected in this way.

Thanks!

