### PR TITLE
Encode group names for x-property-replace header

### DIFF
--- a/lib/Dav/PatchPlugin.php
+++ b/lib/Dav/PatchPlugin.php
@@ -28,8 +28,6 @@ namespace OCA\Contacts\Dav;
 
 use Sabre\CardDAV\Card;
 use Sabre\DAV;
-use Sabre\DAV\INode;
-use Sabre\DAV\PropPatch;
 use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
 use Sabre\HTTP\RequestInterface;
@@ -85,9 +83,13 @@ class PatchPlugin extends ServerPlugin {
 	/**
 	 * Adds all CardDAV-specific properties
 	 *
-	 * @param PropPatch $propPatch
-	 * @param INode $node
+	 * @param RequestInterface $request
+	 * @param ResponseInterface $response
 	 * @return bool
+	 * @throws DAV\Exception\BadRequest
+	 * @throws DAV\Exception\NotAuthenticated
+	 * @throws DAV\Exception\NotFound
+	 * @throws \Sabre\DAVACL\Exception\NeedPrivileges
 	 */
 	public function httpPatch(RequestInterface $request, ResponseInterface $response): bool {
 		$path = $request->getPath();
@@ -118,6 +120,8 @@ class PatchPlugin extends ServerPlugin {
 				throw new DAV\Exception\BadRequest('No valid "X-Property-Append" or "X-Property-Replace" found in the headers');
 			}
 		}
+
+		$propertyData = rawurldecode($propertyData);
 
 		// Init contact
 		$vCard = Reader::read($node->get());

--- a/src/services/appendContactToGroup.js
+++ b/src/services/appendContactToGroup.js
@@ -34,7 +34,7 @@ const appendContactToGroup = async function(contact, groupName) {
 	return axios.patch(contact.url, {}, {
 		headers: {
 			'X-PROPERTY': 'CATEGORIES',
-			'X-PROPERTY-REPLACE': groups.join(','),
+			'X-PROPERTY-REPLACE': groups.map(groupName => encodeURIComponent(groupName)).join(','),
 		},
 	})
 }


### PR DESCRIPTION
Fix #2366 

I totally forgot issue #2366 :see_no_evil: 

As per https://xhr.spec.whatwg.org/#the-setrequestheader()-method and https://infra.spec.whatwg.org/#byte-sequences the header value must be in the range 0x20 (SP) to 0x7E (~) hence we need to encode everything else. 

**How to reproduce**

https://user-images.githubusercontent.com/3902676/126529036-d60ba502-ac26-4261-b403-cddb5afb8a7c.mp4

