### PR TITLE
Fix invalid version specs in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"@nextcloud/paths": "^2.1.0",
 				"@nextcloud/router": "^2.0.0",
 				"@nextcloud/sharing": "^0.1.0",
-				"@nextcloud/vue": "^v7.0.1",
+				"@nextcloud/vue": "^7.0.1",
 				"b64-to-blob": "^1.2.19",
 				"camelcase": "^7.0.0",
 				"d3": "^7.4.4",
@@ -37,7 +37,7 @@
 				"qr-image": "^3.2.0",
 				"string-natural-compare": "^3.0.1",
 				"uuid": "^9.0.0",
-				"vue": "~2.7.14",
+				"vue": "^2.7.14",
 				"vue-click-outside": "^1.1.0",
 				"vue-masonry": "^0.16.0",
 				"vue-material-design-icons": "^5.1.2",
@@ -68,7 +68,7 @@
 				"ts-jest": "^27.1.4",
 				"ts-loader": "^9.4.1",
 				"typescript": "^4.8.4",
-				"vue-template-compiler": "~2.7"
+				"vue-template-compiler": "^2.7.14"
 			},
 			"engines": {
 				"node": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"@nextcloud/paths": "^2.1.0",
 		"@nextcloud/router": "^2.0.0",
 		"@nextcloud/sharing": "^0.1.0",
-		"@nextcloud/vue": "^v7.0.1",
+		"@nextcloud/vue": "^7.0.1",
 		"b64-to-blob": "^1.2.19",
 		"camelcase": "^7.0.0",
 		"d3": "^7.4.4",
@@ -64,7 +64,7 @@
 		"qr-image": "^3.2.0",
 		"string-natural-compare": "^3.0.1",
 		"uuid": "^9.0.0",
-		"vue": "~2.7.14",
+		"vue": "^2.7.14",
 		"vue-click-outside": "^1.1.0",
 		"vue-masonry": "^0.16.0",
 		"vue-material-design-icons": "^5.1.2",
@@ -99,7 +99,7 @@
 		"ts-jest": "^27.1.4",
 		"ts-loader": "^9.4.1",
 		"typescript": "^4.8.4",
-		"vue-template-compiler": "~2.7"
+		"vue-template-compiler": "^2.7.14"
 	},
 	"browserslist": [
 		"extends @nextcloud/browserslist-config"


### PR DESCRIPTION
Regression of https://github.com/nextcloud/contacts/pull/3048 that causes `npm ci` to fail hard.