### PR TITLE
Fix address book picker

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -442,7 +442,10 @@ export default {
 				return this.contact.addressbook.id
 			},
 			set(addressbookId) {
-				this.moveContactToAddressbook(addressbookId)
+				// Only move when the address book actually changed to prevent a conflict.
+				if (this.contact.addressbook.id !== addressbookId) {
+					this.moveContactToAddressbook(addressbookId)
+				}
 			},
 		},
 
@@ -479,6 +482,7 @@ export default {
 		 * This is the list of addressbooks that are available to write
 		 *
 		 * @return {Array}
+		 * @return {{id: string, name: string}[]}
 		 */
 		addressbooksOptions() {
 			return this.addressbooks

--- a/src/components/Properties/PropertySelect.vue
+++ b/src/components/Properties/PropertySelect.vue
@@ -39,7 +39,7 @@
 			</div>
 
 			<Multiselect v-model="matchedOptions"
-				:options="options || propModel.options"
+				:options="propModel.options || options"
 				:placeholder="t('contacts', 'Select option')"
 				:disabled="isSingleOption || isReadOnly"
 				class="property__value"


### PR DESCRIPTION
Fix #2993

The `options` prop is an empty array by default and `[] || b == []`. The component `PropertySelect` is not used anywhere else so this should be a safe change.

I also fixed a conflict error that occurred when picking the same address book as before. The contact should only be moved if the address book actually changes.