### PR TITLE
Revert "Bump vue and vue-template-compiler"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,9 @@
 				"qr-image": "^3.2.0",
 				"string-natural-compare": "^3.0.1",
 				"uuid": "^9.0.0",
-				"vue": "^2.7.14",
+				"vue": "~2.6.14",
 				"vue-click-outside": "^1.1.0",
-				"vue-masonry": "^0.16.0",
+				"vue-masonry": "^0.14.0",
 				"vue-material-design-icons": "^5.1.2",
 				"vue-router": "^3.6.5",
 				"vue-virtual-scroll-list": "^2.3.4",
@@ -55,7 +55,7 @@
 				"@nextcloud/eslint-config": "^8.1.4",
 				"@nextcloud/stylelint-config": "^2.3.0",
 				"@nextcloud/typings": "^1.5.0",
-				"@nextcloud/webpack-vue-config": "~5.4.0",
+				"@nextcloud/webpack-vue-config": "^5.2.0",
 				"@types/jest": "^27.4.1",
 				"@typescript-eslint/parser": "^5.44.0",
 				"@vue/composition-api": "^1.7.1",
@@ -68,7 +68,7 @@
 				"ts-jest": "^27.1.4",
 				"ts-loader": "^9.4.1",
 				"typescript": "^4.8.4",
-				"vue-template-compiler": "^2.7.14"
+				"vue-template-compiler": "~2.6"
 			},
 			"engines": {
 				"node": "^14.0.0",
@@ -151,29 +151,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/babel"
 			}
-		},
-		"node_modules/@babel/core/node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@babel/core/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
 		},
 		"node_modules/@babel/eslint-parser": {
 			"version": "7.19.1",
@@ -304,29 +281,6 @@
 			"peerDependencies": {
 				"@babel/core": "^7.4.0-0"
 			}
-		},
-		"node_modules/@babel/helper-define-polyfill-provider/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@babel/helper-define-polyfill-provider/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
 		},
 		"node_modules/@babel/helper-environment-visitor": {
 			"version": "7.18.9",
@@ -1745,20 +1699,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/traverse/node_modules/debug": {
-			"version": "4.1.1",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.1.1"
-			}
-		},
-		"node_modules/@babel/traverse/node_modules/ms": {
-			"version": "2.1.2",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
 		"node_modules/@babel/types": {
 			"version": "7.20.2",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
@@ -1790,9 +1730,9 @@
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.0.tgz",
-			"integrity": "sha512-u0XZyvUF6Urb2cSivSXA8qXIpT/CxkHcdtZKoWusAzgzmsTWpg0F2FpWXsolHmMUyVY3dLWaoy+0ccJ5uf2QjA==",
+			"version": "0.36.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+			"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -1835,28 +1775,10 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/@eslint/eslintrc/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@eslint/eslintrc/node_modules/globals": {
-			"version": "13.17.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-			"integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+			"version": "13.18.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+			"integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -1882,12 +1804,18 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/@eslint/eslintrc/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+		"node_modules/@eslint/eslintrc/node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true,
-			"peer": true
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/@floating-ui/core": {
 			"version": "0.3.1",
@@ -1916,31 +1844,6 @@
 			"engines": {
 				"node": ">=10.10.0"
 			}
-		},
-		"node_modules/@humanwhocodes/config-array/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@humanwhocodes/config-array/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/@humanwhocodes/module-importer": {
 			"version": "1.0.1",
@@ -3072,6 +2975,15 @@
 				"uuid": "dist/bin/uuid"
 			}
 		},
+		"node_modules/@nextcloud/vue/node_modules/vue": {
+			"version": "2.7.14",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
+			"integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
+			"dependencies": {
+				"@vue/compiler-sfc": "2.7.14",
+				"csstype": "^3.1.0"
+			}
+		},
 		"node_modules/@nextcloud/vue/node_modules/vue-resize": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-1.0.1.tgz",
@@ -3095,27 +3007,27 @@
 			}
 		},
 		"node_modules/@nextcloud/webpack-vue-config": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/webpack-vue-config/-/webpack-vue-config-5.4.0.tgz",
-			"integrity": "sha512-jBVJ01p8iNp5iLYrFtFAJHEal9jcU7HbnBS0Z+HXU9WDKJXp9YAOUDnejJKUXnKaAowZQtrBzSTpAY25cP9aVA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/webpack-vue-config/-/webpack-vue-config-5.2.0.tgz",
+			"integrity": "sha512-yBhYhWSRNErIjj9bGSAkZTjgtCrqsb5f3T2yLcN2/zq6jpSux64uICyQ1sLgnzc/foMKCXf1AIvRWEEPpQQIiA==",
 			"dev": true,
 			"engines": {
-				"node": "^16.0.0",
-				"npm": "^7.0.0 || ^8.0.0"
+				"node": "^14.0.0",
+				"npm": "^7.0.0"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.19.6",
-				"babel-loader": "^8.2.5",
-				"css-loader": "^6.7.1",
-				"node-polyfill-webpack-plugin": "2.0.1",
-				"sass": "^1.55.0",
-				"sass-loader": "^13.1.0",
+				"@babel/core": "^7.16.7",
+				"babel-loader": "^8.2.3",
+				"css-loader": "^6.5.1",
+				"node-polyfill-webpack-plugin": "2.0.0",
+				"sass": "^1.47.0",
+				"sass-loader": "^13.0.1",
 				"style-loader": "^3.3.1",
-				"vue-loader": "^15.10.0",
-				"vue-template-compiler": "^2.7.13",
-				"webpack": "^5.74.0",
-				"webpack-cli": "^4.10.0",
-				"webpack-dev-server": "^4.11.1"
+				"vue-loader": "^15.9.8",
+				"vue-template-compiler": "^2.6.14",
+				"webpack": "^5.66.0",
+				"webpack-cli": "^4.9.1",
+				"webpack-dev-server": "^4.7.2"
 			}
 		},
 		"node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -3300,9 +3212,9 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.4.6",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
-			"integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
+			"version": "8.4.10",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
+			"integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -3566,29 +3478,6 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/parser/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
 		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "5.44.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.44.0.tgz",
