### PR TITLE
Sort org charts

### DIFF
--- a/src/components/OrgChart.vue
+++ b/src/components/OrgChart.vue
@@ -23,6 +23,7 @@
 <script>
 import * as d3 from 'd3'
 import ChartTemplate from './ChartTemplate.vue'
+import { getLocale } from '@nextcloud/l10n'
 import Multiselect from '@nextcloud/vue/dist/Components/NcMultiselect'
 import { OrgChart } from 'd3-org-chart'
 import router from './../router'
@@ -53,6 +54,12 @@ export default {
 					id: index,
 					label: head.org ? `${head.org} (${head.fullName})` : head.fullName,
 				}
+			}).sort((a, b) => {
+				return a.label.localeCompare(
+					b.label,
+					getLocale().replace('_', '-'),
+					{ sensitivity: 'base' },
+				)
 			})
 		},
 		placeholder() {


### PR DESCRIPTION
## How to test

1) Create four contacts
2) Set organization to *A* for two of them, *B* for the others
3) Connect the two people of each organization
4) Go to the charts page

Main: if you are lucky the charts are sorted by chance. If so, rename organization *A* to *C*
This branch: the charts are always sorted.

![Bildschirmfoto vom 2022-09-23 19-19-59](https://user-images.githubusercontent.com/1374172/192020725-c3ccee39-b990-43a7-8432-f5e7dce440c6.png)
