### PR TITLE
fix error when contact has no email

### DIFF
--- a/src/components/AppNavigation/GroupNavigationItem.vue
+++ b/src/components/AppNavigation/GroupNavigationItem.vue
@@ -153,11 +153,7 @@ export default {
 		 */
 		emailGroup(group) {
 			const emails = []
-			group.contacts.forEach(key => {
-        // break if contact has no email
-				if (this.contacts[key].email == null) { 
-					return
-				}
+			group.contacts.filter(key => this.contacts[key].email !== null).forEach(key => {
 				// The email property could contain "John Doe <john.doe@example.com>", but vcard spec only
 				// allows addr-spec, not name-addr, so to stay compliant, replace everything outside of <>
 				const email = this.contacts[key].email.replace(/(.*<)([^>]*)(>)/g, '$2').trim()

--- a/src/components/AppNavigation/GroupNavigationItem.vue
+++ b/src/components/AppNavigation/GroupNavigationItem.vue
@@ -154,6 +154,10 @@ export default {
 		emailGroup(group) {
 			const emails = []
 			group.contacts.forEach(key => {
+        // break if contact has no email
+				if (this.contacts[key].email == null) { 
+					return
+				}
 				// The email property could contain "John Doe <john.doe@example.com>", but vcard spec only
 				// allows addr-spec, not name-addr, so to stay compliant, replace everything outside of <>
 				const email = this.contacts[key].email.replace(/(.*<)([^>]*)(>)/g, '$2').trim()


### PR DESCRIPTION
If you delete the email in a contact and then try to send an email to a group with that contact you get an error:

```TypeError: t.contacts[e].email is null```

here I add a check if the contact has an email.