### PR TITLE
fix(deps)!: Drop Nextcloud 28 and older

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         php-versions: ['8.0']
         databases: ['sqlite']
-        server-versions: ['master', 'stable28', 'stable27', 'stable26']
+        server-versions: ['master']
 
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 * 🙈 **We’re not reinventing the wheel!** Based on the great and open SabreDAV library.
 	</description>
 
-	<version>5.5.0-rc.1</version>
+	<version>6.0.0-alpha.1</version>
 	<licence>agpl</licence>
 
 	<author mail="hamza221@users.noreply.github.com">Hamza Mahjoubi</author>
@@ -39,7 +39,7 @@
 
 	<dependencies>
 		<php min-version="7.4" max-version="8.3" />
-		<nextcloud min-version="26" max-version="29" />
+		<nextcloud min-version="29" max-version="29" />
 	</dependencies>
 
 	<background-jobs>


### PR DESCRIPTION
The Circles to Teams rebranding may only land on 29+.

Ref https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/release_process.html#major-update
Ref https://github.com/nextcloud/contacts/pull/3818