@@ -3645,29 +3534,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
 			"version": "7.3.8",
@@ -4121,29 +3987,6 @@
 				"node": ">= 6.0.0"
 			}
 		},
-		"node_modules/agent-base/node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/agent-base/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4180,9 +4023,9 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-			"integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+			"version": "8.11.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+			"integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -4302,16 +4145,16 @@
 			"peer": true
 		},
 		"node_modules/array-includes": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-			"integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+			"integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
-				"es-abstract": "^1.19.5",
-				"get-intrinsic": "^1.1.1",
+				"es-abstract": "^1.20.4",
+				"get-intrinsic": "^1.1.3",
 				"is-string": "^1.0.7"
 			},
 			"engines": {
@@ -4330,15 +4173,15 @@
 			}
 		},
 		"node_modules/array.prototype.flat": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-			"integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+			"integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4",
 				"es-shim-unscopables": "^1.0.0"
 			},
 			"engines": {
@@ -4536,9 +4379,9 @@
 			}
 		},
 		"node_modules/babel-loader": {
-			"version": "8.2.5",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.5.tgz",
-			"integrity": "sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
+			"integrity": "sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -4764,6 +4607,23 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/body-parser/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/body-parser/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/bonjour-service": {
 			"version": "1.0.14",
@@ -5066,6 +4926,7 @@
 		},
 		"node_modules/call-bind": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
 			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
 			"dev": true,
 			"peer": true,
@@ -5366,6 +5227,23 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/compression/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/compression/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"peer": true
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
@@ -5622,20 +5500,20 @@
 			}
 		},
 		"node_modules/css-loader": {
-			"version": "6.7.1",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
-			"integrity": "sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==",
+			"version": "6.7.2",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.2.tgz",
+			"integrity": "sha512-oqGbbVcBJkm8QwmnNzrFrWTnudnRZC+1eXikLJl0n4ljcfotgRifpg2a1lKy8jTrc4/d9A/ap1GFq1jDKG7J+Q==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"icss-utils": "^5.1.0",
-				"postcss": "^8.4.7",
+				"postcss": "^8.4.18",
 				"postcss-modules-extract-imports": "^3.0.0",
 				"postcss-modules-local-by-default": "^4.0.0",
 				"postcss-modules-scope": "^3.0.0",
 				"postcss-modules-values": "^4.0.0",
 				"postcss-value-parser": "^4.2.0",
-				"semver": "^7.3.5"
+				"semver": "^7.3.8"
 			},
 			"engines": {
 				"node": ">= 12.13.0"
@@ -5662,9 +5540,9 @@
 			}
 		},
 		"node_modules/css-loader/node_modules/postcss": {
-			"version": "8.4.16",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-			"integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+			"version": "8.4.19",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+			"integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
 			"dev": true,
 			"funding": [
 				{
@@ -5750,9 +5628,9 @@
 			}
 		},
 		"node_modules/css-loader/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -6263,13 +6141,20 @@
 			"integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
 		},
 		"node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"ms": "2.0.0"
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/decamelize": {
@@ -6726,9 +6611,9 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.20.2",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.2.tgz",
-			"integrity": "sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==",
+			"version": "1.20.4",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
+			"integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -6736,13 +6621,13 @@
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.1.2",
+				"get-intrinsic": "^1.1.3",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
 				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
-				"is-callable": "^1.2.4",
+				"is-callable": "^1.2.7",
 				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
 				"is-shared-array-buffer": "^1.0.2",
@@ -6752,6 +6637,7 @@
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.4",
 				"regexp.prototype.flags": "^1.4.3",
+				"safe-regex-test": "^1.0.0",
 				"string.prototype.trimend": "^1.0.5",
 				"string.prototype.trimstart": "^1.0.5",
 				"unbox-primitive": "^1.0.2"
@@ -7012,13 +6898,6 @@
 				"ms": "^2.1.1"
 			}
 		},
-		"node_modules/eslint-import-resolver-node/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/eslint-import-resolver-typescript": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.2.tgz",
@@ -7044,23 +6923,6 @@
 				"eslint-plugin-import": "*"
 			}
 		},
-		"node_modules/eslint-import-resolver-typescript/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/eslint-import-resolver-typescript/node_modules/globby": {
 			"version": "13.1.2",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
@@ -7079,12 +6941,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/eslint-import-resolver-typescript/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
 		},
 		"node_modules/eslint-import-resolver-typescript/node_modules/slash": {
 			"version": "4.0.0",
@@ -7125,13 +6981,6 @@
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
-		},
-		"node_modules/eslint-module-utils/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/eslint-plugin-es": {
 			"version": "4.1.0",
@@ -7207,6 +7056,16 @@
 				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
 			}
 		},
+		"node_modules/eslint-plugin-import/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
 		"node_modules/eslint-plugin-import/node_modules/doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -7220,14 +7079,21 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/eslint-plugin-import/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"peer": true
+		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "39.6.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.2.tgz",
-			"integrity": "sha512-dvgY/W7eUFoAIIiaWHERIMI61ZWqcz9YFjEeyTzdPlrZc3TY/3aZm5aB91NUoTLWYZmO/vFlYSuQi15tF7uE5A==",
+			"version": "39.6.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.4.tgz",
+			"integrity": "sha512-fskvdLCfwmPjHb6e+xNGDtGgbF8X7cDwMtVLAP2WwSf9Htrx68OAx31BESBM1FAwsN2HTQyYQq7m4aW4Q4Nlag==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.36.0",
+				"@es-joy/jsdoccomment": "~0.36.1",
 				"comment-parser": "1.3.1",
 				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
@@ -7242,24 +7108,6 @@
 				"eslint": "^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/eslint-plugin-jsdoc/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -7272,13 +7120,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/eslint-plugin-jsdoc/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
 			"version": "7.3.8",
