### PR TITLE
ContactsListItem: make horizontal and  vertical padding equal

### DIFF
--- a/src/components/ContactsList/ContactsListItem.vue
+++ b/src/components/ContactsList/ContactsListItem.vue
@@ -178,8 +178,10 @@ export default {
 	}
 }
 
-.list-item-style {
+:deep(.list-item) {
 	list-style: none;
+	padding-inline: calc(var(--default-grid-baseline) * 3);
+	padding-block: calc(var(--default-grid-baseline) * 2);
 }
 
 </style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/contacts/issues/4029

| After | Before |
| - | - |
| ![Screenshot from 2024-07-24 17-28-20](https://github.com/user-attachments/assets/e184ac1c-b40b-44d5-b797-a1e15b83dd36) | ![Screenshot from 2024-07-24 17-30-27](https://github.com/user-attachments/assets/aa727201-1f65-4f41-b8d1-6e342123bcc3) |

Wasn't able to make this work without a `:deep` selector, if anyone has better ideas...