### PR TITLE
Update selectInput to select on "Name"

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -752,10 +752,10 @@ export default {
 		},
 
 		/**
-		 * Select the text in the input if it is still set to 'new Contact'
+		 * Select the text in the input if it is still set to 'Name'
 		 */
 		selectInput() {
-			if (this.$refs.fullname && this.$refs.fullname.value === t('contacts', 'New contact')) {
+			if (this.$refs.fullname && this.$refs.fullname.value === t('contacts', 'Name')) {
 				this.$refs.fullname.select()
 			}
 		},


### PR DESCRIPTION
The default fullname for new contacts was changed to "Name" in 1505b810b58364448af4e1f7859ca274b5470686 but wasn't updated in the selectInput. This selects the fullname input on "Name" now.

P.S. This is my first ever pull request on Github so I apologize if I'm doing anything wrong.