@@ -7352,9 +7193,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-vue": {
-			"version": "9.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.7.0.tgz",
-			"integrity": "sha512-DrOO3WZCZEwcLsnd3ohFwqCoipGRSTKTBTnLwdhqAbYZtzWl0o7D+D8ZhlmiZvABKTEl8AFsqH1GHGdybyoQmw==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.8.0.tgz",
+			"integrity": "sha512-E/AXwcTzunyzM83C2QqDHxepMzvI2y6x+mmeYHbVDQlKFqmKYvRrhaVixEeeG27uI44p9oKDFiyCRw4XxgtfHA==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -7502,24 +7343,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/eslint/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/eslint/node_modules/escape-string-regexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -7598,9 +7421,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/globals": {
-			"version": "13.17.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-			"integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+			"version": "13.18.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+			"integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -7652,13 +7475,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/eslint/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/eslint/node_modules/p-limit": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7704,6 +7520,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/eslint/node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/eslint/node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -7718,9 +7547,9 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.4.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-			"integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -7980,6 +7809,23 @@
 			"dev": true,
 			"peer": true
 		},
+		"node_modules/express/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/express/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"peer": true
+		},
 		"node_modules/express/node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -8124,6 +7970,23 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/finalhandler/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/finalhandler/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/find-cache-dir": {
 			"version": "3.3.2",
@@ -8893,29 +8756,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/http-proxy-agent/node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/http-proxy-agent/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
 		"node_modules/http-proxy-middleware": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
@@ -8960,29 +8800,6 @@
 			"engines": {
 				"node": ">= 6"
 			}
-		},
-		"node_modules/https-proxy-agent/node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/https-proxy-agent/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
 		},
 		"node_modules/human-signals": {
 			"version": "2.1.0",
@@ -9248,9 +9065,9 @@
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"node_modules/is-callable": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.6.tgz",
-			"integrity": "sha512-krO72EO2NptOGAX2KYyqbP9vYMlNAXdB53rq6f8LXY6RY7JdSR/3BD6wLUlPHSAesmY9vstNrjvqGaCiRK/91Q==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
 			"dev": true,
 			"peer": true,
 			"engines": {
@@ -9672,29 +9489,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/istanbul-lib-source-maps/node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/istanbul-lib-source-maps/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
 		},
 		"node_modules/istanbul-reports": {
 			"version": "3.1.4",
@@ -11432,11 +11226,15 @@
 			}
 		},
 		"node_modules/js-sdsl": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-			"integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
+			"integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
 			"dev": true,
-			"peer": true
+			"peer": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/js-sdsl"
+			}
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -11649,9 +11447,9 @@
 			"dev": true
 		},
 		"node_modules/linkifyjs": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.0.1.tgz",
-			"integrity": "sha512-33dNbzpMEPXqei6i13+DXubONuBdiBLKRGMtYAin44CajYTgg25XunP8Vyua1TAuXhVQ1nocDl0D/qDWfY+GuQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.0.2.tgz",
+			"integrity": "sha512-/VSoCZiglX0VMsXmL5PN3lRg45M86lrD9PskdkA2abWaTKap1bIcJ11LS4EE55bcUl9ZOR4eZ792UtQ9E/5xLA==",
 			"peer": true
 		},
 		"node_modules/loader-runner": {
@@ -11840,9 +11638,9 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "3.4.10",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.10.tgz",
-			"integrity": "sha512-0bCUP+L79P4am30yP1msPzApwuMQG23TjwlwdHeEV5MxioDR1a0AgB0T9FfggU52eJuDCq8WVwb5ekznFyWiTQ==",
+			"version": "3.4.12",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.12.tgz",
+			"integrity": "sha512-BcjuQn6vfqP+k100e0E9m61Hyqa//Brp+I3f0OBmN0ATHlFA8vx3Lt8z57R3u2bPqe3WGDBC+nF72fTH7isyEw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -12040,11 +11838,14 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
 			"dev": true,
-			"peer": true
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/minimist-options": {
 			"version": "4.1.0",
@@ -12083,11 +11884,10 @@
 			}
 		},
 		"node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true,
-			"peer": true
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"node_modules/multicast-dns": {
 			"version": "7.2.5",
@@ -12160,9 +11960,9 @@
 			"dev": true
 		},
 		"node_modules/node-polyfill-webpack-plugin": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/node-polyfill-webpack-plugin/-/node-polyfill-webpack-plugin-2.0.1.tgz",
-			"integrity": "sha512-ZUMiCnZkP1LF0Th2caY6J/eKKoA0TefpoVa68m/LQU1I/mE8rGt4fNYGgNuCcK+aG8P8P43nbeJ2RqJMOL/Y1A==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/node-polyfill-webpack-plugin/-/node-polyfill-webpack-plugin-2.0.0.tgz",
+			"integrity": "sha512-jrMdoL1KmeTUiqLJb19nOgIFjqbX0ClJg97o0kmigy/d5dyoum0+bqPCaRpaX5mccJES6hwuQTXyCdKQ1p2Y3Q==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -12197,19 +11997,6 @@
 			},
 			"peerDependencies": {
 				"webpack": ">=5"
-			}
-		},
-		"node_modules/node-polyfill-webpack-plugin/node_modules/type-fest": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/node-releases": {
@@ -12316,6 +12103,7 @@
 		},
 		"node_modules/object-keys": {
 			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
 			"dev": true,
 			"peer": true,
@@ -12343,15 +12131,15 @@
 			}
 		},
 		"node_modules/object.values": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-			"integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+			"integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.1"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -12768,9 +12556,9 @@
 			"peer": true
 		},
 		"node_modules/postcss-html/node_modules/postcss": {
-			"version": "8.4.16",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-			"integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+			"version": "8.4.19",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+			"integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
 			"dev": true,
 			"funding": [
 				{
@@ -13541,6 +13329,21 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
 		},
+		"node_modules/safe-regex-test": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"is-regex": "^1.1.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -13691,6 +13494,23 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/send/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/send/node_modules/debug/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"peer": true
+		},
 		"node_modules/send/node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -13727,6 +13547,16 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/serve-index/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
 		"node_modules/serve-index/node_modules/depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -13757,6 +13587,13 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/serve-index/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true,
 			"peer": true
 		},
