### PR TITLE
Properly decode escaped principal urls

### DIFF
--- a/src/components/AppNavigation/Settings/SettingsAddressbookShare.vue
+++ b/src/components/AppNavigation/Settings/SettingsAddressbookShare.vue
@@ -34,7 +34,7 @@
 			:user-select="true"
 			open-direction="bottom"
 			track-by="user"
-			label="user"
+			label="displayName"
 			@search-change="findSharee"
 			@input="shareAddressbook" />
 		<!-- list of user or groups addressbook is shared with -->
@@ -53,6 +53,7 @@ import client from '../../../services/cdav'
 
 import addressBookSharee from './SettingsAddressbookSharee'
 import debounce from 'debounce'
+import { urldecode } from '../../../utils/url.js'
 
 export default {
 	name: 'SettingsAddressbookShare',
@@ -100,10 +101,7 @@ export default {
 		 * @param {boolean} data.isGroup is this a group ?
 		 */
 		shareAddressbook({ user, displayName, uri, isGroup }) {
-			const addressbook = this.addressbook
-			uri = decodeURI(uri)
-			user = decodeURI(user)
-			this.$store.dispatch('shareAddressbook', { addressbook, user, displayName, uri, isGroup })
+			this.$store.dispatch('shareAddressbook', { addressbook: this.addressbook, user, displayName, uri, isGroup })
 		},
 
 		/**
@@ -121,10 +119,10 @@ export default {
 					&& !this.addressbook.shares.some((share) => share.uri === result.principalScheme)) {
 						const isGroup = result.calendarUserType === 'GROUP'
 						list.push({
-							user: result[isGroup ? 'groupId' : 'userId'],
+							user: urldecode(result[isGroup ? 'groupId' : 'userId']),
 							displayName: result.displayname,
 							icon: isGroup ? 'icon-group' : 'icon-user',
-							uri: result.principalScheme,
+							uri: urldecode(result.principalScheme),
 							isGroup,
 						})
 					}

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,0 +1,32 @@
+/**
+ * @copyright Copyright (c) 2021 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Works like urldecode() from php
+ *
+ * @see https://www.php.net/manual/en/function.urldecode.php
+ * @param {string} url The url to be decoded
+ * @returns {string} The decoded url
+ */
+export function urldecode(url) {
+	return decodeURIComponent(url.replace(/\+/g, ' '))
+}

--- a/tests/javascript/utils/url.test.js
+++ b/tests/javascript/utils/url.test.js
@@ -1,0 +1,38 @@
+/**
+ * @copyright Copyright (c) 2021 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { urldecode } from '../../../src/utils/url'
+
+describe('utils/url test suite', () => {
+	it('should decode urls encoded by php', () => {
+		const testData = [
+			['my+group+%2B%26%3F%25', 'my group +&?%'],
+			['my%2520+group', 'my%20 group'],
+			['group%20with%20spaces', 'group with spaces'],
+		]
+
+		for (const [encoded, expected] of testData) {
+			const decoded = urldecode(encoded)
+			expect(decoded).toEqual(expected)
+		}
+	})
+})


### PR DESCRIPTION
Apply the same fix as in https://github.com/nextcloud/calendar/commit/8c294b12e16cf0fb9e4297eb35310d341ec30de3 to allow sharing with groups that contains spaces and escaped characters

Fixes #2411