### PR TITLE
Remove min-width to avoid alignment issue

### DIFF
--- a/src/components/ProcessingScreen.vue
+++ b/src/components/ProcessingScreen.vue
@@ -41,7 +41,6 @@ export default {
 		display: flex;
 		flex-direction: column;
 		width: auto;
-		min-width: 30vw;
 		margin: 50px;
 
 		// Progress &desc wrapper


### PR DESCRIPTION
#### I'm using:
- Firefox 104.0.2
- Zoom 110% (100% looks weirder)
- Display 2560x1440

#### Situation

I'd to import contacts from a file by clicking `Settings -> Import`. 

After selecting a file, the result message was only half displayed:

![Bildschirmfoto vom 2022-09-07 13-14-42](https://user-images.githubusercontent.com/22561095/188865382-debfec7f-8808-47bd-99f5-a4bf0b53081c.png)

#### "Solution"

After removing the property `min-width` from the class `processing-screen__wrapper`, everything looks fine:

![Bildschirmfoto vom 2022-09-07 13-20-44](https://user-images.githubusercontent.com/22561095/188866284-b7d33f40-afdd-4802-8405-c6923fc00ee1.png)

This is my first pull request, please don't be rude :bowtie:

Signed-off-by: Michael Dix <thylamediol@gmail.com>