@@ -14051,31 +13888,6 @@
 				"wbuf": "^1.7.3"
 			}
 		},
-		"node_modules/spdy-transport/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/spdy-transport/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/spdy-transport/node_modules/readable-stream": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -14090,31 +13902,6 @@
 			"engines": {
 				"node": ">= 6"
 			}
-		},
-		"node_modules/spdy/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/spdy/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/splitpanes": {
 			"version": "2.4.1",
@@ -14301,30 +14088,30 @@
 			}
 		},
 		"node_modules/string.prototype.trimend": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-			"integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+			"integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
-				"es-abstract": "^1.19.5"
+				"es-abstract": "^1.20.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/string.prototype.trimstart": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-			"integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+			"integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
-				"es-abstract": "^1.19.5"
+				"es-abstract": "^1.20.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -14509,9 +14296,9 @@
 			}
 		},
 		"node_modules/stylelint-config-recommended-scss/node_modules/postcss": {
-			"version": "8.4.16",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-			"integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+			"version": "8.4.19",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+			"integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
 			"dev": true,
 			"funding": [
 				{
@@ -14578,9 +14365,9 @@
 			}
 		},
 		"node_modules/stylelint-config-recommended-vue/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -14632,23 +14419,6 @@
 			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
 			"dev": true
 		},
-		"node_modules/stylelint/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/stylelint/node_modules/is-plain-object": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -14657,12 +14427,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/stylelint/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
 		},
 		"node_modules/stylelint/node_modules/postcss": {
 			"version": "8.4.19",
@@ -14885,9 +14649,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.15.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-			"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+			"version": "5.16.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.0.tgz",
+			"integrity": "sha512-KjTV81QKStSfwbNiwlBXfcgMcOloyuRdb62/iLFPGBcVNF4EXjhdYBhYHmbJpiBrVxZhDvltE11j+LBQUxEEJg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -14958,9 +14722,9 @@
 			}
 		},
 		"node_modules/terser/node_modules/acorn": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
 			"dev": true,
 			"peer": true,
 			"bin": {
@@ -15344,13 +15108,13 @@
 			}
 		},
 		"node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
 			"dev": true,
 			"peer": true,
 			"engines": {
-				"node": ">=10"
+				"node": ">=12.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -15621,13 +15385,9 @@
 			"peer": true
 		},
 		"node_modules/vue": {
-			"version": "2.7.14",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
-			"integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
-			"dependencies": {
-				"@vue/compiler-sfc": "2.7.14",
-				"csstype": "^3.1.0"
-			}
+			"version": "2.6.14",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
+			"integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
 		},
 		"node_modules/vue-click-outside": {
 			"version": "1.1.0",
@@ -15644,9 +15404,9 @@
 			}
 		},
 		"node_modules/vue-demi": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-			"integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+			"version": "0.12.5",
+			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.12.5.tgz",
+			"integrity": "sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q==",
 			"hasInstallScript": true,
 			"bin": {
 				"vue-demi-fix": "bin/vue-demi-fix.js",
@@ -15693,24 +15453,6 @@
 				"eslint": ">=6.0.0"
 			}
 		},
-		"node_modules/vue-eslint-parser/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/vue-eslint-parser/node_modules/eslint-scope": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
@@ -15745,13 +15487,6 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/vue-eslint-parser/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/vue-eslint-parser/node_modules/semver": {
 			"version": "7.3.8",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -15776,9 +15511,9 @@
 			"peer": true
 		},
 		"node_modules/vue-loader": {
-			"version": "15.10.0",
-			"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.0.tgz",
-			"integrity": "sha512-VU6tuO8eKajrFeBzMssFUP9SvakEeeSi1BxdTH5o3+1yUyrldp8IERkSdXlMI2t4kxF2sqYUDsQY+WJBxzBmZg==",
+			"version": "15.10.1",
+			"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.1.tgz",
+			"integrity": "sha512-SaPHK1A01VrNthlix6h1hq4uJu7S/z0kdLUb6klubo738NeQoLbS6V9/d8Pv19tU0XdQKju3D1HSKuI8wJ5wMA==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -15830,14 +15565,14 @@
 			}
 		},
 		"node_modules/vue-masonry": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/vue-masonry/-/vue-masonry-0.16.0.tgz",
