### PR TITLE
Fix position of "New contact" button

### DIFF
--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -419,9 +419,3 @@ export default {
 	},
 }
 </script>
-
-<style lang="scss" scoped>
-.new-contact-button {
-	margin-top: 4px;
-}
-</style>


### PR DESCRIPTION
Seems to be just some leftover from earlier component. Note the unnecessary additional space on top of the "New contact" button, got fixed:

Before | After
-|-
![image](https://github.com/nextcloud/contacts/assets/925062/996ea040-cc77-4d17-9768-db9dbf0f667f)|![image](https://github.com/nextcloud/contacts/assets/925062/05f44a50-c625-4b63-a614-ed6041435fca)
