### PR TITLE
fix: improve matching for tel type parameter

### DIFF
--- a/src/components/ContactDetails/ContactDetailsProperty.vue
+++ b/src/components/ContactDetails/ContactDetailsProperty.vue
@@ -251,11 +251,18 @@ export default {
 					// https://jsperf.com/array-map-and-intersection-perf
 					const matchingTypes = this.propModel.options
 						.map(type => {
-							return {
-								type,
-								// "WORK,HOME" => ['WORK', 'HOME']
-								score: type.id.split(',').filter(value => selectedType.indexOf(value) !== -1).length,
+							let score = 0
+							const types = type.id.split(',') // "WORK,HOME" => ['WORK', 'HOME']
+
+							if (types.length === selectedType.length) {
+								// additional point for same length
+								score++
 							}
+
+							const intersection = types.filter(value => selectedType.includes(value))
+							score = score + intersection.length
+
+							return { type, score }
 						})
 
 					// Sort by score, filtering out the null score and selecting the first match


### PR DESCRIPTION
Fix https://github.com/nextcloud/contacts/issues/3651, Close https://github.com/nextcloud/contacts/pull/3652

The old implementation assigns the same score for HOME,VOICE and VOICE for a tel property with parameter voice.

This pull requests adds an aditional point for the items with the same length.

| This PR | Main |
|--------|--------|
| ![Screenshot from 2023-10-10 20-16-56](https://github.com/nextcloud/contacts/assets/3902676/e8586494-a0b5-4a91-bd09-769203f68184) | ![Screenshot from 2023-10-10 20-18-12](https://github.com/nextcloud/contacts/assets/3902676/1924dfe1-ef11-4f3d-a307-b51d5ea22e65) |



