### PR TITLE
chore: fix prod build after updating babel/preset-env

### DIFF
--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -138,7 +138,9 @@ export default {
 
 	data() {
 		return {
-			appName,
+			// The object shorthand syntax is breaking builds (bug in @babel/preset-env)
+			/* eslint-disable object-shorthand */
+			appName: appName,
 
 			// Let's but the loading state to true if circles is enabled
 			loadingCircles: isCirclesEnabled,


### PR DESCRIPTION
Fix https://github.com/nextcloud/contacts/issues/3747

This PR is outdated on purpose as well to reproduce the production build failure.

This is a bit hacky but the app builds again :see_no_evil: 