### PR TITLE
enh/Improve group adding

### DIFF
--- a/src/components/AppNavigation/GroupNavigationItem.vue
+++ b/src/components/AppNavigation/GroupNavigationItem.vue
@@ -5,6 +5,7 @@
 <template>
 	<div class="group-drop-area"
 		data-testid="group-drop-area"
+		v-if="!isEmpty"
 		@drop="onDrop($event, group)"
 		@dragenter.prevent
 		@dragover="onDragOver($event)"
@@ -118,6 +119,10 @@ export default {
 	computed: {
 		contacts() {
 			return this.$store.getters.getContacts
+		},
+
+		isEmpty() {
+			return this.group.contacts.length === 0
 		},
 	},
 

--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -87,7 +87,7 @@
 					<IconAdd :size="20" />
 				</template>
 				<template #actions>
-					<ActionText>
+					<ActionText v-show="isNewGroupMenuOpen">
 						<template #icon>
 							<IconError v-if="createGroupError" :size="20" />
 							<IconContact v-else-if="!createGroupError" :size="20" />
@@ -95,6 +95,7 @@
 						{{ createGroupError ? createGroupError : t('contacts', 'Create a new contact group') }}
 					</ActionText>
 					<ActionInput icon=""
+						v-show="isNewGroupMenuOpen"
 						:placeholder="t('contacts','Contact group name')"
 						@submit.prevent.stop="createNewGroup" />
 				</template>
@@ -203,6 +204,7 @@ import IconError from 'vue-material-design-icons/AlertCircle.vue'
 
 import RouterMixin from '../../mixins/RouterMixin.js'
 import { showError } from '@nextcloud/dialogs'
+import { emit } from '@nextcloud/event-bus'
 
 export default {
 	name: 'RootNavigation',
@@ -390,22 +392,16 @@ export default {
 			// Check if already exists
 			if (this.groups.find(group => group.name === groupName)) {
 				this.createGroupError = t('contacts', 'This group already exists')
+				emit('contacts:group:append', this.groups.find(group => group.name === groupName).name)
 				return
 			}
 
 			this.createGroupError = null
-
 			this.logger.debug('Created new local group', { groupName })
 			this.$store.dispatch('addGroup', groupName)
 			this.isNewGroupMenuOpen = false
 
-			// Select group
-			this.$router.push({
-				name: 'group',
-				params: {
-					selectedGroup: groupName,
-				},
-			})
+			emit('contacts:group:append', groupName)
 		},
 
 		// Ellipsis item toggles

--- a/src/components/EntityPicker/ContactsPicker.vue
+++ b/src/components/EntityPicker/ContactsPicker.vue
@@ -61,6 +61,7 @@ export default {
 				total: 0,
 				name: '',
 			},
+			passedGroupName: '',
 		}
 	},
 	computed: {
@@ -85,6 +86,7 @@ export default {
 		addContactsToGroup(group) {
 			console.debug('Contacts picker opened for group', group)
 
+			this.passedGroupName = group.name ? group.name : group
 			// Get the full group if we provided the group name only
 			if (typeof group === 'string') {
 				group = this.groups.find(a => a.name === group)
@@ -164,6 +166,14 @@ export default {
 				this.isProcessDone = true
 				this.showPicker = false
 
+				// Select group
+				this.$router.push({
+					name: 'group',
+					params: {
+						selectedGroup: typeof this.passedGroupName === 'string' ? this.passedGroupName : this.passedGroupName.name,
+					},
+				})
+
 				// Auto close after 3 seconds if no errors
 				if (this.processStatus.failed === 0) {
 					setTimeout(this.closeProcess, 3000)
@@ -181,6 +191,17 @@ export default {
 			this.processStatus.progress = 0
 			this.processStatus.success = 0
 			this.processStatus.total = 0
+
+			if (this.passedGroupName === '' || this.passedGroupName === undefined) {
+				return
+			}
+			// Select group
+			this.$router.push({
+				name: 'group',
+				params: {
+					selectedGroup: typeof this.passedGroupName === 'string' ? this.passedGroupName : this.passedGroupName.name,
+				},
+			})
 		},
 	},
 }

--- a/src/components/EntityPicker/EntityPicker.vue
+++ b/src/components/EntityPicker/EntityPicker.vue
@@ -392,6 +392,7 @@ $icon-margin: math.div($clickable-area - $icon-size, 2);
 		position: relative;
 		display: flex;
 		align-items: center;
+		width: 95%;
 		&-input {
 			width: 100%;
 			height: $clickable-area - $entity-spacing !important;
@@ -458,6 +459,10 @@ $icon-margin: math.div($clickable-area - $icon-size, 2);
 it back */
 :deep(.modal-container) {
 	border-radius: var(--border-radius-large) !important;
+}
+
+:deep(.modal-container__close) {
+	margin-top: 19px;
 }
 
 </style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/contacts/issues/2511

The idea is to have the add contact modal show up immediately after creating a new group and for it to not show up in the sidebar until you actually added someone, to not give users the "false hope" of seeing it in the sidebar but then reloading the page and seeing that it hadn't been saved.

TODO:
- [x] Make modal open
- [x] Switch to new contact page after modal close
- [x] Close add group modal when add contacts modal opens
- [x] Remove empty groups from sidebar
- [x] When trying to create an already existing group, open modal to add contacts to that group. This is needed in the following scenario:
    - You create a new group but don't add any contacts
    - You therefore do not see in the sidebar
    - You change your mind and want to add contacts to that group
    - You type in the name into the add group and get a "This group already exists error" with no way to continue. With the modal opening you can actually add contacts instead of just having the error.
- [x] After adding contacts to a group you get rerouted to the group view 