### PR TITLE
fix: defer rendering contact import button

### DIFF
--- a/src/components/AppNavigation/Settings/SettingsImportContacts.vue
+++ b/src/components/AppNavigation/Settings/SettingsImportContacts.vue
@@ -82,7 +82,7 @@
 		<Button v-else
 			id="upload"
 			for="contact-import"
-			class="button import-contact__multiselect-label import-contact__multiselect--no-select">
+			class="button import-contact__button-disabled import-contact__multiselect-label import-contact__multiselect--no-select">
 			<template #icon>
 				<IconError :size="20" />
 			</template>
@@ -332,6 +332,12 @@ export default {
 		&-main {
 			width: 100% !important;
 			margin-left: 0 !important;
+		}
+		&-disabled {
+			// Wrap warning about disabled button instead of ellipsing it
+			::v-deep .button-vue__text {
+				white-space: pre-wrap;
+			}
 		}
 		&--cancel:not(:focus):not(:hover) {
 			border-color: transparent;

--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -29,7 +29,7 @@
 			:selected-group="selectedGroup"
 			:selected-contact="selectedContact">
 			<!-- new-contact-button -->
-			<SettingsImportContacts v-if="isEmptyGroup" />
+			<SettingsImportContacts v-if="!loadingContacts && isEmptyGroup" />
 			<Button v-if="!loadingContacts"
 				class="new-contact-button"
 				type="primary"


### PR DESCRIPTION
Fix #3340 

Fixes 2 things:
1. The button flashes on page load but vanishes after a short delay. ⇒ It should only be rendered when address books are loaded and there really is no address book.
2. The warning is not wrapped and overlaps the list. ⇒ It is no wrapped properly.

![grafik](https://user-images.githubusercontent.com/1479486/235109643-16653ef7-3229-498f-9279-0ff0d90c3315.png)