### PR TITLE
Changed grammar

### DIFF
--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -162,7 +162,7 @@ export const CIRCLES_MEMBER_GROUPING = [
 	},
 	{
 		id: `picker-${Type.SHARE_TYPE_EMAIL}`,
-		label: t('contacts', 'Emails'),
+		label: t('contacts', 'Email addresses'),
 		share: Type.SHARE_TYPE_EMAIL,
 		type: MEMBER_TYPE_MAIL
 	},


### PR DESCRIPTION
"Emails" is not the plural for email addresses

Reported at Transifex.

Signed-off-by: rakekniven <2069590+rakekniven@users.noreply.github.com>