### PR TITLE
Fix scrolling on mobile

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -805,6 +805,7 @@ export default {
 <style lang="scss" scoped>
 // Container height fix for dropdowns
 .app-content-details {
+	height: 100%;
 	min-height: calc(100vh - var(--header-height));
 	padding: 0 44px 80px 44px;
 }


### PR DESCRIPTION
Try scrolling the contact details page on mobile. It won't work. Now it works.