### PR TITLE
Fix the empty content showing on edit mode

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -309,7 +309,7 @@
 					class="property--groups property--last"
 					@update:value="updateGroups" />
 			</div>
-			<div v-if="nextcloudVersionAtLeast28" class="related-resources">
+			<div v-if="nextcloudVersionAtLeast28 && !editMode" class="related-resources">
 				<NcRelatedResourcesPanel v-if="!filesPanelHasError"
 					provider-id="account"
 					resource-type="files"
@@ -350,7 +350,7 @@
 					:primary="true"
 					@has-resources="value => hasRelatedResources = value"
 					@has-error="value => deckPanelHasError = value" />
-				<NcEmptyContent v-if="!hasRelatedResources"
+				<NcEmptyContent v-if="!hasRelatedResources && !loadingData"
 					:name="t('contacts', 'No shared items with this contact')">
 					<template #icon>
 						<FolderMultipleImage :size="20" />
@@ -473,7 +473,7 @@ export default {
 		},
 		desc: {
 			type: String,
-			required: true,
+			required: false,
 			default: '',
 		},
 	},


### PR DESCRIPTION
![Screenshot from 2023-11-14 14-15-29](https://github.com/nextcloud/contacts/assets/12728974/e30c1aec-8629-4a42-984a-f162d2f2cf24) 
after ![Screenshot from 2023-11-14 14-17-24](https://github.com/nextcloud/contacts/assets/12728974/fb62c53d-a656-40ec-b5e4-a4a4ff01dfab)

this pr fixes

- [ ] the empty content shown before the contact details are loaded
- [ ] the empty content shown on edit mode
- [ ] desc is not required