### PR TITLE
[stable5.0] chore(deps): bump @mattkrick/sanitize-svg from 0.3.1 to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "5.0.2",
 			"license": "agpl",
 			"dependencies": {
-				"@mattkrick/sanitize-svg": "^0.3.1",
+				"@mattkrick/sanitize-svg": "^0.4.0",
 				"@nextcloud/auth": "^2.0.0",
 				"@nextcloud/axios": "^2.0.0",
 				"@nextcloud/capabilities": "^1.0.4",
@@ -2663,8 +2663,9 @@
 			"peer": true
 		},
 		"node_modules/@mattkrick/sanitize-svg": {
-			"version": "0.3.1",
-			"integrity": "sha512-wbIv43EBkzMlYcfv2+SrLVfgpzEp8axjOFD1TGOwHuS1I60GQplzx8fduWWHGNpgt/1QlrI95vNXFRSZM2oWtA==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@mattkrick/sanitize-svg/-/sanitize-svg-0.4.0.tgz",
+			"integrity": "sha512-TnPI97WVAxo8SQcPy8aV3OF9/2WjXB5/+pRNVudIWR7Bhi5ZjtR/ur162So08GkvsvB914AXCW2sxFh1x6KhHA==",
 			"engines": {
 				"node": ">=6.0.0"
 			},
@@ -18239,8 +18240,9 @@
 			"peer": true
 		},
 		"@mattkrick/sanitize-svg": {
-			"version": "0.3.1",
-			"integrity": "sha512-wbIv43EBkzMlYcfv2+SrLVfgpzEp8axjOFD1TGOwHuS1I60GQplzx8fduWWHGNpgt/1QlrI95vNXFRSZM2oWtA==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@mattkrick/sanitize-svg/-/sanitize-svg-0.4.0.tgz",
+			"integrity": "sha512-TnPI97WVAxo8SQcPy8aV3OF9/2WjXB5/+pRNVudIWR7Bhi5ZjtR/ur162So08GkvsvB914AXCW2sxFh1x6KhHA==",
 			"requires": {}
 		},
 		"@nextcloud/auth": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"test:coverage": "jest --coverage"
 	},
 	"dependencies": {
-		"@mattkrick/sanitize-svg": "^0.3.1",
+		"@mattkrick/sanitize-svg": "^0.4.0",
 		"@nextcloud/auth": "^2.0.0",
 		"@nextcloud/axios": "^2.0.0",
 		"@nextcloud/capabilities": "^1.0.4",


### PR DESCRIPTION
Backport of #3138