### PR TITLE
ci(xmllint): bump xmllint-action to v1.1

### DIFF
--- a/.github/workflows/lint-info-xml.yml
+++ b/.github/workflows/lint-info-xml.yml
@@ -33,7 +33,7 @@ jobs:
         run: wget https://raw.githubusercontent.com/nextcloud/appstore/master/nextcloudappstore/api/v1/release/info.xsd
 
       - name: Lint info.xml
-        uses: ChristophWurst/xmllint-action@d18a551aab4728e4af449617638600634d7a48cb # v1
+        uses: ChristophWurst/xmllint-action@39155a91429af431d65fafc21fa52ba5c4f5cb71 # v1.1
         with:
           xml-file: ./appinfo/info.xml
           xml-schema-file: ./info.xsd


### PR DESCRIPTION
Should (hopefully) fix failures like https://github.com/nextcloud/contacts/actions/runs/5372260728/jobs/9745542829?pr=3484.