### PR TITLE
Remove broken icons.css reference

### DIFF
--- a/lib/Listener/LoadContactsFilesActions.php
+++ b/lib/Listener/LoadContactsFilesActions.php
@@ -38,7 +38,6 @@ class LoadContactsFilesActions implements IEventListener {
 			return;
 		}
 
-		Util::addStyle(Application::APP_ID, 'icons');
 		Util::addScript(Application::APP_ID, 'contacts-files-action');
 	}
 }


### PR DESCRIPTION
should fix #3085

LoadContactsFilesActions adds the "icons" style, which does not exist anymore.

I could not figure out whether the next line (`Util::addScript(Application::APP_ID, 'contacts-files-action');`) should also be removed.