### PR TITLE
v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 5.1.0 - 2023-02-02
+### Added
+- Support for Nextcloud 26
+- Support for PHP 8.2
+- Allow social avatars from telegram
+- Move app settings to a modal
+### Removed
+- Support for PHP 7.3 (EOL)
+- Support for PHP 7.4 (EOL)
+### Changed
+- Use composer's authoritative classmap
+- Rephrase "There is no member in this circle"
+- Rename 'Groups' to 'Contact groups'
+- Changed grammar of email address field label
+### Fixed
+- Prioritize local users in mastodon avatar download
+- Empty content for settings dialogs
+
 ## 5.0.3 - 2023-01-24
 ### Fixed
 - Social avatar background update

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 * 🙈 **We’re not reinventing the wheel!** Based on the great and open SabreDAV library.
 	</description>
 
-	<version>5.1.0-alpha.1</version>
+	<version>5.1.0</version>
 	<licence>agpl</licence>
 
 	<author>Christoph Wurst</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "contacts",
-	"version": "5.1.0-alpha1",
+	"version": "5.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "contacts",
-			"version": "5.1.0-alpha1",
+			"version": "5.1.0",
 			"license": "agpl",
 			"dependencies": {
 				"@mattkrick/sanitize-svg": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "contacts",
 	"description": "A contacts app for Nextcloud. Easily sync contacts from various devices, share and edit them online.",
-	"version": "5.1.0-alpha1",
+	"version": "5.1.0",
 	"author": "John Molakvoæ <skjnldsv@protonmail.com>",
 	"contributors": [
 		"John Molakvoæ <skjnldsv@protonmail.com>",


### PR DESCRIPTION
# Changelog
## 5.1.0 - 2023-02-02
### Added
- Support for Nextcloud 26
- Support for PHP 8.2
- Allow social avatars from telegram
- Move app settings to a modal
### Removed
- Support for PHP 7.3 (EOL)
- Support for PHP 7.4 (EOL)
### Changed
- Use composer's authoritative classmap
- Rephrase "There is no member in this circle"
- Rename 'Groups' to 'Contact groups'
- Changed grammar of email address field label
### Fixed
- Prioritize local users in mastodon avatar download
- Empty content for settings dialogs