### PR TITLE
allow social avatars from telegram, fixes #2393

### DIFF
--- a/lib/Service/Social/CompositeSocialProvider.php
+++ b/lib/Service/Social/CompositeSocialProvider.php
@@ -38,6 +38,7 @@ class CompositeSocialProvider {
 								TumblrProvider $tumblrProvider,
 								DiasporaProvider $diasporaProvider,
 								XingProvider $xingProvider,
+								TelegramProvider $telegramProvider,
 								GravatarProvider $gravatarProvider) {
 
 		// This determines the priority of known providers
@@ -49,6 +50,7 @@ class CompositeSocialProvider {
 			$tumblrProvider->name => $tumblrProvider,
 			$diasporaProvider->name => $diasporaProvider,
 			$xingProvider->name => $xingProvider,
+			$telegramProvider->name => $telegramProvider,
 			$gravatarProvider->name => $gravatarProvider
 		];
 	}

--- a/lib/Service/Social/TelegramProvider.php
+++ b/lib/Service/Social/TelegramProvider.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023 Matthias Heinisch <nextcloud@matthiasheinisch.de>
+ *
+ * @author Matthias Heinisch <nextcloud@matthiasheinisch.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Contacts\Service\Social;
+
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\RequestOptions;
+use OC\AppFramework\Http\Request;
+use OCA\Contacts\AppInfo\Application;
+use OCP\Http\Client\IClientService;
+use Psr\Log\LoggerInterface;
+
+class TelegramProvider implements ISocialProvider {
+	/** @var IClientService */
+	private $httpClient;
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	/** @var string */
+	public $name = 'telegram';
+
+	public function __construct(IClientService $httpClient,
+								LoggerInterface $logger) {
+		$this->httpClient = $httpClient->NewClient();
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Returns if this provider supports this contact
+	 *
+	 * @param {array} contact info
+	 *
+	 * @return bool
+	 */
+	public function supportsContact(array $contact):bool {
+		if (!array_key_exists('IMPP', $contact)) {
+			return false;
+		}
+		$socialprofiles = $this->getProfileIds($contact);
+		return isset($socialprofiles) && count($socialprofiles) > 0;
+	}
+
+	/**
+	 * Returns the profile-picture url
+	 *
+	 * @param {array} contact information
+	 *
+	 * @return array
+	 */
+	public function getImageUrls(array $contact):array {
+		$profileIds = $this->getProfileIds($contact);
+		$urls = [];
+		foreach ($profileIds as $profileId) {
+			$recipe = 'https://t.me/{socialId}';
+			$connector = str_replace('{socialId}', $profileId, $recipe);
+			$connector = $this->getFromHtml($connector, 'tgme_page_photo_image');
+			$urls[] = $connector;
+		}
+		return $urls;
+	}
+
+	/**
+	 * Returns the profile-id
+	 *
+	 * @param {string} the value from the contact's x-socialprofile
+	 *
+	 * @return string
+	 */
+	protected function cleanupId(string $candidate):string {
+		$candidate = basename($candidate, ".t.me");
+		if ($candidate[0] === '@') {
+			$candidate = substr($candidate, 1);
+		}
+		return $candidate;
+	}
+
+	/**
+	 * Returns all possible profile ids for contact
+	 *
+	 * @param {array} contact information
+	 *
+	 * @return array of string profile ids
+	 */
+	protected function getProfileIds($contact):array {
+		$socialprofiles = $contact['IMPP'];
+		$profileIds = [];
+		if (isset($socialprofiles)) {
+			foreach ($socialprofiles as $profile) {
+				if (strtolower($profile['type']) == $this->name) {
+					$profileIds[] = $this->cleanupId($profile['value']);
+				}
+			}
+		}
+		return $profileIds;
+	}
+
+	/**
+	 * extracts desired value from an html page
+	 *
+	 * @param {string} url the target from where to fetch the content
+	 * @param {String} the desired catchword to filter for
+	 *
+	 * @returns {String} the extracted value (first match) or null if not present
+	 */
+	protected function getFromHtml(string $url, string $desired) : ?string {
+		try {
+			$result = $this->httpClient->get($url, [
+				RequestOptions::HEADERS => [
+					// Make the request as google bot so twitter display the full static html page
+					'User-Agent' => 'Googlebot/2.1'
+				]
+			]);
+
+			$htmlResult = new \DOMDocument();
+			$htmlResult->loadHTML($result->getBody());
+			$imgs = $htmlResult->getElementsByTagName('img');
+			foreach ($imgs as $img) {
+				foreach ($img->attributes as $attr) {
+					$value = $attr->nodeValue;
+					if (strcmp($value, $desired)) {
+						return $value;
+					}
+				}
+			}
+			return null;
+		} catch (RequestException $e) {
+			$this->logger->debug('Error fetching telegram urls', [
+				'app' => Application::APP_ID,
+				'exception' => $e
+			]);
+			return null;
+		}
+	}
+}

--- a/src/components/ContactDetails/ContactDetailsAvatar.vue
+++ b/src/components/ContactDetails/ContactDetailsAvatar.vue
@@ -154,8 +154,11 @@ export default {
 		supportedSocial() {
 			const emails = this.contact.vCard.getAllProperties('email')
 			// get social networks set for the current contact
-			const available = this.contact.vCard.getAllProperties('x-socialprofile')
+			const availableSocial = this.contact.vCard.getAllProperties('x-socialprofile')
 				.map(a => a.jCal[1].type.toString().toLowerCase())
+			const availableMessenger = this.contact.vCard.getAllProperties('impp')
+				.map(a => a.jCal[1].type.toString().toLowerCase())
+			const available = [].concat(availableSocial, availableMessenger)
 			// get list of social networks that allow for avatar download
 			const supported = supportedNetworks.map(v => v.toLowerCase())
 			if (emails.length) {

--- a/tests/unit/Service/Social/TelegramProviderTest.php
+++ b/tests/unit/Service/Social/TelegramProviderTest.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023 Matthias Heinisch <nextcloud@matthiasheinisch.de>
+ *
+ * @author Matthias Heinisch <nextcloud@matthiasheinisch.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Contacts\Service\Social;
+
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IResponse;
+use OCP\Http\Client\IClientService;
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+class TelegramProviderTest extends TestCase {
+	private $provider;
+
+	/** @var IClientService|MockObject */
+	private $clientService;
+
+	/** @var LoggerInterface|MockObject */
+	private $logger;
+
+	/** @var IClient|MockObject */
+	private $client;
+
+	/** @var IResponse|MockObject */
+	private $response;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->clientService = $this->createMock(IClientService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->response = $this->createMock(IResponse::class);
+		$this->client = $this->createMock(IClient::class);
+
+		$this->clientService
+			->method('NewClient')
+			->willReturn($this->client);
+
+		$this->provider = new TelegramProvider(
+			$this->clientService,
+			$this->logger
+		);
+	}
+
+	public function dataProviderSupportsContact() {
+		$contactWithSocial = [
+			'IMPP' => [
+				['value' => 'username1', 'type' => 'telegram'],
+				['value' => '@username2', 'type' => 'telegram']
+			]
+		];
+
+		$contactWithoutSocial = [
+			'IMPP' => [
+				['value' => 'one', 'type' => 'social2'],
+				['value' => 'two', 'type' => 'social1']
+			]
+		];
+
+		return [
+			'contact with telegram fields' => [$contactWithSocial, true],
+			'contact without telegram fields' => [$contactWithoutSocial, false]
+		];
+	}
+
+	/**
+	 * @dataProvider dataProviderSupportsContact
+	 */
+	public function testSupportsContact($contact, $expected) {
+		$result = $this->provider->supportsContact($contact);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function dataProviderGetImageUrls() {
+		$contactWithSocial = [
+			'IMPP' => [
+				['value' => 'username1', 'type' => 'telegram'],
+				['value' => '@username2', 'type' => 'telegram'],
+				['value' => 'https://t.me/username3', 'type' => 'telegram'],
+				['value' => 'https://t.me/@username4', 'type' => 'telegram'],
+				['value' => 'https://username5.t.me/', 'type' => 'telegram'],
+				['value' => 'https://telegram.dog/username6', 'type' => 'telegram']
+			]
+		];
+		$contactWithSocialUrls = [
+			'https://t.me/username1',
+			'https://t.me/username2',
+			'https://t.me/username3',
+			'https://t.me/username4',
+			'https://t.me/username5',
+			'https://t.me/username6',
+		];
+		$contactWithSocialHtml = [
+			'<html><img class="tgme_page_photo_image" src="https://cdn4.telegram-cdn.org/file/username1.jpg"></html>',
+			'<html><img class="tgme_page_photo_image" src="https://cdn4.telegram-cdn.org/file/username2.jpg"></html>',
+			'<html><img class="tgme_page_photo_image" src="https://cdn4.telegram-cdn.org/file/username3.jpg"></html>',
+			'<html><img class="tgme_page_photo_image" src="https://cdn4.telegram-cdn.org/file/username4.jpg"></html>',
+			'<html><img class="tgme_page_photo_image" src="https://cdn4.telegram-cdn.org/file/username5.jpg"></html>',
+			'<html><img class="tgme_page_photo_image" src="https://cdn4.telegram-cdn.org/file/username6.jpg"></html>'
+		];
+		$contactWithSocialImgs = [
+			'https://cdn4.telegram-cdn.org/file/username1.jpg',
+			'https://cdn4.telegram-cdn.org/file/username2.jpg',
+			'https://cdn4.telegram-cdn.org/file/username3.jpg',
+			'https://cdn4.telegram-cdn.org/file/username4.jpg',
+			'https://cdn4.telegram-cdn.org/file/username5.jpg',
+			'https://cdn4.telegram-cdn.org/file/username6.jpg'
+		];
+
+		$contactWithoutSocial = [
+			'IMPP' => [
+				['value' => 'one', 'type' => 'social2'],
+				['value' => 'two', 'type' => 'social1']
+			]
+		];
+		$contactWithoutSocialUrls = [];
+		$contactWithoutSocialHtml = [];
+		$contactWithoutSocialImgs = [];
+
+		return [
+			'contact with twitter fields' => [
+				$contactWithSocial,
+				$contactWithSocialHtml,
+				$contactWithSocialUrls,
+				$contactWithSocialImgs
+			],
+			'contact without twitter fields' => [
+				$contactWithoutSocial,
+				$contactWithoutSocialHtml,
+				$contactWithoutSocialUrls,
+				$contactWithoutSocialImgs
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider dataProviderGetImageUrls
+	 */
+	public function testGetImageUrls($contact, $htmls, $urls, $imgs) {
+		if (count($urls)) {
+			$this->response->method('getBody')->willReturnOnConsecutiveCalls(...$htmls);
+			$this->client
+		   ->expects($this->exactly(count($urls)))
+		   ->method('get')
+		   ->withConsecutive(...array_map(function ($a) {
+		   	return [$a];
+		   }, $urls))
+		   ->willReturn($this->response);
+		}
+
+
+		$result = $this->provider->getImageUrls($contact);
+		$this->assertEquals($imgs, $result);
+	}
+}


### PR DESCRIPTION
Fix #2393

This PR allows to fetch avatar pictures from telegram messenger profiles.

Q: maybe there is a smarter way to fetch ical, looking for something like:
`this.contact.vCard.getAllProperties(['x-socialprofile', 'impp'])` instead of getting each one and then concatenating them.