### PR TITLE
GroupNavigationItem: encode exported contact groups as UTF-8

### DIFF
--- a/src/components/AppNavigation/GroupNavigationItem.vue
+++ b/src/components/AppNavigation/GroupNavigationItem.vue
@@ -227,7 +227,8 @@ export default {
 		async downloadVcardPromise(vcardPromise) {
 			vcardPromise.then(response => {
 				const filename = moment().format('YYYY-MM-DD_HH-mm') + '_' + response.groupName + '.vcf'
-				download(response.data, filename, 'text/vcard')
+				const content = 'data:text/plain;charset=utf-8,' + window.encodeURIComponent(response.data)
+				download(content, filename, 'text/vcard')
 			})
 		},
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/contacts/issues/2365
Fix https://github.com/nextcloud/contacts/issues/946

Previously exported contact groups would be encoded either as `us-ascii`, or `iso-8859-1` if they had umlauts or other special characters. I made all of them be exported as `utf-8`, as singular contacts are.

The main issues with this were that when contact groups were encoded as `iso-8859-1` they would have a weird character instead of umlauts and would bug out while importing. 