### PR TITLE
feat(contacts): implement final design enhancements from mockups

### DIFF
--- a/css/Properties/Properties.scss
+++ b/css/Properties/Properties.scss
@@ -116,6 +116,14 @@ $property-row-gap: $contact-details-row-gap;
 		}
 	}
 
+	// Mobile tweaks
+	@media (max-width: 1024px) {
+		// Left align labels on mobile
+		&__label {
+			justify-content: flex-start;
+		}
+	}
+
 	// Show ext buttons on full row hover
 	&:hover {
 		.property__ext {

--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -121,7 +121,7 @@
 					<!-- edit and save buttons -->
 					<template v-if="!addressbookIsReadOnly">
 						<NcButton v-if="!editMode"
-							type="tertiary"
+							:type="isMobile ? 'secondary' : 'tertiary'"
 							@click="editMode = true">
 							<template #icon>
 								<PencilIcon :size="20" />
@@ -129,7 +129,7 @@
 							{{ t('contacts', 'Edit') }}
 						</NcButton>
 						<NcButton v-else
-							type="primary"
+							type="secondary"
 							:disabled="loadingUpdate"
 							@click="onSave">
 							<template #icon>
@@ -286,6 +286,7 @@ import {
 	NcMultiselect as Multiselect,
 	NcLoadingIcon as IconLoading,
 	NcButton,
+	isMobile,
 } from '@nextcloud/vue'
 import IconContact from 'vue-material-design-icons/AccountMultiple.vue'
 import IconDownload from 'vue-material-design-icons/Download.vue'
@@ -311,6 +312,8 @@ import PropertySelect from './Properties/PropertySelect.vue'
 
 export default {
 	name: 'ContactDetails',
+
+	mixins: [isMobile],
 
 	components: {
 		ActionButton,

--- a/src/components/DetailsHeader.vue
+++ b/src/components/DetailsHeader.vue
@@ -89,23 +89,32 @@ $top-padding: 50px;
 // Header with avatar, name, position, actions...
 .contact-header {
 	display: flex;
-	flex-wrap: wrap;
 	align-items: center;
 	padding: $top-padding 0 20px;
 	gap: $contact-details-row-gap;
 
-	// Top padding of 44px is already included in AppContent by default on mobile
 	@media (max-width: 1024px) {
+		// Top padding of 44px is already included in AppContent by default on mobile
 		padding-top: calc($top-padding - 44px);
+
+		// Wrap actions on mobile
+		flex-wrap: wrap;
+		&__no-wrap {
+			width: 100%;
+		}
+		&__infos {
+			// Account for nonexistent actions menu
+			width: calc($contact-details-value-max-width + $contact-details-row-gap + 44px) !important;
+		}
+		&__actions {
+			justify-content: space-between;
+		}
 	}
 
 	&__no-wrap {
 		display: flex;
-		flex: 9999 1 auto;
 		gap: $contact-details-row-gap;
 		align-items: center;
-
-		// Wrap actions to next line before shrinking
 		min-width: 0;
 	}
 
@@ -126,7 +135,7 @@ $top-padding: 50px;
 		// Global single column layout
 		display: flex;
 		flex: 0 1 auto;
-		width: calc($contact-details-value-max-width + $contact-details-row-gap + 44px);
+		width: $contact-details-value-max-width;
 		min-width: 0; // Has to be zero unless we implement wrapping
 
 		&-title,
@@ -153,7 +162,6 @@ $top-padding: 50px;
 	&__actions {
 		display: flex;
 		flex: 1 0 auto;
-		justify-content: space-between;
 	}
 }
 </style>

--- a/src/components/Properties/PropertyTitle.vue
+++ b/src/components/Properties/PropertyTitle.vue
@@ -101,3 +101,18 @@ export default {
 	},
 }
 </script>
+
+<style lang="scss" scoped>
+.property {
+	// Left align icon and title on mobile
+	@media (max-width: 1024px) {
+		&__label {
+			width: unset;
+		}
+	}
+
+	&__value {
+		font-weight: bold;
+	}
+}
+</style>


### PR DESCRIPTION
Fix #3326 

This PR fixes final leftovers from the mockups:
1. Left align labels and titles on mobile.
2. Make section titles bold.
3. Use a secondary edit button (instead of a tertiary) on mobile.
4. Only wrap actions in the header on mobile.
5. Use a secondary save buttons on desktop and mobile (instead of primary).

## After

### Desktop

| View | Edit |
| --- | --- |
| ![grafik](https://user-images.githubusercontent.com/1479486/235857642-190d758e-9be9-4bcf-bff1-ac9816a61a9b.png) | ![grafik](https://user-images.githubusercontent.com/1479486/235858161-1fbecc82-e0e0-45e3-b2ca-3a85b0064395.png) |

### Mobile

| View | Edit |
| --- | --- |
| ![grafik](https://user-images.githubusercontent.com/1479486/235857487-7fb2849a-59d5-42a1-9527-11b7426f3531.png) | ![grafik](https://user-images.githubusercontent.com/1479486/235858293-04819819-6631-4a58-909a-d77cdaeb6567.png) |

## Mockups (to refresh your memory)

![image](https://user-images.githubusercontent.com/52440189/231748464-39cc019e-a317-45e1-a271-65001583a94c.png)
![image](https://user-images.githubusercontent.com/52440189/231748352-ba00dde3-3987-416a-aab0-ae86f928b256.png)

### Mobile
![image](https://user-images.githubusercontent.com/52440189/231752991-84b7d2cf-6617-4d8a-88cf-9fb0b2911719.png)