### PR TITLE
fixed - Change New contact to Name

### DIFF
--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -286,7 +286,7 @@ export default {
 			`.trim().replace(/\t/gm, ''),
 			this.defaultAddressbook)
 
-			contact.fullName = t('contacts', 'New contact')
+			contact.fullName = t('contacts', 'Name')
 			rev.fromUnixTime(Date.now() / 1000)
 			contact.rev = rev
 


### PR DESCRIPTION
Issue Desription:

Describe the bug
When you click new contact, the default name for it its new contact. Should be name instead

Steps to reproduce
Create a new contact
Look at the detailed view

Expected behavior
The name is name and not new contact

Actual behavior
The field is called new contact

Fixes #3319 