### PR TITLE
fix(contacts): defer birthday exclusion until contact was loaded

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -522,6 +522,7 @@ export default {
 
 		enableToggleBirthdayExclusion() {
 			return parseInt(OC.config.version.split('.')[0]) >= 26
+				&& this.localContact?.vCard // Wait until localContact was fetched
 		},
 
 		/**


### PR DESCRIPTION
Fix #3334 