-			"integrity": "sha512-0Wi/BH4iYYRrAAFY/wokczz0lWWPg1vmOvFW4aC2nKybKf6kVqUvFfR9/+izDfzG657/vY+Om0gqOB5YPxPxuQ==",
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/vue-masonry/-/vue-masonry-0.14.1.tgz",
+			"integrity": "sha512-FFihoFv0du7dQIEIRYd+3kpHQb3apdQLw0PAJvgH6uBpr4xJ0z9g4EY4O3gBECq6gn2DSVSbPqSquZOqYVZIVw==",
 			"dependencies": {
 				"imagesloaded": "4.1.4",
 				"masonry-layout": "^4.2.2",
 				"mitt": "^3.0.0",
-				"vue-demi": "^0.13.2"
+				"vue-demi": "^0.12.1"
 			},
 			"peerDependencies": {
 				"@vue/composition-api": "^1.0.0-rc.1",
@@ -15918,13 +15653,13 @@
 			}
 		},
 		"node_modules/vue-template-compiler": {
-			"version": "2.7.14",
-			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
-			"integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
+			"version": "2.6.14",
+			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz",
+			"integrity": "sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==",
 			"dev": true,
 			"dependencies": {
 				"de-indent": "^1.0.2",
-				"he": "^1.2.0"
+				"he": "^1.1.0"
 			}
 		},
 		"node_modules/vue-template-es2015-compiler": {
@@ -16030,9 +15765,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.74.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-			"integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+			"version": "5.75.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
+			"integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -16160,9 +15895,9 @@
 			}
 		},
 		"node_modules/webpack-dev-middleware/node_modules/ajv": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-			"integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+			"version": "8.11.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+			"integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -16273,9 +16008,9 @@
 			}
 		},
 		"node_modules/webpack-dev-server/node_modules/ajv": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-			"integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+			"version": "8.11.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+			"integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -16354,9 +16089,9 @@
 			}
 		},
 		"node_modules/webpack/node_modules/acorn": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
 			"dev": true,
 			"peer": true,
 			"bin": {
@@ -16745,23 +16480,6 @@
 				"gensync": "^1.0.0-beta.2",
 				"json5": "^2.2.1",
 				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.3",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/eslint-parser": {
@@ -16855,23 +16573,6 @@
 				"lodash.debounce": "^4.0.8",
 				"resolve": "^1.14.2",
 				"semver": "^6.1.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-environment-visitor": {
@@ -17842,21 +17543,6 @@
 				"@babel/types": "^7.20.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/types": {
@@ -17884,9 +17570,9 @@
 			"peer": true
 		},
 		"@es-joy/jsdoccomment": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.0.tgz",
-			"integrity": "sha512-u0XZyvUF6Urb2cSivSXA8qXIpT/CxkHcdtZKoWusAzgzmsTWpg0F2FpWXsolHmMUyVY3dLWaoy+0ccJ5uf2QjA==",
+			"version": "0.36.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+			"integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -17920,20 +17606,10 @@
 					"dev": true,
 					"peer": true
 				},
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
 				"globals": {
-					"version": "13.17.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-					"integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+					"version": "13.18.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+					"integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
 					"dev": true,
 					"peer": true,
 					"requires": {
@@ -17950,10 +17626,10 @@
 						"argparse": "^2.0.1"
 					}
 				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+				"type-fest": {
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 					"dev": true,
 					"peer": true
 				}
@@ -17982,25 +17658,6 @@
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
 				"minimatch": "^3.0.5"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true,
-					"peer": true
-				}
 			}
 		},
 		"@humanwhocodes/module-importer": {
@@ -18860,6 +18517,15 @@
 					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 					"peer": true
 				},
+				"vue": {
+					"version": "2.7.14",
+					"resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
+					"integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
+					"requires": {
+						"@vue/compiler-sfc": "2.7.14",
+						"csstype": "^3.1.0"
+					}
+				},
 				"vue-resize": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-1.0.1.tgz",
@@ -18879,9 +18545,9 @@
 			}
 		},
 		"@nextcloud/webpack-vue-config": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/webpack-vue-config/-/webpack-vue-config-5.4.0.tgz",
-			"integrity": "sha512-jBVJ01p8iNp5iLYrFtFAJHEal9jcU7HbnBS0Z+HXU9WDKJXp9YAOUDnejJKUXnKaAowZQtrBzSTpAY25cP9aVA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/webpack-vue-config/-/webpack-vue-config-5.2.0.tgz",
+			"integrity": "sha512-yBhYhWSRNErIjj9bGSAkZTjgtCrqsb5f3T2yLcN2/zq6jpSux64uICyQ1sLgnzc/foMKCXf1AIvRWEEPpQQIiA==",
 			"dev": true,
 			"requires": {}
 		},
@@ -19051,9 +18717,9 @@
 			}
 		},
 		"@types/eslint": {
-			"version": "8.4.6",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
-			"integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
+			"version": "8.4.10",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
+			"integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -19300,23 +18966,6 @@
 				"@typescript-eslint/types": "5.44.0",
 				"@typescript-eslint/typescript-estree": "5.44.0",
 				"debug": "^4.3.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"@typescript-eslint/scope-manager": {
@@ -19350,21 +18999,6 @@
 				"tsutils": "^3.21.0"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
 				"semver": {
 					"version": "7.3.8",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -19743,23 +19377,6 @@
 			"dev": true,
 			"requires": {
 				"debug": "4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.3",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"ajv": {
@@ -19786,9 +19403,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.11.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-					"integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+					"version": "8.11.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+					"integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
 					"dev": true,
 					"peer": true,
 					"requires": {
@@ -19879,16 +19496,16 @@
 			"peer": true
 		},
 		"array-includes": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-			"integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+			"integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
 			"dev": true,
 			"peer": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
-				"es-abstract": "^1.19.5",
-				"get-intrinsic": "^1.1.1",
+				"es-abstract": "^1.20.4",
+				"get-intrinsic": "^1.1.3",
 				"is-string": "^1.0.7"
 			}
 		},
@@ -19898,15 +19515,15 @@
 			"dev": true
 		},
 		"array.prototype.flat": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-			"integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+			"integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
 			"dev": true,
 			"peer": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4",
 				"es-shim-unscopables": "^1.0.0"
 			}
 		},
@@ -20062,9 +19679,9 @@
 			}
 		},
 		"babel-loader": {
-			"version": "8.2.5",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.5.tgz",
-			"integrity": "sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
+			"integrity": "sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -20230,6 +19847,23 @@
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
 					"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+					"dev": true,
+					"peer": true
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 					"dev": true,
 					"peer": true
 				}
@@ -20478,6 +20112,7 @@
 		},
 		"call-bind": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
 			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
 			"dev": true,
 			"peer": true,
@@ -20705,6 +20340,25 @@
 				"on-headers": "~1.0.2",
 				"safe-buffer": "5.1.2",
 				"vary": "~1.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"dev": true,
