### PR TITLE
don't filter results while sharing

### DIFF
--- a/src/components/AppNavigation/Settings/SettingsAddressbookShare.vue
+++ b/src/components/AppNavigation/Settings/SettingsAddressbookShare.vue
@@ -31,6 +31,7 @@
 			:placeholder="placeholder"
 			:class="{ 'showContent': inputGiven, 'icon-loading': isLoading }"
 			:user-select="true"
+			:filter-by="filterResults"
 			open-direction="bottom"
 			track-by="user"
 			label="displayName"
@@ -107,6 +108,18 @@ export default {
 		shareAddressbook({ user, displayName, uri, isGroup }) {
 			this.$store.dispatch('shareAddressbook', { addressbook: this.addressbook, user, displayName, uri, isGroup })
 		},
+		/**
+		 * Function to filter results in NcSelect
+		 *
+		 * @param {object} option
+		 * @param {string} label
+		 * @param {string} search
+		 */
+		/* eslint-disable @typescript-eslint/no-unused-vars */
+		filterResults(option, label, search) {
+			return true
+		},
+		/* eslint-enable @typescript-eslint/no-unused-vars */
 
 		/**
 		 * Use the cdav client call to find matches to the query from the existing Users & Groups


### PR DESCRIPTION
Share only works by display name right now

- Search by email to share calendar is broken completely as there is a filterBy option in [vue-select](https://vue-select.org/api/props.html#filterby) whose return value defaults to return (label || '').toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) > -1
  - label in our code is set to displayName so only search by displayName works Since we already get our results by
 - searching(DAV & OCS), I don't see why we need the filterBy option in the first place
   - So I just make the return value true
   - In case we do need the option, we should make it check for both displayName and email attributes