### PR TITLE
Implement share password settings

### DIFF
--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -93,6 +93,7 @@
 
 		<section v-if="circle.isOwner && !circle.isPersonal" class="circle-details-section">
 			<CircleConfigs class="circle-details-section__configs" :circle="circle" />
+			<CirclePasswordSettings class="circle-details-section__configs" :circle="circle" />
 		</section>
 
 		<section v-else>
@@ -137,6 +138,7 @@ import CircleActionsMixin from '../mixins/CircleActionsMixin'
 import DetailsHeader from './DetailsHeader'
 import CircleConfigs from './CircleDetails/CircleConfigs'
 import ContentHeading from './CircleDetails/ContentHeading'
+import CirclePasswordSettings from './CircleDetails/CirclePasswordSettings'
 
 export default {
 	name: 'CircleDetails',
@@ -145,6 +147,7 @@ export default {
 		AppContentDetails,
 		Avatar,
 		CircleConfigs,
+		CirclePasswordSettings,
 		ContentHeading,
 		DetailsHeader,
 		Login,

--- a/src/components/CircleDetails/CirclePasswordSettings.vue
+++ b/src/components/CircleDetails/CirclePasswordSettings.vue
@@ -1,0 +1,274 @@
+<!--
+  - @copyright Copyright (c) 2022 Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<ul>
+		<li class="circle-config">
+			<ContentHeading class="circle-config__title">
+				{{ t('contacts', 'Password protection') }}
+			</ContentHeading>
+
+			<ul class="circle-config__list">
+				<CheckboxRadioSwitch :checked="enforcePasswordProtection"
+					:loading="loading.includes(ENFORCE_PASSWORD_PROTECTION)"
+					:disabled="loading.length > 0"
+					wrapper-element="li"
+					@update:checked="changePasswordProtection">
+					{{ t('contacts', 'Enforce Password protection on Files shared to this circle') }}
+				</CheckboxRadioSwitch>
+
+				<CheckboxRadioSwitch v-if="enforcePasswordProtection"
+					:checked="useUniquePassword || showUniquePasswordInput"
+					:loading="loading.includes(USE_UNIQUE_PASSWORD)"
+					:disabled="loading.length > 0"
+					wrapper-element="li"
+					@update:checked="changeUseUniquePassword">
+					{{ t('contacts', 'Use a unique password for all shares to this circles') }}
+				</CheckboxRadioSwitch>
+
+				<li class="unique-password">
+					<template v-if="showUniquePasswordInput">
+						<input
+							v-model="uniquePassword"
+							:disabled="loading.length > 0"
+							:placeholder="t('contacts', 'Unique password ...')"
+							type="text"
+							@keyup.enter="saveUniquePassword" />
+						<Button
+							type="tertiary-no-background"
+							:disabled="loading.length > 0 || uniquePassword.length === 0"
+							@click="saveUniquePassword">
+							{{ t('contacts', 'Save') }}
+						</Button>
+					</template>
+					<Button
+						v-else-if="useUniquePassword"
+						class="change-unique-password"
+						@click="onClickChangePassword">
+						{{ t('contacts', 'Change unique password') }}
+					</Button>
+
+					<div v-if="uniquePasswordError" class="unique-password-error">
+						{{ t('contacts', 'Failed to save password. Please try again later.') }}
+					</div>
+				</li>
+			</ul>
+		</li>
+	</ul>
+</template>
+
+<script>
+import ContentHeading from './ContentHeading'
+import CheckboxRadioSwitch from '@nextcloud/vue/dist/Components/CheckboxRadioSwitch'
+import Button from '@nextcloud/vue/dist/Components/Button'
+
+// Circle setting keys
+const ENFORCE_PASSWORD_PROTECTION = 'enforce_password'
+const USE_UNIQUE_PASSWORD = 'password_single_enabled'
+const UNIQUE_PASSWORD = 'password_single'
+
+export default {
+	name: 'CirclePasswordSettings',
+	components: {
+		ContentHeading,
+		CheckboxRadioSwitch,
+		Button,
+	},
+	props: {
+		circle: {
+			type: Object,
+			required: true,
+		},
+	},
+	data() {
+		return {
+			ENFORCE_PASSWORD_PROTECTION,
+			USE_UNIQUE_PASSWORD,
+			UNIQUE_PASSWORD,
+
+			loading: [],
+
+			uniquePassword: '',
+			uniquePasswordError: false,
+			showUniquePasswordInput: false,
+		}
+	},
+	computed: {
+		/**
+		 * @return {string}
+		 */
+		circleId() {
+			return this.circle._data.id
+		},
+
+		/**
+		 * @return {boolean}
+		 */
+		enforcePasswordProtection() {
+			const value = this.circle._data.settings[ENFORCE_PASSWORD_PROTECTION]
+			return value === '1' || value === 'true'
+		},
+
+		/**
+		 * @return {boolean}
+		 */
+		useUniquePassword() {
+			const value = this.circle._data.settings[USE_UNIQUE_PASSWORD]
+			return value === '1' || value === 'true'
+		},
+	},
+	methods: {
+		/**
+		 * Change handler for enforcePasswordProtection checkbox.
+		 */
+		async changePasswordProtection() {
+			this.loading.push(ENFORCE_PASSWORD_PROTECTION)
+			try {
+				const newValue = !this.enforcePasswordProtection
+
+				// Also disable unique password setting
+				if (!newValue && this.useUniquePassword) {
+					await this.saveUseUniquePassword(false)
+				}
+
+				// Also hide password input
+				if (!newValue && this.showUniquePasswordInput) {
+					this.showUniquePasswordInput = false
+				}
+
+				await this.$store.dispatch('editCircleSetting', {
+					circleId: this.circleId,
+					setting: {
+						setting: ENFORCE_PASSWORD_PROTECTION,
+						value: newValue.toString(),
+					},
+				})
+			} finally {
+				this.loading = this.loading.filter(item => item !== ENFORCE_PASSWORD_PROTECTION)
+			}
+		},
+
+		/**
+		 * Change handler for useUniquePassword checkbox.
+		 */
+		async changeUseUniquePassword() {
+			// Only update backend if the user disables the setting.
+			// It will be enabled once a unique password has been set.
+			if (!this.useUniquePassword) {
+				this.showUniquePasswordInput = !this.showUniquePasswordInput
+				return
+			}
+
+			await this.saveUseUniquePassword(!this.useUniquePassword)
+		},
+
+		/**
+		 * Update backend with given value for useUniquePassword.
+		 *
+		 * @param {boolean} value New value
+		 */
+		async saveUseUniquePassword(value) {
+			this.loading.push(USE_UNIQUE_PASSWORD)
+			try {
+				await this.$store.dispatch('editCircleSetting', {
+					circleId: this.circleId,
+					setting: {
+						setting: USE_UNIQUE_PASSWORD,
+						value: value.toString(),
+					},
+				})
+
+				// Reset unique password input state if disabled
+				if (!value) {
+					this.uniquePassword = ''
+					this.showUniquePasswordInput = false
+				}
+			} finally {
+				this.loading = this.loading.filter(item => item !== USE_UNIQUE_PASSWORD)
+			}
+		},
+
+		/**
+		 * Persist uniquePassword to backend.
+		 */
+		async saveUniquePassword() {
+			if (this.uniquePassword.length === 0) {
+				return
+			}
+
+			this.loading.push(UNIQUE_PASSWORD)
+			this.uniquePasswordError = false
+			try {
+				if (!this.useUniquePassword) {
+					await this.saveUseUniquePassword(true)
+				}
+
+				await this.$store.dispatch('editCircleSetting', {
+					circleId: this.circleId,
+					setting: {
+						setting: UNIQUE_PASSWORD,
+						value: this.uniquePassword,
+					},
+				})
+
+				// Show change button after saving the password
+				this.showUniquePasswordInput = false
+				this.uniquePassword = ''
+			} catch {
+				this.uniquePasswordError = true
+			} finally {
+				this.loading = this.loading.filter(item => item !== UNIQUE_PASSWORD)
+			}
+		},
+
+		/**
+		 * Click handler for the button to show the uniquePassword input.
+		 */
+		onClickChangePassword() {
+			this.showUniquePasswordInput = true
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.unique-password {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	width: 100%;
+
+	input {
+		flex: 1 auto;
+		max-width: 200px;
+	}
+
+	.change-unique-password {
+		margin-top: 5px;
+	}
+
+	// Force wrap error into a new line
+	.unique-password-error {
+		flex: 1 100%;
+	}
+}
+</style>

--- a/src/services/circles.d.ts
+++ b/src/services/circles.d.ts
@@ -31,6 +31,10 @@ export declare enum CircleEdit {
     Settings = "settings",
     Config = "config"
 }
+interface CircleSetting {
+    setting: string;
+    value: string;
+}
 /**
  * Get the circles list without the members
  *
@@ -128,4 +132,5 @@ export declare const changeMemberLevel: (circleId: string, memberId: string, lev
  * @returns {Array}
  */
 export declare const acceptMember: (circleId: string, memberId: string) => Promise<any>;
+export declare const editCircleSetting: (circleId: string, setting: CircleSetting) => Promise<any>;
 export {};

--- a/src/services/circles.ts
+++ b/src/services/circles.ts
@@ -36,6 +36,11 @@ export enum CircleEdit {
 	Config = 'config',
 }
 
+interface CircleSetting {
+	setting: string,
+	value: string
+}
+
 /**
  * Get the circles list without the members
  *
@@ -48,7 +53,7 @@ export const getCircles = async function() {
 
 /**
  * Get a specific circle
- * @param {string} circleId 
+ * @param {string} circleId
  * @returns {Object}
  */
 export const getCircle = async function(circleId: string) {
@@ -192,5 +197,13 @@ export const changeMemberLevel = async function(circleId: string, memberId: stri
  */
 export const acceptMember = async function(circleId: string, memberId: string) {
 	const response = await axios.put(generateOcsUrl('apps/circles/circles/{circleId}/members/{memberId}', { circleId, memberId }))
+	return response.data.ocs.data
+}
+
+export const editCircleSetting = async function(circleId: string, setting: CircleSetting) {
+	const response = await axios.put(
+		generateOcsUrl('apps/circles/circles/{circleId}/setting', { circleId }),
+		setting,
+	)
 	return response.data.ocs.data
 }

--- a/src/store/circles.js
+++ b/src/store/circles.js
@@ -23,7 +23,18 @@
 import { showError } from '@nextcloud/dialogs'
 import Vue from 'vue'
 
-import { acceptMember, createCircle, deleteCircle, deleteMember, getCircleMembers, getCircle, getCircles, leaveCircle, addMembers } from '../services/circles.ts'
+import {
+	acceptMember,
+	createCircle,
+	deleteCircle,
+	deleteMember,
+	getCircleMembers,
+	getCircle,
+	getCircles,
+	leaveCircle,
+	addMembers,
+	editCircleSetting,
+} from '../services/circles.ts'
 import Member from '../models/member.ts'
 import Circle from '../models/circle.ts'
 import logger from '../services/logger'
@@ -94,6 +105,10 @@ const mutations = {
 	deleteMemberFromCircle(state, member) {
 		// Circles dependencies are managed directly from the model
 		member.delete()
+	},
+
+	setCircleSettings(state, { circleId, settings }) {
+		Vue.set(state.circles[circleId]._data, 'settings', settings)
 	},
 }
 
@@ -271,6 +286,14 @@ const actions = {
 		const member = new Member(result, circle)
 
 		await context.commit('addMemberToCircle', { circleId, member })
+	},
+
+	async editCircleSetting(context, { circleId, setting }) {
+		const { settings } = await editCircleSetting(circleId, setting)
+		await context.commit('setCircleSettings', {
+			circleId,
+			settings,
+		})
 	},
 
 }


### PR DESCRIPTION
Fix #2644 

## How to test?
1. Configure your dev server to be able to send emails.
2. Create a circle.
3. Add an external member to the circle by email (you have to be able to receive emails for this address).
4. Test random password:
4.1. Enforce share passwords for the circle (but not a unique password).
4.2. Share a file with the circle.
4.3. Observe that the external user gets 2 mails (one with the share and one with a random password).
5. Test unique password:
5.1. Configure a unique password (second checkbox + input).
5.2. Share another file with the circle.
5.3. Observe that the external user gets a singe mail containing the share.
5.4. Unlock the share using the unique password from 5.1.

## Case 1: Configuring a new unique password

![new-password](https://user-images.githubusercontent.com/1479486/173560989-00d88d9a-e2cd-44af-8f53-fedec5177519.gif)


## Case 2: Changing the unique password when one is already set

I added a button for this case because the password is hashed and stored. It is impossible to reverse this process so it does not make sense to show a prefilled input field in this case.

![change-password](https://user-images.githubusercontent.com/1479486/173561012-fef78df4-432b-4ac5-9185-e9c96c5816f2.gif)

## Case 3: An error happens while saving the password

![change-password-error](https://user-images.githubusercontent.com/1479486/173561084-cf565fad-9b3e-491c-96e2-4542d39ebc84.gif)

## Case 4: Disabling password protection

![remove-password](https://user-images.githubusercontent.com/1479486/173561127-24de10c2-a662-484b-850b-203f2b94229a.gif)


## TODO
- [x] Enforce share password checkbox
- [x] Use unique password checkbox
- [x] Unique password input field
- [x] Test if feature/backend is working