### PR TITLE
fix: disable select component if single option

### DIFF
--- a/src/components/Properties/PropertySelect.vue
+++ b/src/components/Properties/PropertySelect.vue
@@ -110,7 +110,7 @@ export default {
 
 		// is there only one option available
 		isSingleOption() {
-			return this.propModel.options.length <= 1 && this.options.length <= 1
+			return this.selectableOptions.length <= 1
 		},
 
 		// matching value to the options we provide


### PR DESCRIPTION
While fixing #3342 backports I noticed a bug:

Select should be enabled only if there is at least another writeable adressbook to select.

I'll fix this in the #3342 #3343 backport PRs as well.

|before|after|
|--|--|
|![image](https://user-images.githubusercontent.com/74607597/234846067-b06247b8-ab81-421f-8e2d-e6bd8de2cb7c.png)|![image](https://user-images.githubusercontent.com/74607597/234845614-00e66b4c-1412-4826-adf2-366de2c498b3.png)|
|![image](https://user-images.githubusercontent.com/74607597/234845934-92a809b4-9bd9-4c65-b32e-a936fea12818.png)|![image](https://user-images.githubusercontent.com/74607597/234845757-eb35b444-3d2d-4a0f-8e12-8fd775fe0c8f.png)|