### PR TITLE
[stable5.0] Fix create group actions icon

### DIFF
--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -102,9 +102,11 @@
 				:force-menu="true"
 				:menu-open.sync="isNewGroupMenuOpen"
 				:title="t('contacts', 'Groups')"
-				default-icon="icon-add"
 				@click.prevent.stop="toggleNewGroupMenu">
-				<template slot="actions">
+				<template #actionsTriggerIcon>
+					<IconAdd :size="20" />
+				</template>
+				<template #actions>
 					<ActionText>
 						<template #icon>
 							<IconError v-if="createGroupError" :size="20" />


### PR DESCRIPTION
Partial backport of #3068

The create group button was still not using a material design icon.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1479486/197175596-c9b628b5-58c9-4177-be97-8c39a2795266.png) | ![image](https://user-images.githubusercontent.com/1479486/197175566-26e8901b-adba-4031-8ade-1bb49808f6b8.png) |
