### PR TITLE
Use the color-primary-element* variables

### DIFF
--- a/src/components/ChartTemplate.vue
+++ b/src/components/ChartTemplate.vue
@@ -109,13 +109,13 @@ export default {
 	}
 
 	.inner-box-highlight {
-		border: 2px solid var(--color-primary) !important;
+		border: 2px solid var(--color-primary-element) !important;
 	}
 
 	.panel {
 		width: 100%;
 		margin: -34px -1px 0 -1px;
-		background-color: var(--color-primary);
+		background-color: var(--color-primary-element);
 		height: 15px;
 		border-top-left-radius: var(--border-radius-large);
 		border-top-right-radius: var(--border-radius-large);

--- a/src/components/EntityPicker/EntitySearchResult.vue
+++ b/src/components/EntityPicker/EntitySearchResult.vue
@@ -100,7 +100,7 @@ $icon-margin: math.div($clickable-area - $icon-size, 2);
 			white-space: nowrap;
 			text-overflow: ellipsis;
 			pointer-events: none;
-			color: var(--color-primary);
+			color: var(--color-primary-element);
 			box-shadow: none !important;
 			line-height: $clickable-area;
 
@@ -130,7 +130,7 @@ $icon-margin: math.div($clickable-area - $icon-size, 2);
 		&:focus {
 			::v-deep .user-bubble__content {
 				// better visual with light default tint
-				background-color: var(--color-primary-light);
+				background-color: var(--color-primary-element-light);
 			}
 		}
 	}

--- a/src/components/OrgChart.vue
+++ b/src/components/OrgChart.vue
@@ -135,7 +135,7 @@ export default {
 				})
 				.linkUpdate(function(d) {
 					d3.select(this)
-						.attr('stroke', () => 'var(--color-primary)')
+						.attr('stroke', () => 'var(--color-primary-element)')
 						.attr('stroke-width', (dRect) =>
 							dRect.data._upToTheRootHighlighted ? 2 : 1
 						)


### PR DESCRIPTION
Explanation: the color-primary variables are not to be used in components because the introduce problems with high-contrast primary colors. Fix this by using the primary-element variables instead.