### PR TITLE
Fix entity picker modal size

### DIFF
--- a/src/components/EntityPicker/EntityPicker.vue
+++ b/src/components/EntityPicker/EntityPicker.vue
@@ -21,7 +21,7 @@
 
 <template>
 	<Modal
-		size="full"
+		size="normal"
 		@close="onCancel">
 		<!-- Wrapper for content & navigation -->
 		<div class="entity-picker">
@@ -372,8 +372,7 @@ export default {
 <style lang="scss" scoped>
 
 // Dialog variables
-$dialog-margin: 20px;
-$dialog-width: 320px;
+$dialog-padding: 20px;
 $dialog-height: 480px;
 $entity-spacing: 4px;
 
@@ -394,15 +393,10 @@ $icon-margin: ($clickable-area - $icon-size) / 2;
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	/** This next 2 rules are pretty hacky, with the modal component somehow
-	the margin applied to the content is added to the total modal width,
-	so here we subtract it to the width and height of the content.
-	*/
-	width: $dialog-width;
-	max-width: 100vw;
-	height: $dialog-height;
-	max-height: calc(100vh - #{$dialog-margin} * 2 - 10px);
-	margin: $dialog-margin;
+	min-height: $dialog-height;
+	height: 100%;
+	padding: $dialog-padding;
+	box-sizing: border-box;
 
 	&__search {
 		position: relative;


### PR DESCRIPTION
Ref #2777 

The modal was full screen on desktop before.

| Desktop | Mobile |
| --- | --- |
| ![Screenshot 2022-07-15 at 11-18-49 Contacts - Nextcloud](https://user-images.githubusercontent.com/1479486/179194346-8751cba6-88ad-4868-abb5-2b55fe5cfce5.png) | ![image](https://user-images.githubusercontent.com/1479486/179194328-d05cacb7-1329-4aff-806c-c73444912af1.png) |


