### PR TITLE
Address book settings: style changes and add NcTextField

### DIFF
--- a/src/components/AppNavigation/Settings/SettingsAddressbook.vue
+++ b/src/components/AppNavigation/Settings/SettingsAddressbook.vue
@@ -4,7 +4,7 @@
 -->
 <template>
 	<div class="settings-addressbook-list">
-		<IconContact class="settings-line__icon" />
+		<IconContactPlus class="settings-line__icon" />
 		<li :class="{'addressbook--disabled': !addressbook.enabled}" class="addressbook">
 			<div class="addressbook__content">
 				<!-- addressbook name -->
@@ -124,7 +124,7 @@ import {
 import IconDownload from 'vue-material-design-icons/Download.vue'
 import IconRename from 'vue-material-design-icons/Pencil.vue'
 import IconDelete from 'vue-material-design-icons/Delete.vue'
-import IconContact from 'vue-material-design-icons/AccountMultiple.vue'
+import IconContactPlus from 'vue-material-design-icons/AccountMultiplePlus.vue'
 import IconShare from 'vue-material-design-icons/ShareVariant.vue'
 import ShareAddressBook from './SettingsAddressbookShare.vue'
 import { showError } from '@nextcloud/dialogs'
@@ -146,7 +146,7 @@ export default {
 		IconDelete,
 		IconDownload,
 		IconRename,
-		IconContact,
+		IconContactPlus,
 		IconShare,
 		IconLoading,
 		ShareAddressBook,
@@ -369,7 +369,6 @@ export default {
 
 	&__count-wrapper {
 		display: flex;
-		flex-direction: center;
 	}
 
 	&__count {
@@ -384,8 +383,6 @@ export default {
 
 	&__share,
 	&__menu .icon-more {
-		width: 44px;
-		height: 44px;
 		opacity: .5;
 		&:hover,
 		&:focus,

--- a/src/components/AppNavigation/Settings/SettingsNewAddressbook.vue
+++ b/src/components/AppNavigation/Settings/SettingsNewAddressbook.vue
@@ -5,32 +5,27 @@
 
 <template>
 	<div class="new-addressbook-entry">
-		<IconAdd class="settings-line__icon" />
-		<form id="new-addressbook-form"
+		<IconLoading v-if="loading" :size="20" />
+		<NcTextField class="new-addressbook"
+			:value.sync="displayName"
 			:disabled="loading"
-			name="new-addressbook-form"
-			class="new-addressbook"
-			@submit.prevent.stop="addAddressbook">
-			<IconLoading v-if="loading" :size="20" />
-			<input id="new-addressbook"
-				ref="addressbook"
-				v-model="displayName"
-				:disabled="loading"
-				:placeholder="t('contacts', 'Add new address book')"
-				:pattern="addressBookRegex"
-				class="new-addressbook-input"
-				type="text"
-				autocomplete="off"
-				autocorrect="off"
-				spellcheck="false"
-				minlength="1"
-				required>
-			<input class="icon-confirm" type="submit" value="">
-		</form>
+			:label="t('contacts', 'Add new address book')"
+			:pattern="addressBookRegex"
+			:show-trailing-button="true"
+			:trailing-button-label="t('contacts', 'Add')"
+			trailing-button-icon="arrowRight"
+			type="text"
+			autocomplete="off"
+			autocorrect="off"
+			spellcheck="false"
+			@trailing-button-click="addAddressbook">
+			<IconAdd :size="20" />
+		</NcTextField>
 	</div>
 </template>
 
 <script>
+import { NcTextField } from '@nextcloud/vue'
 import { showError } from '@nextcloud/dialogs'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
 import IconLoading from 'vue-material-design-icons/Loading.vue'
@@ -38,6 +33,7 @@ import IconLoading from 'vue-material-design-icons/Loading.vue'
 export default {
 	name: 'SettingsNewAddressbook',
 	components: {
+		NcTextField,
 		IconAdd,
 		IconLoading,
 	},
@@ -55,6 +51,10 @@ export default {
 		 * Add a new address book
 		 */
 		addAddressbook() {
+			if (this.displayName === '') {
+				return
+			}
+
 			this.loading = true
 			this.$store.dispatch('appendAddressbook', { displayName: this.displayName })
 				.then(() => {
@@ -70,14 +70,3 @@ export default {
 	},
 }
 </script>
-<style lang="scss" scoped>
-#new-addressbook-form {
-	display: flex;
-	width: calc(100% - 44px);
-}
-
-.new-addressbook-entry {
-	display: flex;
-	align-items: center;
-}
-</style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/contacts/issues/4024

| A | B |
| - | - |
| ![Screenshot from 2024-07-18 12-14-37](https://github.com/user-attachments/assets/656bc115-fef0-4f66-b746-bdccfc3af0f2) | ![Screenshot from 2024-07-18 12-10-02](https://github.com/user-attachments/assets/54589bcc-6641-4b4c-bf60-057b100fbf2a) |

Changelog:
- Share icon is now square
- Add address book icon has a plus
- Instead of having a *boring* form and HTML input, we have an ✨`NcTextField`✨

Small complaint about `NcTextField` though, to submit you have to use the `@trailing-button-click` event, and using the <kbd>Enter</kbd> key on the field doesn't trigger it

Also, due to the custom event, using `min-length` doesn't work, and you have to check whether there are any characters inputted in the triggered method. 