### PR TITLE
fix(contacts): split up detailed-name again to fix vCard

### DIFF
--- a/src/models/rfcProps.js
+++ b/src/models/rfcProps.js
@@ -49,19 +49,32 @@ const properties = {
 			t('contacts', 'Additional names'),
 			t('contacts', 'Prefix'),
 			t('contacts', 'Suffix'),
-
-			t('contacts', 'Nickname'),
-			t('contacts', 'Phonetic first name'),
-			t('contacts', 'Phonetic last name'),
 		],
-		displayOrder: [3, 1, 2, 0, 4, 5, 6, 7],
+		displayOrder: [3, 1, 2, 0, 4],
 		defaultValue: {
-			value: ['', '', '', '', '', '', '', ''],
+			value: ['', '', '', '', ''],
 		},
 		icon: 'icon-detailed-name',
 		actions: [
 			ActionCopyNtoFN,
 		],
+		primary: false,
+	},
+	nickname: {
+		readableName: t('contacts', 'Nickname'),
+		icon: 'icon-detailed-name',
+		primary: false,
+	},
+	'x-phonetic-first-name': {
+		readableName: t('contacts', 'Phonetic first name'),
+		icon: 'icon-detailed-name',
+		force: 'text',
+		primary: false,
+	},
+	'x-phonetic-last-name': {
+		readableName: t('contacts', 'Phonetic last name'),
+		icon: 'icon-detailed-name',
+		force: 'text',
 		primary: false,
 	},
 	note: {
@@ -398,6 +411,9 @@ const fieldOrder = [
 	'anniversary',
 	'deathdate',
 	'n',
+	'nickname',
+	'x-phonetic-first-name',
+	'x-phonetic-last-name',
 	'gender',
 	'cloud',
 	'impp',


### PR DESCRIPTION
Fix: #3486

Regression of: #3314 

Contacts created by the new design without this fix will lose the nickname and phonetic names

|before|after|
|---|---|
|`N:sur;first;middle;pre;suf;nick;phonfirst;phonlast`|`N:sur;first;middle;pre;suf`<br>`X-PHONETIC-FIRST-NAME:phonfirst`<br>`X-PHONETIC-LAST-NAME:phonelast`<br>`NICKNAME:nick`|
|![Screenshot from 2023-06-30 10-59-07](https://github.com/nextcloud/contacts/assets/74607597/75397b64-6bb7-456a-9377-71ef7a2afd58)|![Screenshot from 2023-06-30 10-57-23](https://github.com/nextcloud/contacts/assets/74607597/99b3e3da-cb0d-436b-86df-8dc3dbeac903)|
|![Screenshot from 2023-06-30 10-58-53](https://github.com/nextcloud/contacts/assets/74607597/78ee585c-f288-405c-8977-2053f63e50fd)|![Screenshot from 2023-06-30 10-56-55](https://github.com/nextcloud/contacts/assets/74607597/fc2872f5-89a8-4ed7-885e-85f642dd43c6)|