### PR TITLE
Add NOTES and RELATED to search properties

### DIFF
--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -41,7 +41,7 @@ const isEmpty = value => {
 export const ContactKindProperties = ['KIND', 'X-ADDRESSBOOKSERVER-KIND']
 
 export const MinimalContactProperties = [
-	'EMAIL', 'UID', 'CATEGORIES', 'FN', 'ORG', 'N', 'X-PHONETIC-FIRST-NAME', 'X-PHONETIC-LAST-NAME', 'X-MANAGERSNAME', 'TITLE',
+	'EMAIL', 'UID', 'CATEGORIES', 'FN', 'ORG', 'N', 'X-PHONETIC-FIRST-NAME', 'X-PHONETIC-LAST-NAME', 'X-MANAGERSNAME', 'TITLE', 'NOTES', 'RELATED'
 ].concat(ContactKindProperties)
 
 export default class Contact {


### PR DESCRIPTION
before the search only searches in the following properties:

`'EMAIL', 'UID', 'CATEGORIES', 'FN', 'ORG', 'N', 'X-PHONETIC-FIRST-NAME', 'X-PHONETIC-LAST-NAME', 'X-MANAGERSNAME', 'TITLE', 'KIND', 'X-ADDRESSBOOKSERVER-KIND'`

so if you search something  in the property 'notes' it is not found.

with this patch, all fields are loaded and searched.

Fixes https://github.com/nextcloud/contacts/issues/2925
