### PR TITLE
Create "the" circle (button's wording improvement)

### DIFF
--- a/src/components/EntityPicker/NewCircleIntro.vue
+++ b/src/components/EntityPicker/NewCircleIntro.vue
@@ -70,7 +70,7 @@
 				<button :disabled="isEmptyName || loading"
 					class="navigation__button-right primary"
 					@click="onSubmit">
-					{{ t('contacts', 'Create circle') }}
+					{{ t('contacts', 'Create the circle') }}
 				</button>
 			</div>
 		</div>


### PR DESCRIPTION
Because you know which circle you're talking about.