+					"peer": true
+				}
 			}
 		},
 		"concat-map": {
@@ -20914,20 +20568,20 @@
 			"dev": true
 		},
 		"css-loader": {
-			"version": "6.7.1",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
-			"integrity": "sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==",
+			"version": "6.7.2",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.2.tgz",
+			"integrity": "sha512-oqGbbVcBJkm8QwmnNzrFrWTnudnRZC+1eXikLJl0n4ljcfotgRifpg2a1lKy8jTrc4/d9A/ap1GFq1jDKG7J+Q==",
 			"dev": true,
 			"peer": true,
 			"requires": {
 				"icss-utils": "^5.1.0",
-				"postcss": "^8.4.7",
+				"postcss": "^8.4.18",
 				"postcss-modules-extract-imports": "^3.0.0",
 				"postcss-modules-local-by-default": "^4.0.0",
 				"postcss-modules-scope": "^3.0.0",
 				"postcss-modules-values": "^4.0.0",
 				"postcss-value-parser": "^4.2.0",
-				"semver": "^7.3.5"
+				"semver": "^7.3.8"
 			},
 			"dependencies": {
 				"icss-utils": {
@@ -20939,9 +20593,9 @@
 					"requires": {}
 				},
 				"postcss": {
-					"version": "8.4.16",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-					"integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+					"version": "8.4.19",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+					"integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
 					"dev": true,
 					"peer": true,
 					"requires": {
@@ -20991,9 +20645,9 @@
 					}
 				},
 				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 					"dev": true,
 					"peer": true,
 					"requires": {
@@ -21377,13 +21031,12 @@
 			"integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
 		},
 		"debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
-				"ms": "2.0.0"
+				"ms": "2.1.2"
 			}
 		},
 		"decamelize": {
@@ -21742,9 +21395,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.20.2",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.2.tgz",
-			"integrity": "sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==",
+			"version": "1.20.4",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
+			"integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -21752,13 +21405,13 @@
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.1.2",
+				"get-intrinsic": "^1.1.3",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
 				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
-				"is-callable": "^1.2.4",
+				"is-callable": "^1.2.7",
 				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
 				"is-shared-array-buffer": "^1.0.2",
@@ -21768,6 +21421,7 @@
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.4",
 				"regexp.prototype.flags": "^1.4.3",
+				"safe-regex-test": "^1.0.0",
 				"string.prototype.trimend": "^1.0.5",
 				"string.prototype.trimstart": "^1.0.5",
 				"unbox-primitive": "^1.0.2"
@@ -21976,16 +21630,6 @@
 					"dev": true,
 					"peer": true
 				},
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
 				"escape-string-regexp": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -22040,9 +21684,9 @@
 					}
 				},
 				"globals": {
-					"version": "13.17.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-					"integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+					"version": "13.18.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+					"integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
 					"dev": true,
 					"peer": true,
 					"requires": {
@@ -22076,13 +21720,6 @@
 						"p-locate": "^5.0.0"
 					}
 				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true,
-					"peer": true
-				},
 				"p-limit": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -22112,6 +21749,13 @@
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
+				},
+				"type-fest": {
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+					"dev": true,
+					"peer": true
 				},
 				"yocto-queue": {
 					"version": "0.1.0",
@@ -22150,13 +21794,6 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
-				},
-				"ms": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-					"dev": true,
-					"peer": true
 				}
 			}
 		},
@@ -22175,15 +21812,6 @@
 				"synckit": "^0.8.4"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
 				"globby": {
 					"version": "13.1.2",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
@@ -22196,12 +21824,6 @@
 						"merge2": "^1.4.1",
 						"slash": "^4.0.0"
 					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
 				},
 				"slash": {
 					"version": "4.0.0",
@@ -22230,13 +21852,6 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
-				},
-				"ms": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-					"dev": true,
-					"peer": true
 				}
 			}
 		},
@@ -22292,6 +21907,16 @@
 				"tsconfig-paths": "^3.14.1"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
 				"doctrine": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -22301,17 +21926,24 @@
 					"requires": {
 						"esutils": "^2.0.2"
 					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"dev": true,
+					"peer": true
 				}
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "39.6.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.2.tgz",
-			"integrity": "sha512-dvgY/W7eUFoAIIiaWHERIMI61ZWqcz9YFjEeyTzdPlrZc3TY/3aZm5aB91NUoTLWYZmO/vFlYSuQi15tF7uE5A==",
+			"version": "39.6.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.4.tgz",
+			"integrity": "sha512-fskvdLCfwmPjHb6e+xNGDtGgbF8X7cDwMtVLAP2WwSf9Htrx68OAx31BESBM1FAwsN2HTQyYQq7m4aW4Q4Nlag==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@es-joy/jsdoccomment": "~0.36.0",
+				"@es-joy/jsdoccomment": "~0.36.1",
 				"comment-parser": "1.3.1",
 				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
@@ -22320,27 +21952,10 @@
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
 				"escape-string-regexp": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-					"dev": true,
-					"peer": true
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true,
 					"peer": true
 				},
@@ -22394,9 +22009,9 @@
 			"requires": {}
 		},
 		"eslint-plugin-vue": {
-			"version": "9.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.7.0.tgz",
-			"integrity": "sha512-DrOO3WZCZEwcLsnd3ohFwqCoipGRSTKTBTnLwdhqAbYZtzWl0o7D+D8ZhlmiZvABKTEl8AFsqH1GHGdybyoQmw==",
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.8.0.tgz",
+			"integrity": "sha512-E/AXwcTzunyzM83C2QqDHxepMzvI2y6x+mmeYHbVDQlKFqmKYvRrhaVixEeeG27uI44p9oKDFiyCRw4XxgtfHA==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -22457,9 +22072,9 @@
 			"peer": true
 		},
 		"espree": {
-			"version": "9.4.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-			"integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -22661,6 +22276,23 @@
 					"dev": true,
 					"peer": true
 				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"dev": true,
+					"peer": true
+				},
 				"safe-buffer": {
 					"version": "5.2.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -22771,6 +22403,25 @@
 				"parseurl": "~1.3.3",
 				"statuses": "2.0.1",
 				"unpipe": "~1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"dev": true,
+					"peer": true
+				}
 			}
 		},
 		"find-cache-dir": {
@@ -23356,23 +23007,6 @@
 				"@tootallnate/once": "1",
 				"agent-base": "6",
 				"debug": "4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.3",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"http-proxy-middleware": {
@@ -23404,23 +23038,6 @@
 			"requires": {
 				"agent-base": "6",
 				"debug": "4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.3",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"human-signals": {
@@ -23610,9 +23227,9 @@
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-callable": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.6.tgz",
-			"integrity": "sha512-krO72EO2NptOGAX2KYyqbP9vYMlNAXdB53rq6f8LXY6RY7JdSR/3BD6wLUlPHSAesmY9vstNrjvqGaCiRK/91Q==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
 			"dev": true,
 			"peer": true
 		},
@@ -23900,23 +23517,6 @@
 				"debug": "^4.1.1",
 				"istanbul-lib-coverage": "^3.0.0",
 				"source-map": "^0.6.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.3",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"istanbul-reports": {
@@ -25213,9 +24813,9 @@
 			}
 		},
 		"js-sdsl": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-			"integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
+			"integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
 			"dev": true,
 			"peer": true
 		},
@@ -25368,9 +24968,9 @@
 			"dev": true
 		},
 		"linkifyjs": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.0.1.tgz",
