### PR TITLE
More appropriate circle section wording

### DIFF
--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -137,7 +137,7 @@ export const CIRCLES_MEMBER_GROUPING = [
 	},
 	{
 		id: `picker-${Type.SHARE_TYPE_GROUP}`,
-		label: t('contacts', 'Contact groups'),
+		label: t('contacts', 'User groups'),
 		share: Type.SHARE_TYPE_GROUP,
 		type: MEMBER_TYPE_GROUP
 	},


### PR DESCRIPTION
"user" groups instead of "contact" groups because here are only listed user groups and not contact groups (if I'm not mistaking).

![2023-06-06_09-45](https://github.com/nextcloud/contacts/assets/33763786/275c47dd-6aab-462b-aeb5-63a3c567f211)
