### PR TITLE
chore(php-cs-fixer): ignore node_modules

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -16,5 +16,6 @@ $config
 	->notPath('l10n')
 	->notPath('src')
 	->notPath('vendor')
+	->notPath('node_modules')
 	->in(__DIR__);
 return $config;


### PR DESCRIPTION
Ignore `node_modules` when running php-cs-fixer (e.g. `composer run cs:check`).

## Before

1 unrelated error! :cry: 

```
   1) node_modules/flatted/php/flatted.php
      ---------- begin diff ----------
--- /home/richard/src/nextcloud/master/dev_apps/contacts/node_modules/flatted/php/flatted.php
+++ /home/richard/src/nextcloud/master/dev_apps/contacts/node_modules/flatted/php/flatted.php
```

## After

No errors! :smiley: 