### PR TITLE
Save UID and display name for managers of the org chart

### DIFF
--- a/src/components/AppContent/ChartContent.vue
+++ b/src/components/AppContent/ChartContent.vue
@@ -44,14 +44,17 @@ export default {
 				prev.push(transformNode(contact))
 
 				const manager = contactsByUid[contact.addressbook.id][contact.managersName]
-				if (manager && !manager.managersName && !headManagers.includes(manager.uid)) {
+				if (manager && !manager.managersName && !headManagers.some(m => m.nodeId === manager.uid)) {
 					prev.push(transformNode(manager))
-					headManagers.push(manager.uid)
+					headManagers.push(transformNode(manager))
 				}
 				return prev
 			}, [])
 
-			return headManagers.map(uid => getChart(tempContacts, uid))
+			const charts = headManagers.map(managerNode => getChart(tempContacts, managerNode))
+			// Debugging logs to figure out why a graph might not show. Leave this in place until the logic is bulletproof
+			console.debug('Org charts', charts.map((nodes, index) => nodes.map(n => `list ${index} ${n.nodeId} (${n.fullName}) -> ${n.parentNodeId}`)))
+			return charts
 		},
 	},
 }

--- a/src/components/ContactDetails/ContactDetailsProperty.vue
+++ b/src/components/ContactDetails/ContactDetailsProperty.vue
@@ -230,7 +230,7 @@ export default {
 				return {
 					...prev,
 					[contact.uid]: {
-						id: contact.uid,
+						id: contact.key,
 						name: contact.displayName,
 					},
 				}
@@ -333,6 +333,16 @@ export default {
 						? this.property.getValues()[0]
 						: this.property.getValues()
 				}
+				if (this.propName === 'x-managersname') {
+					if (this.property.getParameter('uid')) {
+						return this.property.getParameter('uid') + '~' + this.contact.addressbook.id
+					}
+					// Try to find the matching contact by display name
+					// TODO: this only *shows* the display name but doesn't assign the missing UID
+					const displayName = this.property.getFirstValue()
+					const other = this.otherContacts(this.contact).find(contact => contact.displayName === displayName)
+					return other?.key
+				}
 				return this.property.getFirstValue()
 			},
 			set(data) {
@@ -342,7 +352,13 @@ export default {
 						? this.property.setValues([data])
 						: this.property.setValues(data)
 				} else {
-					this.property.setValue(data)
+					if (this.propName === 'x-managersname') {
+						const manager = this.$store.getters.getContact(data)
+						this.property.setValue(manager.displayName)
+						this.property.setParameter('uid', manager.uid)
+					} else {
+						this.property.setValue(data)
+					}
 				}
 				this.updateContact()
 			},

--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -371,22 +371,11 @@ export default class Contact {
 	 * @memberof Contact
 	 */
 	get managersName() {
-		return this.firstIfArray(this.vCard.getFirstPropertyValue('x-managersname'))
-	}
-
-	/**
-	 * Set the x-managersname
-	 *
-	 * @param {string} managersName the x-managersname data
-	 * @memberof Contact
-	 */
-	set managersName(managersName) {
-		// delete the org if empty
-		if (isEmpty(managersName)) {
-			this.vCard.removeProperty('x-managersname')
-			return
+		const prop = this.vCard.getFirstProperty('x-managersname')
+		if (!prop) {
+			return null
 		}
-		this.vCard.updatePropertyWithValue('x-managersname', managersName)
+		return prop.getFirstParameter('uid') ?? null
 	}
 
 	/**

--- a/src/utils/chartUtils.js
+++ b/src/utils/chartUtils.js
@@ -1,20 +1,16 @@
 import { generateUrl } from '@nextcloud/router'
 import { GROUP_ALL_CONTACTS } from '../models/constants.ts'
 
-export const getChart = (list, parent, nodes = []) => {
-	if (!nodes.length) {
-		nodes.push(list.find(node => node.nodeId === parent))
-	}
-	const children = list.filter(node => {
-		return node.parentNodeId === parent
+export const getChart = (allNodes, currentNode) => {
+	const result = [currentNode]
+	const children = allNodes.filter(node => {
+		return node.nodeId !== currentNode.nodeId && node.parentNodeId === currentNode.nodeId
 	})
 
-	children.forEach(node => {
-		nodes.push(node)
-		getChart(list, node.nodeId, nodes)
-	})
-
-	return nodes
+	return [
+		...result,
+		...children.flatMap(child => getChart(allNodes, child)),
+	]
 }
 
 export const transformNode = (contact) => {


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/contacts/pull/2954
Discussed in https://github.com/nextcloud/contacts/pull/2726#discussion_r949061158

Previously assigned managers will show a broken link because we wrongly stored the UID as display name. Those contacts need to be fixed but it only affects dev and pre-production instances.