### PR TITLE
fix: respect advanced group sharing settings in frontend

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -8,6 +8,7 @@ namespace OCA\Contacts\Controller;
 
 use OC\App\CompareVersion;
 use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\Service\GroupSharingService;
 use OCA\Contacts\Service\SocialApiService;
 use OCP\App\IAppManager;
 
@@ -42,6 +43,8 @@ class PageController extends Controller {
 	/** @var CompareVersion */
 	private $compareVersion;
 
+	private GroupSharingService $groupSharingService;
+
 	public function __construct(IRequest $request,
 		IConfig $config,
 		IInitialStateService $initialStateService,
@@ -49,7 +52,8 @@ class PageController extends Controller {
 		IUserSession $userSession,
 		SocialApiService $socialApiService,
 		IAppManager $appManager,
-		CompareVersion $compareVersion) {
+		CompareVersion $compareVersion,
+		GroupSharingService $groupSharingService) {
 		parent::__construct(Application::APP_ID, $request);
 
 		$this->config = $config;
@@ -59,6 +63,7 @@ class PageController extends Controller {
 		$this->socialApiService = $socialApiService;
 		$this->appManager = $appManager;
 		$this->compareVersion = $compareVersion;
+		$this->groupSharingService = $groupSharingService;
 	}
 
 	/**
@@ -69,10 +74,7 @@ class PageController extends Controller {
 	 */
 	public function index(): TemplateResponse {
 		$user = $this->userSession->getUser();
-		$userId = '';
-		if (!is_null($user)) {
-			$userId = $user->getUid();
-		}
+		$userId = $user->getUid();
 
 		$locales = $this->languageFactory->findAvailableLocales();
 		$defaultProfile = $this->config->getAppValue(Application::APP_ID, 'defaultProfile', 'HOME');
@@ -89,7 +91,7 @@ class PageController extends Controller {
 		// if circles is not installed, we use 0.0.0
 		$isCircleVersionCompatible = $this->compareVersion->isCompatible($circleVersion ? $circleVersion : '0.0.0', 22);
 		// Check whether group sharing is enabled or not
-		$isGroupSharingEnabled = $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes') === 'yes';
+		$isGroupSharingEnabled = $this->groupSharingService->isGroupSharingAllowed($user);
 		$talkVersion = $this->appManager->getAppVersion('spreed');
 		$isTalkEnabled = $this->appManager->isEnabledForUser('spreed') === true;
 

--- a/lib/Service/GroupSharingService.php
+++ b/lib/Service/GroupSharingService.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Service;
+
+use OCP\IConfig;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\Share\IManager as IShareManager;
+
+class GroupSharingService {
+
+	public function __construct(
+		private IConfig $config,
+		private IGroupManager $groupManager,
+		private IShareManager $shareManager,
+	) {
+	}
+
+	public function isGroupSharingAllowed(IUser $user): bool {
+		if (!$this->shareManager->allowGroupSharing()) {
+			return false;
+		}
+
+		$userGroups = $this->groupManager->getUserGroups($user);
+		$userGroupNames = array_map(static fn (IGroup $group) => $group->getGID(), $userGroups);
+
+		$excludeGroupList = json_decode($this->config->getAppValue('core', 'shareapi_exclude_groups_list', '[]'));
+		$excludeGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups');
+
+		// "no"    => Allow sharing for everyone
+		// "yes"   => Exclude listed groups from sharing
+		// "allow" => Limit sharing to listed groups
+		return match ($excludeGroups) {
+			'yes' => count(array_intersect($userGroupNames, $excludeGroupList)) === 0,
+			'allow' => count(array_intersect($userGroupNames, $excludeGroupList)) > 0,
+			default => true,
+		};
+	}
+}

--- a/tests/unit/Controller/PageControllerTest.php
+++ b/tests/unit/Controller/PageControllerTest.php
@@ -8,6 +8,7 @@ namespace OCA\Contacts\Controller;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OC\App\CompareVersion;
+use OCA\Contacts\Service\GroupSharingService;
 use OCA\Contacts\Service\SocialApiService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -46,6 +47,8 @@ class PageControllerTest extends TestCase {
 	/** @var CompareVersion|MockObject */
 	private $compareVersion;
 
+	private GroupSharingService|MockObject $groupSharingService;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -57,6 +60,7 @@ class PageControllerTest extends TestCase {
 		$this->socialApi = $this->createMock(SocialApiService::class);
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->compareVersion = $this->createMock(CompareVersion::class);
+		$this->groupSharingService = $this->createMock(GroupSharingService::class);
 
 		$this->controller = new PageController(
 			$this->request,
@@ -66,7 +70,8 @@ class PageControllerTest extends TestCase {
 			$this->userSession,
 			$this->socialApi,
 			$this->appManager,
-			$this->compareVersion
+			$this->compareVersion,
+			$this->groupSharingService,
 		);
 	}
 

--- a/tests/unit/Service/GroupSharingServiceTest.php
+++ b/tests/unit/Service/GroupSharingServiceTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace unit\Service;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Contacts\Service\GroupSharingService;
+use OCP\IConfig;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\Share\IManager as IShareManager;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class GroupSharingServiceTest extends TestCase {
+	private GroupSharingService $service;
+	private IConfig|MockObject $config;
+	private IGroupManager|MockObject $groupManager;
+	private IShareManager|MockObject $shareManager;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->shareManager = $this->createMock(IShareManager::class);
+
+		$this->service = new GroupSharingService(
+			$this->config,
+			$this->groupManager,
+			$this->shareManager,
+		);
+	}
+
+	public function provideTestIsGroupSharingAllowed(): array {
+		return [
+			// Basic group sharing is forbidden (-> short circuit)
+			[false, false, '["group1"]', 'no'],
+			[false, false, '["group1"]', 'yes'],
+			[false, false, '["group1"]', 'allow'],
+
+			// Basic sharing is allowed and allow sharing with every group
+			[true, true, '["group1"]', 'no'],
+			[true, true, '[]', 'no'],
+			[true, true, '["group99"]', 'no'],
+
+			// Basic sharing is allowed and user's group is excluded
+			[false, true, '["group1"]', 'yes'],
+			[false, true, '["group2"]', 'yes'],
+			[false, true, '["group2", "group3"]', 'yes'],
+
+			// Basic sharing is allowed and user's group is not excluded
+			[true, true, '["group3"]', 'yes'],
+			[true, true, '[]', 'yes'],
+
+			// Basic sharing is allowed and user's group is included
+			[true, true, '["group1"]', 'allow'],
+			[true, true, '["group2"]', 'allow'],
+			[true, true, '["group2", "group3"]', 'allow'],
+
+			// Basic sharing is allowed and user's group is not included
+			[false, true, '["group3"]', 'allow'],
+			[false, true, '[]', 'allow'],
+		];
+	}
+
+	/** @dataProvider provideTestIsGroupSharingAllowed */
+	public function testIsGroupSharingAllowed(
+		bool $expected,
+		bool $allowGroupSharing,
+		string $excludeGroupList,
+		string $excludeGroups,
+	): void {
+		$user = $this->createMock(IUser::class);
+		$group1 = $this->createMock(IGroup::class);
+		$group1->method('getGID')
+			->willReturn('group1');
+		$group2 = $this->createMock(IGroup::class);
+		$group2->method('getGID')
+			->willReturn('group2');
+
+		$this->shareManager->expects(self::once())
+			->method('allowGroupSharing')
+			->willReturn($allowGroupSharing);
+		if ($allowGroupSharing) {
+			$this->groupManager->expects(self::once())
+				->method('getUserGroups')
+				->with($user)
+				->willReturn([$group1, $group2]);
+			$this->config->expects(self::exactly(2))
+				->method('getAppValue')
+				->willReturnMap([
+					['core', 'shareapi_exclude_groups_list', '[]', $excludeGroupList],
+					['core', 'shareapi_exclude_groups', '', $excludeGroups],
+				]);
+		} else {
+			$this->groupManager->expects(self::never())
+				->method('getUserGroups');
+			$this->config->expects(self::never())
+				->method('getAppValue');
+		}
+
+		$actual = $this->service->isGroupSharingAllowed($user);
+		$this->assertEquals($expected, $actual);
+	}
+}


### PR DESCRIPTION
Partially addresses https://github.com/nextcloud/contacts/issues/1139

The DAV backend seems to ignore the setting though. So I think it is still possible to forge a request via curl and share with a group. That needs to be fixed in server.
 
## Screenshots

### Empty search

| Before | After |
| --- | --- |
| ![grafik](https://github.com/user-attachments/assets/e2a6bfc8-ad7f-4dc3-9224-a4bbc2bb9dfd) | ![grafik](https://github.com/user-attachments/assets/658daf35-9b2c-495c-8c3d-14aab17aaf97) |

### Searching for a group (with disabled group sharing)

| Before | After |
| --- | --- |
|![grafik](https://github.com/user-attachments/assets/3aadaf0c-64d0-452b-bd7c-c63d932b881a) | ![grafik](https://github.com/user-attachments/assets/2f2206f9-a134-4988-a751-abbc78e94e2b) |
