### PR TITLE
Replace "Add members" with "Manage members" in team's dashboards

### DIFF
--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -104,7 +104,7 @@
 					<template #icon>
 						<AccountMultiplePlus :size="20" />
 					</template>
-					{{ t('contacts', 'Add members') }}
+					{{ t('contacts', 'Manage members') }}
 				</Button>
 			</div>
 			<Modal v-if="showMembersModal" @close="showMembersModal=false">


### PR DESCRIPTION
With this PR, I would like to replace "Add" with "Manage" because, the modal which appears after clicking on the button allows adding members, removing members, and setting role for each member (not only adding). Do in the team's dashboard, "Manage users" (button's wording) is more relevant : 
![2024-05-02_15-35](https://github.com/nextcloud/contacts/assets/33763786/9ffce9a6-1863-49ff-98f2-0261057db4e6)

Then, once in the modal, the "Add members" button's wording is relevant because the button only allows to add users :
![2024-05-02_15-35_1](https://github.com/nextcloud/contacts/assets/33763786/0146bd9c-4c2d-4cec-b931-ba6529e0f40a)
