### PR TITLE
fix: bundle moment.js locale data

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,8 @@
 const path = require('path')
-const webpack = require('webpack')
 const webpackConfig = require('@nextcloud/webpack-vue-config')
 
 webpackConfig.entry['files-action'] = path.join(__dirname, 'src', 'files-action.js')
 webpackConfig.entry['admin-settings'] = path.join(__dirname, 'src', 'admin-settings.js')
-webpackConfig.plugins.push(...[
-	new webpack.IgnorePlugin({
-		resourceRegExp: /^\.\/locale$/,
-		contextRegExp: /moment$/,
-	}),
-])
 
 webpackConfig.module.rules.push({
 	  test: /\.tsx?$/,


### PR DESCRIPTION
Fix #3657 

Locales other than `en` were broken as they were not bundled. Only the default locale (`en`) is included by default with moment.