-			"integrity": "sha512-33dNbzpMEPXqei6i13+DXubONuBdiBLKRGMtYAin44CajYTgg25XunP8Vyua1TAuXhVQ1nocDl0D/qDWfY+GuQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.0.2.tgz",
+			"integrity": "sha512-/VSoCZiglX0VMsXmL5PN3lRg45M86lrD9PskdkA2abWaTKap1bIcJ11LS4EE55bcUl9ZOR4eZ792UtQ9E/5xLA==",
 			"peer": true
 		},
 		"loader-runner": {
@@ -25528,9 +25128,9 @@
 			"peer": true
 		},
 		"memfs": {
-			"version": "3.4.10",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.10.tgz",
-			"integrity": "sha512-0bCUP+L79P4am30yP1msPzApwuMQG23TjwlwdHeEV5MxioDR1a0AgB0T9FfggU52eJuDCq8WVwb5ekznFyWiTQ==",
+			"version": "3.4.12",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.12.tgz",
+			"integrity": "sha512-BcjuQn6vfqP+k100e0E9m61Hyqa//Brp+I3f0OBmN0ATHlFA8vx3Lt8z57R3u2bPqe3WGDBC+nF72fTH7isyEw==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -25684,9 +25284,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
 			"dev": true,
 			"peer": true
 		},
@@ -25720,11 +25320,10 @@
 			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
 		},
 		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true,
-			"peer": true
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"multicast-dns": {
 			"version": "7.2.5",
@@ -25782,9 +25381,9 @@
 			"dev": true
 		},
 		"node-polyfill-webpack-plugin": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/node-polyfill-webpack-plugin/-/node-polyfill-webpack-plugin-2.0.1.tgz",
-			"integrity": "sha512-ZUMiCnZkP1LF0Th2caY6J/eKKoA0TefpoVa68m/LQU1I/mE8rGt4fNYGgNuCcK+aG8P8P43nbeJ2RqJMOL/Y1A==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/node-polyfill-webpack-plugin/-/node-polyfill-webpack-plugin-2.0.0.tgz",
+			"integrity": "sha512-jrMdoL1KmeTUiqLJb19nOgIFjqbX0ClJg97o0kmigy/d5dyoum0+bqPCaRpaX5mccJES6hwuQTXyCdKQ1p2Y3Q==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -25813,15 +25412,6 @@
 				"url": "^0.11.0",
 				"util": "^0.12.4",
 				"vm-browserify": "^1.1.2"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "2.19.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-					"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-					"dev": true,
-					"peer": true
-				}
 			}
 		},
 		"node-releases": {
@@ -25903,6 +25493,7 @@
 		},
 		"object-keys": {
 			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
 			"dev": true,
 			"peer": true
@@ -25921,15 +25512,15 @@
 			}
 		},
 		"object.values": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-			"integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+			"integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
 			"dev": true,
 			"peer": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.1"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4"
 			}
 		},
 		"obuf": {
@@ -26249,9 +25840,9 @@
 					"peer": true
 				},
 				"postcss": {
-					"version": "8.4.16",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-					"integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+					"version": "8.4.19",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+					"integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
 					"dev": true,
 					"peer": true,
 					"requires": {
@@ -26824,6 +26415,18 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
 		},
+		"safe-regex-test": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"is-regex": "^1.1.4"
+			}
+		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -26921,6 +26524,25 @@
 				"statuses": "2.0.1"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"ms": "2.0.0"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+							"dev": true,
+							"peer": true
+						}
+					}
+				},
 				"ms": {
 					"version": "2.1.3",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -26956,6 +26578,16 @@
 				"parseurl": "~1.3.2"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
 				"depd": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -26980,6 +26612,13 @@
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 					"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+					"dev": true,
+					"peer": true
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 					"dev": true,
 					"peer": true
 				},
@@ -27212,25 +26851,6 @@
 				"http-deceiver": "^1.2.7",
 				"select-hose": "^2.0.0",
 				"spdy-transport": "^3.0.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true,
-					"peer": true
-				}
 			}
 		},
 		"spdy-transport": {
@@ -27248,23 +26868,6 @@
 				"wbuf": "^1.7.3"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true,
-					"peer": true
-				},
 				"readable-stream": {
 					"version": "3.6.0",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -27424,27 +27027,27 @@
 			}
 		},
 		"string.prototype.trimend": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-			"integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+			"integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
-				"es-abstract": "^1.19.5"
+				"es-abstract": "^1.20.4"
 			}
 		},
 		"string.prototype.trimstart": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-			"integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+			"integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
 			"dev": true,
 			"peer": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.4",
-				"es-abstract": "^1.19.5"
+				"es-abstract": "^1.20.4"
 			}
 		},
 		"strip-ansi": {
@@ -27561,25 +27164,10 @@
 					"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
 					"dev": true
 				},
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
 				"is-plain-object": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
 					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-					"dev": true
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				},
 				"postcss": {
@@ -27645,9 +27233,9 @@
 			},
 			"dependencies": {
 				"postcss": {
-					"version": "8.4.16",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-					"integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+					"version": "8.4.19",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+					"integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
 					"dev": true,
 					"peer": true,
 					"requires": {
@@ -27678,9 +27266,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 					"dev": true,
 					"peer": true,
 					"requires": {
@@ -27827,9 +27415,9 @@
 			}
 		},
 		"terser": {
-			"version": "5.15.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-			"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+			"version": "5.16.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.0.tgz",
+			"integrity": "sha512-KjTV81QKStSfwbNiwlBXfcgMcOloyuRdb62/iLFPGBcVNF4EXjhdYBhYHmbJpiBrVxZhDvltE11j+LBQUxEEJg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -27840,9 +27428,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "8.8.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-					"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+					"version": "8.8.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+					"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
 					"dev": true,
 					"peer": true
 				}
@@ -28147,9 +27735,9 @@
 			"dev": true
 		},
 		"type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
 			"dev": true,
 			"peer": true
 		},
