### PR TITLE
fix(contacts): display the new avatar on change

### DIFF
--- a/src/components/AppContent/ContactsContent.vue
+++ b/src/components/AppContent/ContactsContent.vue
@@ -63,11 +63,12 @@
 		<template #list>
 			<ContactsList :list="contactsList"
 				:contacts="contacts"
-				:search-query="searchQuery" />
+				:search-query="searchQuery"
+				:reload-bus="reloadBus" />
 		</template>
 
 		<!-- main contacts details -->
-		<ContactDetails :contact-key="selectedContact" :contacts="sortedContacts" />
+		<ContactDetails :contact-key="selectedContact" :contacts="sortedContacts" :reload-bus="reloadBus" />
 	</AppContent>
 </template>
 <script>
@@ -83,6 +84,7 @@ import ContactDetails from '../ContactDetails.vue'
 import ContactsList from '../ContactsList.vue'
 import IconContact from 'vue-material-design-icons/AccountMultiple.vue'
 import RouterMixin from '../../mixins/RouterMixin.js'
+import Vue from 'vue'
 
 export default {
 	name: 'ContactsContent',
@@ -114,6 +116,8 @@ export default {
 	data() {
 		return {
 			searchQuery: '',
+			// communication for ContactListItem and ContactDetails (reload avatar)
+			reloadBus: new Vue(),
 		}
 	},
 

--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -41,6 +41,7 @@
 				<ContactAvatar slot="avatar"
 					:contact="contact"
 					:is-read-only="isReadOnly"
+					:reload-bus="reloadBus"
 					@update-local-contact="updateLocalContact" />
 
 				<!-- fullname -->
@@ -89,12 +90,12 @@
 				<!-- actions -->
 				<template #actions>
 					<!-- warning message -->
-					<component v-if="warning"
+					<component :is="warning.icon"
+						v-if="warning"
 						v-tooltip.bottom="{
 							content: warning ? warning.msg : '',
 							trigger: 'hover focus'
 						}"
-						:is="warning.icon"
 						class="header-icon"
 						:classes="warning.classes" />
 
@@ -346,6 +347,10 @@ export default {
 		contacts: {
 			type: Array,
 			default: () => [],
+		},
+		reloadBus: {
+			type: Object,
+			required: true,
 		},
 	},
 
@@ -855,7 +860,7 @@ export default {
 		async onSave() {
 			await this.updateContact()
 			this.editMode = false
-		}
+		},
 	},
 }
 </script>

--- a/src/components/ContactDetails/ContactDetailsProperty.vue
+++ b/src/components/ContactDetails/ContactDetailsProperty.vue
@@ -103,7 +103,7 @@ export default {
 		isReadOnly: {
 			type: Boolean,
 			required: true,
-		}
+		},
 	},
 
 	computed: {

--- a/src/components/ContactsList.vue
+++ b/src/components/ContactsList.vue
@@ -32,7 +32,8 @@
 			data-key="key"
 			:data-sources="filteredList"
 			:data-component="ContactsListItem"
-			:estimate-size="68" />
+			:estimate-size="68"
+			:extra-props="{reloadBus}" />
 	</AppContentList>
 </template>
 
@@ -61,6 +62,10 @@ export default {
 		searchQuery: {
 			type: String,
 			default: '',
+		},
+		reloadBus: {
+			type: Object,
+			required: true,
 		},
 	},
 

--- a/src/components/ContactsList/ContactsListItem.vue
+++ b/src/components/ContactsList/ContactsListItem.vue
@@ -44,12 +44,17 @@ export default {
 			type: Object,
 			required: true,
 		},
+		reloadBus: {
+			type: Object,
+			required: true,
+		},
 	},
 	data() {
 		return {
 			avatarUrl: undefined,
 		}
 	},
+
 	computed: {
 		selectedGroup() {
 			return this.$route.params.selectedGroup
@@ -63,15 +68,44 @@ export default {
 			return window.btoa(this.source.key).slice(0, -2)
 		},
 	},
-	watch: {
-		async source() {
-			await this.loadAvatarUrl()
-		},
+
+	created() {
+		this.reloadBus.$on('reload-avatar', this.reloadAvatarUrl)
+		this.reloadBus.$on('delete-avatar', this.deleteAvatar)
+	},
+	destroyed() {
+		this.reloadBus.$off('reload-avatar', this.reloadAvatarUrl)
+		this.reloadBus.$off('delete-avatar', this.deleteAvatar)
 	},
 	async mounted() {
 		await this.loadAvatarUrl()
 	},
 	methods: {
+
+		/**
+		 * Is called on save in ContactDetails to reload Avatar,
+		 * url does not change, so trigger on source change don't work
+		 *
+		 * @param {string} key from contact
+		 */
+		reloadAvatarUrl(key) {
+			if (key === this.source.key) {
+				this.loadAvatarUrl()
+			}
+		},
+
+		/**
+		 * Is called on save in ContactDetails to delete Avatar,
+		 * somehow the avatarUrl is not unavailable immediately, so we just set undefined
+		 *
+		 * @param {string} key from contact
+		 */
+		deleteAvatar(key) {
+			if (key === this.source.key) {
+				this.avatarUrl = undefined
+			}
+		},
+
 		async loadAvatarUrl() {
 			this.avatarUrl = undefined
 			if (this.source.photo) {

--- a/src/components/Properties/PropertyGroups.vue
+++ b/src/components/Properties/PropertyGroups.vue
@@ -132,7 +132,7 @@ export default {
 			}
 
 			return t('contacts', 'Add contact in group')
-		}
+		},
 	},
 
 	watch: {


### PR DESCRIPTION
Fix: #3351 

When you add, edit, or delete an avatar, it should now update properly.

While working on it I noticed that the avatar doesn't update as well on deletion, even with the fix for a new avatar. Somehow the avatarUrl is not unavailable immediately. I fixed this by setting the avatarUrl undefined on deletion.