### PR TITLE
Fix copy to full name and omit year actions

### DIFF
--- a/src/components/Actions/ActionCopyNtoFN.vue
+++ b/src/components/Actions/ActionCopyNtoFN.vue
@@ -21,7 +21,7 @@
   -->
 
 <template>
-	<ActionButton icon="icon-up" @click="copyNtoFN">
+	<ActionButton icon="icon-up" @click="copyNToFN">
 		{{ t('contacts', 'Copy to full name') }}
 	</ActionButton>
 </template>
@@ -37,13 +37,12 @@ export default {
 	mixins: [ActionsMixin],
 	methods: {
 		copyNToFN() {
-			console.info(this.component)
-			if (this.component.contact.vCard.hasProperty('n')) {
+			if (this.component.localContact.vCard.hasProperty('n')) {
 				// Stevenson;John;Philip,Paul;Dr.;Jr.,M.D.,A.C.P.
 				// -> John Stevenson
-				const n = this.component.contact.vCard.getFirstPropertyValue('n')
-				this.component.contact.fullName = n.slice(0, 2).reverse().join(' ')
-				this.component.updateContact()
+				const n = this.component.localContact.vCard.getFirstPropertyValue('n')
+				this.component.localContact.fullName = n.slice(0, 2).reverse().join(' ')
+				this.component.$emit('update')
 			}
 		},
 	},

--- a/src/components/Properties/PropertyActions.vue
+++ b/src/components/Properties/PropertyActions.vue
@@ -28,9 +28,10 @@
 			</template>
 			{{ t('contacts', 'Delete') }}
 		</ActionButton>
-		<Actions :is="action"
-			v-for="(action, index) in actions"
-			:key="index" />
+		<component v-for="action in actions"
+			:is="action"
+			:key="action.name"
+			:component="propertyComponent" />
 	</Actions>
 </template>
 
@@ -52,6 +53,10 @@ export default {
 		actions: {
 			type: Array,
 			default: () => [],
+		},
+		propertyComponent: {
+			type: Object,
+			required: true,
 		},
 	},
 

--- a/src/components/Properties/PropertyDateTime.vue
+++ b/src/components/Properties/PropertyDateTime.vue
@@ -73,6 +73,7 @@
 			<PropertyActions
 				v-if="!isReadOnly"
 				:actions="actions"
+				:property-component="this"
 				@delete="deleteProperty" />
 		</div>
 	</div>


### PR DESCRIPTION
This fixes 2 things at once because both issues share code:

1. The button `Copy to full name` in the detailed name section was broken.
2. The toggle `Omit year` in the birthday section was broken.

## 1. Copy to full name

### After
[Peek 2022-07-15 17-59.webm](https://user-images.githubusercontent.com/1479486/179261828-4cdc6fdd-9357-4fc8-8f99-4bdd2ab6ff68.webm)

## 2. Omit year

### Before
[bday-before.webm](https://user-images.githubusercontent.com/1479486/179264305-5283babb-925d-4f7e-97ed-e5a4c1236b7d.webm)

### After
[bday-after.webm](https://user-images.githubusercontent.com/1479486/179264302-e5817c7d-9000-449e-a89f-6fb9c80a0097.webm)