### PR TITLE
feat(contacts): adjust header to single column layout

### DIFF
--- a/css/ContactDetailsLayout.scss
+++ b/css/ContactDetailsLayout.scss
@@ -1,0 +1,31 @@
+/**
+ * @copyright Copyright (c) 2023 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+$contact-details-label-min-width: 100px;
+$contact-details-label-max-width: 200px;
+$contact-details-label-width: calc(($contact-details-label-min-width + $contact-details-label-max-width) / 2);
+
+$contact-details-value-min-width: 200px;
+$contact-details-value-max-width: 300px;
+$contact-details-value-width: calc(($contact-details-value-min-width + $contact-details-value-max-width) / 2);
+
+$contact-details-row-gap: 15px;

--- a/css/Properties/Properties.scss
+++ b/css/Properties/Properties.scss
@@ -21,16 +21,18 @@
  *
  */
 
-$property-label-min-width: 100px;
-$property-label-max-width: 200px;
-$property-label-width: calc(($property-label-min-width + $property-label-max-width) / 2);
+@import '../ContactDetailsLayout.scss';
 
-$property-value-min-width: 200px;
-$property-value-max-width: 300px;
-$property-value-width: calc(($property-value-min-width + $property-value-max-width) / 2);
+$property-label-min-width: $contact-details-label-min-width;
+$property-label-max-width: $contact-details-label-max-width;
+$property-label-width: $contact-details-label-width;
+
+$property-value-min-width: $contact-details-value-min-width;
+$property-value-max-width: $contact-details-value-max-width;
+$property-value-width: $contact-details-value-width;
 
 $property-ext-padding-right: 8px;
