### PR TITLE
Fix: open import contacts filePicker

### DIFF
--- a/src/components/AppNavigation/Settings/SettingsImportContacts.vue
+++ b/src/components/AppNavigation/Settings/SettingsImportContacts.vue
@@ -110,10 +110,9 @@ const CancelToken = axios.CancelToken
 
 const picker = getFilePickerBuilder(t('contacts', 'Choose a vCard file to import'))
 	.setMultiSelect(false)
-	.setModal(true)
 	.setType(1)
 	.allowDirectories(false)
-	.setMimeTypeFilter('text/vcard')
+	.addMimeTypeFilter('text/vcard')
 	.build()
 
 export default {


### PR DESCRIPTION
Caused by #3847

`.setModal()` was removed -> https://github.com/nextcloud-libraries/nextcloud-dialogs/blob/a19a863819bba34d45a2bd3dec4d2503f2730e7d/CHANGELOG.md?plain=1#L235

`setMimeTypeFilter ` takes string array 