### PR TITLE
fix(contacts): remove obsolete warning and fix header alignment

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -296,7 +296,6 @@ import CakeIcon from 'vue-material-design-icons/Cake.vue'
 import IconCopy from 'vue-material-design-icons/ContentCopy.vue'
 import PencilIcon from 'vue-material-design-icons/Pencil.vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
-import AlertCircleIcon from 'vue-material-design-icons/AlertCircle.vue'
 import EyeCircleIcon from 'vue-material-design-icons/EyeCircle.vue'
 
 import rfcProps from '../models/rfcProps.js'
@@ -403,13 +402,7 @@ export default {
 		 * @return {object | boolean}
 		 */
 		warning() {
-			if (!this.contact.dav) {
-				return {
-					icon: AlertCircleIcon,
-					classes: ['header-icon--pulse'],
-					msg: t('contacts', 'This contact is not yet synced. Edit it to save it to the server.'),
-				}
-			} else if (this.addressbookIsReadOnly) {
+			if (this.addressbookIsReadOnly) {
 				return {
 					icon: EyeCircleIcon,
 					classes: [],

--- a/src/components/DetailsHeader.vue
+++ b/src/components/DetailsHeader.vue
@@ -106,8 +106,8 @@ $top-padding: 50px;
 			// Account for nonexistent actions menu
 			width: calc($contact-details-value-max-width + $contact-details-row-gap + 44px) !important;
 		}
-		&__actions {
-			justify-content: space-between;
+		&__actions .header-menu {
+			margin-left: auto;
 		}
 	}
 
@@ -162,6 +162,7 @@ $top-padding: 50px;
 	&__actions {
 		display: flex;
 		flex: 1 0 auto;
+		gap: 5px;
 	}
 }
 </style>


### PR DESCRIPTION
Fix #3361 

Remove the obsolete warning about unsaved changes when creating a new contact. 
Also fix the horizontal alignment on mobile when other warning are shown (e.g. read-only contact, or conflicts).

| Before | After |
| --- | --- |
| ![grafik](https://user-images.githubusercontent.com/1479486/236159626-4ba598a7-d707-41e1-9596-d3b74ab2c3bc.png) | ![grafik](https://user-images.githubusercontent.com/1479486/236159485-e621fb4b-5c12-4ae6-8086-92dc3bef6109.png) |

## No regressions on desktop

![grafik](https://user-images.githubusercontent.com/1479486/236159802-1c8e997d-86a5-490a-a8bf-400ecc4623d6.png)

