### PR TITLE
Fix link to user documentation

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@
 	</types>
 
 	<documentation>
-		<user>https://docs.nextcloud.com/server/stable/user_manual/en/groupware/contacts.html</user>
+		<user>https://docs.nextcloud.com/server/latest/user_manual/en/groupware/contacts.html</user>
 		<admin>https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/occ_command.html?highlight=occ%20commands#dav-label</admin>
 		<developer>https://github.com/nextcloud/contacts#build-the-app</developer>
 	</documentation>


### PR DESCRIPTION
Link with stable in URL is leading to "File not found." In case of server docs, it is redirected from stable to latest anyway (so what about to change server docs url too?).


Signed-off-by: p-bo <pavel.borecki@gmail.com>