### PR TITLE
[main] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3875,9 +3875,9 @@
       }
     },
     "node_modules/@nextcloud/files": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.9.0.tgz",
-      "integrity": "sha512-GKlD8PESRgpP3Rz7xgLbRPXvk1EKStkN8zwM3/L2Dl70g2qkUh1IdEAPZO2KlCdJPD8QxcdK4ib0KClk/ounpA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.9.1.tgz",
+      "integrity": "sha512-eureE0Hi13QhC7detUUlp5B7NjLLu1JnVLDF0yuNv/My5ETbe3SuWjulAXQ2KH3lvqVjhjgbNoEjH5wHemIG+g==",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",
         "@nextcloud/capabilities": "^1.2.0",
@@ -8279,9 +8279,9 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
       "dev": true,
       "dependencies": {
         "bn.js": "^4.11.9",
@@ -22452,9 +22452,9 @@
       }
     },
     "@nextcloud/files": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.9.0.tgz",
-      "integrity": "sha512-GKlD8PESRgpP3Rz7xgLbRPXvk1EKStkN8zwM3/L2Dl70g2qkUh1IdEAPZO2KlCdJPD8QxcdK4ib0KClk/ounpA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.9.1.tgz",
+      "integrity": "sha512-eureE0Hi13QhC7detUUlp5B7NjLLu1JnVLDF0yuNv/My5ETbe3SuWjulAXQ2KH3lvqVjhjgbNoEjH5wHemIG+g==",
       "requires": {
         "@nextcloud/auth": "^2.4.0",
         "@nextcloud/capabilities": "^1.2.0",
@@ -25759,9 +25759,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
       "dev": true,
       "requires": {
         "bn.js": "^4.11.9",


### PR DESCRIPTION
# Audit report

This audit fix resolves 13 of the total 25 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/files](#user-content-\@nextcloud\/files)
* [@nextcloud/moment](#user-content-\@nextcloud\/moment)
* [@nextcloud/vite-config](#user-content-\@nextcloud\/vite-config)
* [@vitejs/plugin-vue2](#user-content-\@vitejs\/plugin-vue2)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [@vue/language-core](#user-content-\@vue\/language-core)
* [elliptic](#user-content-elliptic)
* [postcss](#user-content-postcss)
* [vite-plugin-dts](#user-content-vite-plugin-dts)
* [vue-template-compiler](#user-content-vue-template-compiler)
* [vue-tsc](#user-content-vue-tsc)
* [vuex](#user-content-vuex)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/files](#user-content-\@nextcloud\/files)
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/files <a href="#user-content-\@nextcloud\/files" id="\@nextcloud\/files">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/files`

### @nextcloud/moment <a href="#user-content-\@nextcloud\/moment" id="\@nextcloud\/moment">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.1
* Package usage:
  * `node_modules/@nextcloud/moment`

### @nextcloud/vite-config <a href="#user-content-\@nextcloud\/vite-config" id="\@nextcloud\/vite-config">#</a>
* Caused by vulnerable dependency:
  * [@vitejs/plugin-vue2](#user-content-\@vitejs\/plugin-vue2)
  * [vite-plugin-dts](#user-content-vite-plugin-dts)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/vite-config`

### @vitejs/plugin-vue2 <a href="#user-content-\@vitejs\/plugin-vue2" id="\@vitejs\/plugin-vue2">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: *
* Package usage:
  * `node_modules/@vitejs/plugin-vue2`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### @vue/language-core <a href="#user-content-\@vue\/language-core" id="\@vue\/language-core">#</a>
* Caused by vulnerable dependency:
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=2.0.28
* Package usage:
  * `node_modules/@vue/language-core`

### elliptic <a href="#user-content-elliptic" id="elliptic">#</a>
* Valid ECDSA signatures erroneously rejected in Elliptic
* Severity: **low**
* Reference: [https://github.com/advisories/GHSA-fc9h-whq2-v747](https://github.com/advisories/GHSA-fc9h-whq2-v747)
* Affected versions: <=6.5.7
* Package usage:
  * `node_modules/elliptic`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### vite-plugin-dts <a href="#user-content-vite-plugin-dts" id="vite-plugin-dts">#</a>
* Caused by vulnerable dependency:
  * [@vue/language-core](#user-content-\@vue\/language-core)
  * [vue-tsc](#user-content-vue-tsc)
* Affected versions: 3.0.0-beta.1 - 4.0.0-beta.2
* Package usage:
  * `node_modules/vite-plugin-dts`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`

### vue-tsc <a href="#user-content-vue-tsc" id="vue-tsc">#</a>
* Caused by vulnerable dependency:
  * [@vue/language-core](#user-content-\@vue\/language-core)
* Affected versions: 1.7.0-alpha.0 - 2.0.28
* Package usage:
  * `node_modules/vue-tsc`

### vuex <a href="#user-content-vuex" id="vuex">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 3.1.3 - 3.6.2
* Package usage:
  * `node_modules/vuex`