### PR TITLE
Moved QR code close button away from QR code image

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -189,7 +189,8 @@
 				size="small"
 				:clear-view-delay="-1"
 				:title="contact.displayName"
-				@close="closeQrModal">
+				@close="closeQrModal"
+				:closeButtonContained="false">
 				<img :src="`data:image/svg+xml;base64,${qrcode}`"
 					:alt="t('contacts', 'Contact vCard as QR code')"
 					class="qrcode"


### PR DESCRIPTION
Fixes #3410

I am not sure if the button is too far away from the QR code now but since this is coded into Modal I guess this is how it should be.

Before:
![image](https://github.com/nextcloud/contacts/assets/81317317/515ee6c0-f90f-4013-87cb-72262919ba9f)

After:
![image](https://github.com/nextcloud/contacts/assets/81317317/51c916a5-6315-4000-8e0d-8ab108be6b82)