@@ -28357,13 +27945,9 @@
 			"peer": true
 		},
 		"vue": {
-			"version": "2.7.14",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
-			"integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
-			"requires": {
-				"@vue/compiler-sfc": "2.7.14",
-				"csstype": "^3.1.0"
-			}
+			"version": "2.6.14",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
+			"integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
 		},
 		"vue-click-outside": {
 			"version": "1.1.0",
@@ -28380,9 +27964,9 @@
 			}
 		},
 		"vue-demi": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-			"integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+			"version": "0.12.5",
+			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.12.5.tgz",
+			"integrity": "sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q==",
 			"requires": {}
 		},
 		"vue-eslint-parser": {
@@ -28401,16 +27985,6 @@
 				"semver": "^7.3.6"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
 				"eslint-scope": {
 					"version": "7.1.1",
 					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
@@ -28436,13 +28010,6 @@
 					"dev": true,
 					"peer": true
 				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true,
-					"peer": true
-				},
 				"semver": {
 					"version": "7.3.8",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -28463,9 +28030,9 @@
 			"peer": true
 		},
 		"vue-loader": {
-			"version": "15.10.0",
-			"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.0.tgz",
-			"integrity": "sha512-VU6tuO8eKajrFeBzMssFUP9SvakEeeSi1BxdTH5o3+1yUyrldp8IERkSdXlMI2t4kxF2sqYUDsQY+WJBxzBmZg==",
+			"version": "15.10.1",
+			"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.1.tgz",
+			"integrity": "sha512-SaPHK1A01VrNthlix6h1hq4uJu7S/z0kdLUb6klubo738NeQoLbS6V9/d8Pv19tU0XdQKju3D1HSKuI8wJ5wMA==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -28501,14 +28068,14 @@
 			}
 		},
 		"vue-masonry": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/vue-masonry/-/vue-masonry-0.16.0.tgz",
-			"integrity": "sha512-0Wi/BH4iYYRrAAFY/wokczz0lWWPg1vmOvFW4aC2nKybKf6kVqUvFfR9/+izDfzG657/vY+Om0gqOB5YPxPxuQ==",
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/vue-masonry/-/vue-masonry-0.14.1.tgz",
+			"integrity": "sha512-FFihoFv0du7dQIEIRYd+3kpHQb3apdQLw0PAJvgH6uBpr4xJ0z9g4EY4O3gBECq6gn2DSVSbPqSquZOqYVZIVw==",
 			"requires": {
 				"imagesloaded": "4.1.4",
 				"masonry-layout": "^4.2.2",
 				"mitt": "^3.0.0",
-				"vue-demi": "^0.13.2"
+				"vue-demi": "^0.12.1"
 			}
 		},
 		"vue-material-design-icons": {
@@ -28570,13 +28137,13 @@
 			}
 		},
 		"vue-template-compiler": {
-			"version": "2.7.14",
-			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
-			"integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
+			"version": "2.6.14",
+			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz",
+			"integrity": "sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==",
 			"dev": true,
 			"requires": {
 				"de-indent": "^1.0.2",
-				"he": "^1.2.0"
+				"he": "^1.1.0"
 			}
 		},
 		"vue-template-es2015-compiler": {
@@ -28665,9 +28232,9 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "5.74.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-			"integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+			"version": "5.75.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
+			"integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -28698,9 +28265,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "8.8.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-					"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+					"version": "8.8.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+					"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
 					"dev": true,
 					"peer": true
 				},
@@ -28771,9 +28338,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.11.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-					"integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+					"version": "8.11.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+					"integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
 					"dev": true,
 					"peer": true,
 					"requires": {
@@ -28854,9 +28421,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.11.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-					"integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+					"version": "8.11.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+					"integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
 					"dev": true,
 					"peer": true,
 					"requires": {

--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
 		"qr-image": "^3.2.0",
 		"string-natural-compare": "^3.0.1",
 		"uuid": "^9.0.0",
-		"vue": "^2.7.14",
+		"vue": "~2.6.14",
 		"vue-click-outside": "^1.1.0",
-		"vue-masonry": "^0.16.0",
+		"vue-masonry": "^0.14.0",
 		"vue-material-design-icons": "^5.1.2",
 		"vue-router": "^3.6.5",
 		"vue-virtual-scroll-list": "^2.3.4",
@@ -86,7 +86,7 @@
 		"@nextcloud/eslint-config": "^8.1.4",
 		"@nextcloud/stylelint-config": "^2.3.0",
 		"@nextcloud/typings": "^1.5.0",
-		"@nextcloud/webpack-vue-config": "~5.4.0",
+		"@nextcloud/webpack-vue-config": "^5.2.0",
 		"@types/jest": "^27.4.1",
 		"@typescript-eslint/parser": "^5.44.0",
 		"@vue/composition-api": "^1.7.1",
@@ -99,7 +99,7 @@
 		"ts-jest": "^27.1.4",
 		"ts-loader": "^9.4.1",
 		"typescript": "^4.8.4",
-		"vue-template-compiler": "^2.7.14"
+		"vue-template-compiler": "~2.6"
 	},
 	"browserslist": [
 		"extends @nextcloud/browserslist-config"


### PR DESCRIPTION
This reverts commit f07b9c238bf31bd450d2af4a933e2becd7079965 and downgrades a few related packages.

We had to downgrade before: https://github.com/nextcloud/contacts/pull/2928.

Until the virtual scroller workds with 2.7 we can not update Vue nor the template compiler.

## How to test
1) Open the app
2) Add a contact if you have none
3) Look at the contacts list

Main: no contacts rendered
Here: contacts rendered