### PR TITLE
Hide social sync option if social sync is not available

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @copyright Copyright (c) 2018 John Molakvoæ <skjnldsv@protonmail.com>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author John Molakvoæ <skjnldsv@protonmail.com>
  * @author Matthias Heinisch <nextcloud@matthiasheinisch.de>
@@ -96,8 +97,9 @@ class PageController extends Controller {
 		$defaultProfile = $this->config->getAppValue(Application::APP_ID, 'defaultProfile', 'HOME');
 
 		$supportedNetworks = $this->socialApiService->getSupportedNetworks();
-		// allow users to retrieve avatars from social networks (default: yes)
-		$syncAllowedByAdmin = $this->config->getAppValue(Application::APP_ID, 'allowSocialSync', 'yes');
+		// Allow users to retrieve avatars from social networks (default: yes). Disabled if internet connection is not available.
+		$syncAllowedByAdmin = (($this->config->getAppValue(Application::APP_ID, 'allowSocialSync', 'yes') === 'yes')
+			&& $this->config->getSystemValueBool('has_internet_connection', true)) ? 'yes' : 'no';
 		// automated background syncs for social avatars (default: no)
 		$bgSyncEnabledByUser = $this->config->getUserValue($userId, Application::APP_ID, 'enableSocialSync', 'no');
 

--- a/lib/Cron/SocialUpdateRegistration.php
+++ b/lib/Cron/SocialUpdateRegistration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright 2017 Georg Ehrke <oc.list@georgehrke.com>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Georg Ehrke <oc.list@georgehrke.com>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
@@ -84,9 +85,9 @@ class SocialUpdateRegistration extends TimedJob {
 	 */
 	protected function run($arguments) {
 
-		// check if admin allows for social updates:
-		$syncAllowedByAdmin = $this->config->getAppValue($this->appName, 'allowSocialSync', 'yes');
-		if (!($syncAllowedByAdmin === 'yes')) {
+		// Social updates must be enabled by admin and internet connection must be available.
+		if (($this->config->getAppValue($this->appName, 'allowSocialSync', 'yes') !== 'yes')
+			 || !$this->config->getSystemValueBool('has_internet_connection', true)) {
 			return;
 		}
 

--- a/lib/Service/SocialApiService.php
+++ b/lib/Service/SocialApiService.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @copyright Copyright (c) 2020 Matthias Heinisch <nextcloud@matthiasheinisch.de>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Matthias Heinisch <nextcloud@matthiasheinisch.de>
  *
@@ -89,8 +90,9 @@ class SocialApiService {
 	 * @return {array} array of the supported social networks
 	 */
 	public function getSupportedNetworks() : array {
-		$syncAllowedByAdmin = $this->config->getAppValue($this->appName, 'allowSocialSync', 'yes');
-		if ($syncAllowedByAdmin !== 'yes') {
+		// Check if admin allows for social updates and internet connection is available.
+		if (($this->config->getAppValue($this->appName, 'allowSocialSync', 'yes') !== 'yes')
+			|| !$this->config->getSystemValueBool('has_internet_connection', true)) {
 			return [];
 		}
 		return $this->socialProvider->getSupportedNetworks();
@@ -364,10 +366,10 @@ class SocialApiService {
 	 */
 	public function updateAddressbooks(string $userId, string $offsetBook = null, string $offsetContact = null, string $network = null) : JSONResponse {
 
-		// double check!
-		$syncAllowedByAdmin = $this->config->getAppValue($this->appName, 'allowSocialSync', 'yes');
-		$bgSyncEnabledByUser = $this->config->getUserValue($userId, $this->appName, 'enableSocialSync', 'no');
-		if (($syncAllowedByAdmin !== 'yes') || ($bgSyncEnabledByUser !== 'yes')) {
+		// Forbid if social sync is disabled by admin or by user or no internet connection is available.
+		if (($this->config->getAppValue($this->appName, 'allowSocialSync', 'yes') !== 'yes')
+				|| ($this->config->getUserValue($userId, $this->appName, 'enableSocialSync', 'no') !== 'yes')
+				|| !$this->config->getSystemValueBool('has_internet_connection', true)) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 

--- a/src/components/AppNavigation/SettingsSection.vue
+++ b/src/components/AppNavigation/SettingsSection.vue
@@ -1,5 +1,6 @@
 <!--
   - @copyright Copyright (c) 2018 John Molakvoæ <skjnldsv@protonmail.com>
+  - @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
   -
   - @author John Molakvoæ <skjnldsv@protonmail.com>
   - @author Matthias Heinisch <nextcloud@matthiasheinisch.de>
@@ -24,7 +25,7 @@
 <template>
 	<div>
 		<SettingsSortContacts class="settings-section" />
-		<CheckboxRadioSwitch :checked="enableSocialSync"
+		<CheckboxRadioSwitch v-if="allowSocialSync" :checked="enableSocialSync"
 			:loading="enableSocialSyncLoading"
 			:disabled="enableSocialSyncLoading"
 			class="social-sync__checkbox"


### PR DESCRIPTION
This mod hides `Update avatars from social media (refreshed once per week)`
checkbox from contacts settings if syncing avatars is disabled by admin
or no internet connection is avalable.

Author-Change-Id: IB#1125033
Related: https://github.com/nextcloud/contacts/issues/1594
Signed-off-by: Pawel Boguslawski <pawel.boguslawski@ib.pl>