### PR TITLE
RootNavigation: align submit add new group icon with input

### DIFF
--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -492,4 +492,11 @@ $caption-padding: 22px;
 	width: 100%;
 	justify-content: start !important;
 }
+
+:deep(.button-vue__icon), :deep(.button-vue--icon-only) {
+	min-height: auto;
+	min-width: auto;
+	height: var(--default-clickable-area) !important;
+	width: var(--default-clickable-area) !important;
+}
 </style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/contacts/issues/4031

| A | B |
| - | - |
| ![Screenshot from 2024-07-17 17-09-15](https://github.com/user-attachments/assets/372a50bd-52e9-4d79-80fe-0355d52cee0f)| ![Screenshot from 2024-07-17 17-08-37](https://github.com/user-attachments/assets/d05401c6-95bc-42cf-9407-23ea7976b099) |

I know that the solution isn't the best, but we have a custom icon size in contacts, so the bug isn't related to nextcloud vue

