### PR TITLE
Resize maximum dimensions for pictures coming from SocialApiService

### DIFF
--- a/lib/Service/ImageResizer.php
+++ b/lib/Service/ImageResizer.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Thomas Citharel <nextcloud@tcit.fr>
+ *
+ * @author Thomas Citharel <nextcloud@tcit.fr>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Contacts\Service;
+
+use OCP\Image;
+
+class ImageResizer {
+	public const RESIZE_MAX_X = 256;
+	public const RESIZE_MAX_Y = 256;
+
+	/**
+	 * @param string $socialData
+	 * @return null|string
+	 */
+	public function resizeImage(string $socialData) {
+		$image = new Image();
+
+		$image->loadFromData($socialData);
+
+		if ($image->valid()) {
+			$image->scaleDownToFit(self::RESIZE_MAX_X, self::RESIZE_MAX_Y);
+			return $image->data();
+		}
+		return null;
+	}
+}

--- a/lib/Service/SocialApiService.php
+++ b/lib/Service/SocialApiService.php
@@ -57,7 +57,8 @@ class SocialApiService {
 	private $davBackend;
 	/** @var ITimeFactory */
 	private $timeFactory;
-
+	/** @var ImageResizer */
+	private $imageResizer;
 
 	public function __construct(
 					CompositeSocialProvider $socialProvider,
@@ -67,7 +68,8 @@ class SocialApiService {
 					IL10N $l10n,
 					IURLGenerator $urlGen,
 					CardDavBackend $davBackend,
-					ITimeFactory $timeFactory) {
+					ITimeFactory $timeFactory,
+					ImageResizer $imageResizer) {
 		$this->appName = Application::APP_ID;
 		$this->socialProvider = $socialProvider;
 		$this->manager = $manager;
@@ -77,6 +79,7 @@ class SocialApiService {
 		$this->urlGen = $urlGen;
 		$this->davBackend = $davBackend;
 		$this->timeFactory = $timeFactory;
+		$this->imageResizer = $imageResizer;
 	}
 
 
@@ -222,6 +225,16 @@ class SocialApiService {
 
 			if (!$socialdata || $imageType === null) {
 				return new JSONResponse([], Http::STATUS_NOT_FOUND);
+			}
+
+			if (is_resource($socialdata)) {
+				$socialdata = stream_get_contents($socialdata);
+			}
+
+			$socialdata = $this->imageResizer->resizeImage($socialdata);
+
+			if (!$socialdata) {
+				return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
 			}
 
 			// update contact

--- a/tests/unit/Service/ImageResizerTest.php
+++ b/tests/unit/Service/ImageResizerTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @copyright Copyright (c) 2022 Thomas Citharel <nextcloud@tcit.fr>
+ *
+ * @author Thomas Citharel <nextcloud@tcit.fr>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Contacts\Service;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+
+class ImageResizerTest extends TestCase {
+
+	/** @var ImageResizer */
+	private $imageResizer;
+
+	protected function setUp(): void {
+		$this->imageResizer = new ImageResizer();
+	}
+
+	public function testReturnsNullForInvalidImage() {
+		$this->assertNull($this->imageResizer->resizeImage('badImage'));
+	}
+}

--- a/tests/unit/Service/SocialApiServiceTest.php
+++ b/tests/unit/Service/SocialApiServiceTest.php
@@ -62,6 +62,8 @@ class SocialApiServiceTest extends TestCase {
 	private $davBackend;
 	/** @var ITimeFactory|MockObject */
 	private $timeFactory;
+	/** @var ImageResizer|MockObject */
+	private $imageResizer;
 
 	public function allSocialProfileProviders(): array {
 		$body = "the body";
@@ -127,6 +129,7 @@ class SocialApiServiceTest extends TestCase {
 		$this->urlGen = $this->createMock(IURLGenerator::class);
 		$this->davBackend = $this->createMock(CardDavBackend::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->imageResizer = $this->createMock(ImageResizer::class);
 		$this->service = new SocialApiService(
 			$this->socialProvider,
 			$this->manager,
@@ -135,7 +138,8 @@ class SocialApiServiceTest extends TestCase {
 			$this->l10n,
 			$this->urlGen,
 			$this->davBackend,
-			$this->timeFactory
+			$this->timeFactory,
+			$this->imageResizer
 		);
 	}
 
@@ -174,12 +178,16 @@ class SocialApiServiceTest extends TestCase {
 		$this->clientService
 			->method('NewClient')
 			->willReturn($client);
+		$this->imageResizer
+			->expects($body ? $this->once() : $this->never())
+			->method('resizeImage')
+			->willReturn($body);
 
 		$result = $this->service
-									 ->updateContact(
-										 'contacts',
-										 '3225c0d5-1bd2-43e5-a08c-4e65eaa406b0',
-										 null);
+			 ->updateContact(
+				 'contacts',
+				 '3225c0d5-1bd2-43e5-a08c-4e65eaa406b0',
+				 null);
 		$this->assertEquals($status, $result->getStatus());
 	}
 
@@ -231,6 +239,10 @@ class SocialApiServiceTest extends TestCase {
 		$this->clientService
 			->method('NewClient')
 			->willReturn($client);
+		$this->imageResizer
+			->expects($this->once())
+			->method('resizeImage')
+			->willReturn($body);
 
 		$changes = [
 			'URI' => $contact['URI'],
@@ -300,6 +312,10 @@ class SocialApiServiceTest extends TestCase {
 		$this->clientService
 			->method('NewClient')
 			->willReturn($client);
+		$this->imageResizer
+			->expects($this->once())
+			->method('resizeImage')
+			->willReturn($body);
 
 		$changes = [
 			'URI' => $contact['URI'],
@@ -424,6 +440,9 @@ class SocialApiServiceTest extends TestCase {
 		$this->clientService
 			->method('NewClient')
 			->willReturn($client);
+		$this->imageResizer
+			->method('resizeImage')
+			->willReturn('someBody');
 	}
 
 	/**


### PR DESCRIPTION
Closes #2743

Make sure every picture fetched from SocialAPIService has a maximum size of 256 pixels.

Should we add an extra condition to reject on size being to high?

Would be nice to test ImageResizer with a few test pictures too.