### PR TITLE
fix: validate group name

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,6 +9,7 @@
 - Christian Kraus <hanzi@hanzi.cc>
 - Christoph Wurst <christoph@winzerhof-wurst.at>
 - Daniel Kesselberg <mail@danielkesselberg.de>
+- Dominik Kuzila <kuziladominik@gmail.com>
 - Gary Kim <gary@garykim.dev>
 - Georg Ehrke <oc.list@georgehrke.com>
 - Greta Doci <gretadoci@gmail.com>

--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -393,10 +393,14 @@ export default {
 
 			this.createGroupError = null
 			this.logger.debug('Created new local group', { groupName })
-			this.$store.dispatch('addGroup', groupName)
-			this.isNewGroupMenuOpen = false
 
-			emit('contacts:group:append', groupName)
+			try {
+				this.$store.dispatch('addGroup', groupName)
+				this.isNewGroupMenuOpen = false
+				emit('contacts:group:append', groupName)
+			} catch (error) {
+				showError(t('contacts', 'An error occurred while creating the group'))
+			}
 		},
 
 		// Ellipsis item toggles

--- a/src/store/groups.js
+++ b/src/store/groups.js
@@ -184,6 +184,9 @@ const actions = {
 	 * @param {string} groupName the name of the group
 	 */
 	addGroup(context, groupName) {
+		if (!groupName || groupName.trim() === '') {
+			throw new Error('Group name cannot be empty')
+		}
 		context.commit('addGroup', groupName)
 	},
 }


### PR DESCRIPTION
Added a validator to addGroup action so that a new group name cannot be an empty string.
#2367