### PR TITLE
fix: long contact name overlapping with other content

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -29,7 +29,7 @@
 
 				<!-- fullname -->
 				<template #title>
-					<div v-if="isReadOnly">
+					<div v-if="isReadOnly" class="contact-title">
 						{{ contact.fullName }}
 					</div>
 					<input v-else
@@ -1158,5 +1158,10 @@ section.contact-details {
 
 .empty-content {
 	height: 100%;
+}
+.contact-title {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 </style>


### PR DESCRIPTION
fixes #3771 

After:
![image](https://github.com/nextcloud/contacts/assets/107960207/abb9a848-623a-4d6c-8e5b-2b6abf467946)
