### PR TITLE
Ensure padding for entity picker input text area

### DIFF
--- a/src/components/EntityPicker/EntityPicker.vue
+++ b/src/components/EntityPicker/EntityPicker.vue
@@ -415,7 +415,7 @@ $icon-margin: ($clickable-area - $icon-size) / 2;
 			width: 100%;
 			height: $clickable-area - $entity-spacing !important;
 			margin: $entity-spacing 0;
-			padding-left: $clickable-area;
+			padding-left: $clickable-area !important;
 			font-size: 16px;
 			line-height: $clickable-area - $entity-spacing;
 		}


### PR DESCRIPTION
Fixes missing padding for Group/Circle entity pickers. 
Previously:
![image](https://user-images.githubusercontent.com/10717998/192294599-f50538f3-fd04-485c-9035-f3ecb6746bfd.png)

After Fix:
![image](https://user-images.githubusercontent.com/10717998/192294661-1795c575-d09d-476a-80ac-0f3623b1b9f3.png)