-$property-row-gap: 15px;
+$property-row-gap: $contact-details-row-gap;
 
 .property {
 	width: 100%;

--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -41,42 +41,45 @@
 					@update-local-contact="updateLocalContact" />
 
 				<!-- fullname -->
-				<input id="contact-fullname"
-					slot="title"
-					ref="fullname"
-					v-model="contact.fullName"
-					:readonly="contact.addressbook.readOnly"
-					:placeholder="t('contacts', 'Name')"
-					type="text"
-					autocomplete="off"
-					autocorrect="off"
-					spellcheck="false"
-					name="fullname"
-					@input="debounceUpdateContact"
-					@click="selectInput">
+				<template #title>
+					<div v-if="isReadOnly">{{ contact.fullName }}</div>
+					<input v-else
+						id="contact-fullname"
+						ref="fullname"
+						v-model="contact.fullName"
+						:placeholder="t('contacts', 'Name')"
+						type="text"
+						autocomplete="off"
+						autocorrect="off"
+						spellcheck="false"
+						name="fullname"
+						@input="debounceUpdateContact"
+						@click="selectInput">
+				</template>
 
 				<!-- org, title -->
 				<template #subtitle>
-					<input id="contact-org"
-						v-model="contact.org"
-						:readonly="contact.addressbook.readOnly"
-						:placeholder="t('contacts', 'Company')"
-						type="text"
-						autocomplete="off"
-						autocorrect="off"
-						spellcheck="false"
-						name="org"
-						@input="debounceUpdateContact">
-					<input id="contact-title"
-						v-model="contact.title"
-						:readonly="contact.addressbook.readOnly"
-						:placeholder="t('contacts', 'Title')"
-						type="text"
-						autocomplete="off"
-						autocorrect="off"
-						spellcheck="false"
-						name="title"
-						@input="debounceUpdateContact">
+					<template v-if="isReadOnly">{{ formattedSubtitle }}</template>
+					<template v-else>
+						<input id="contact-title"
+							v-model="contact.title"
+							:placeholder="t('contacts', 'Title')"
+							type="text"
+							autocomplete="off"
+							autocorrect="off"
+							spellcheck="false"
+							name="title"
+							@input="debounceUpdateContact">
+						<input id="contact-org"
+							v-model="contact.org"
+							:placeholder="t('contacts', 'Company')"
+							type="text"
+							autocomplete="off"
+							autocorrect="off"
+							spellcheck="false"
+							name="org"
+							@input="debounceUpdateContact">
+					</template>
 				</template>
 
 				<!-- actions -->
@@ -514,6 +517,29 @@ export default {
 		enableToggleBirthdayExclusion() {
 			return parseInt(OC.config.version.split('.')[0]) >= 26
 		},
+
+		/**
+		 * Read-only representation of the contact title and organization.
+		 *
+		 * @return {string}
+		 */
+		formattedSubtitle() {
+			const title = this.contact.title
+			const organization = this.contact.org
+
+			if (title && organization) {
+				return t('contacts', '{title} at {organization}', {
+					title,
+					organization,
+				})
+			} else if (title) {
+				return title
+			} else if (organization) {
+				return organization
+			}
+
+			return ''
+		}
 	},
 
 	watch: {

--- a/src/components/DetailsHeader.vue
+++ b/src/components/DetailsHeader.vue
@@ -2,6 +2,7 @@
   - @copyright Copyright (c) 2018 John Molakvoæ <skjnldsv@protonmail.com>
   -
   - @author John Molakvoæ <skjnldsv@protonmail.com>
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
   -
   - @license GNU AGPL version 3 or any later version
   -
@@ -79,26 +80,37 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '../../css/ContactDetailsLayout.scss';
+
 // Header with avatar, name, position, actions...
 .contact-header {
 	display: flex;
 	align-items: center;
 	padding: 50px 0 20px;
+	gap: $contact-details-row-gap;
 
+	// AVATAR
 	&__avatar {
-		position: relative;
-		flex: 0 0 var(--avatar-size);
-		margin: 10px;
-		margin-left: 0;
 		display: flex;
+		flex: 1 auto;
 		justify-content: flex-end;
+
+		// Global single column layout
+		width: $contact-details-label-width;
+		min-width: $contact-details-label-min-width;
+		max-width: $contact-details-label-max-width;
 	}
 
 	// ORG-TITLE-NAME
 	&__infos {
 		display: flex;
-		flex: 1 1 auto; // shrink avatar before this one
+		flex: 1 auto;
 		flex-direction: column;
+
+		// Global single column layout
+		width: $contact-details-value-width;
+		min-width: $contact-details-value-min-width;
+		max-width: $contact-details-value-max-width;
 
 		&-title,
 		&-subtitle {
@@ -106,18 +118,9 @@ export default {
 			flex-wrap: wrap;
 			margin: 0;
 		}
+
 		::v-deep input {
-			overflow: hidden;
-			flex: 1 1;
-			min-width: 100px;
-			max-width: 100%;
-			margin: 0;
-			padding: 0;
-			white-space: nowrap;
-			text-overflow: ellipsis;
-			border: none;
-			background: transparent;
-			font-size: inherit;
+			flex: 1 auto;
 		}
 
 		&-title ::v-deep input {
@@ -128,36 +131,5 @@ export default {
 			max-width: 20%;
 		}
 	}
-
-	// ACTIONS
-	&__actions {
-		position: relative;
-		display: flex;
-
-		&-menu {
-			margin-right: 10px;
-		}
-
-		> div,
-		> a {
-			width: 44px;
-			height: 44px;
-			padding: 14px;
-			cursor: pointer;
-			opacity: .7;
-			border-radius: 22px;
-			background-size: 16px;
-			&:hover,
-			&:focus {
-				opacity: 1;
-			}
-			&.header-icon--pulse {
-				width: 16px;
-				height: 16px;
-				margin: 8px;
-			}
-		}
-	}
 }
-
 </style>


### PR DESCRIPTION
Fix #3325 

Followup to #3315 

Please ignore the borders around the read only input fields below the header. This is just a **visual** regression from #3315. The inputs are read-only/disabled but are rendered with a (slightly transparent) border.

Read-only mode is tracked in #3284.

## Desktop
| read-write | read-only |
| --- | ---|
|  ![contact-details-rw-after](https://user-images.githubusercontent.com/1479486/234274168-660a1c65-6c07-4786-a29d-b710fc042c12.png) | ![contact-details-ro-after](https://user-images.githubusercontent.com/1479486/234274166-ce53f1c3-f864-41ba-83ab-1d07a22ab109.png) |

## Mobile
| read-write | read-only |
| --- | --- |
| ![contact-details-mobile-rw-after](https://user-images.githubusercontent.com/1479486/234274161-623a0a5c-77be-444d-a706-c81f3bc19c89.png) | ![contact-details-mobile-ro-after](https://user-images.githubusercontent.com/1479486/234274157-746de050-9b81-4c49-b66c-efa05396bba5.png) |