### PR TITLE
Fix: CSS for circles app / add members modal looked weird

### DIFF
--- a/src/components/MembersList/MembersListItem.vue
+++ b/src/components/MembersList/MembersListItem.vue
@@ -347,7 +347,6 @@ export default {
 	display: flex;
 	overflow: hidden;
 	flex-shrink: 0;
-	order: 1;
 	padding-top: 22px;
 	padding-left: 8px;
 	user-select: none;


### PR DESCRIPTION
Before this PR:
<a href="https://github.com/user-attachments/assets/ffddb3e3-52ee-408b-8687-294da6234b8f"><img width=280 srC="https://github.com/user-attachments/assets/ffddb3e3-52ee-408b-8687-294da6234b8f"></a>

After:
<a href="https://github.com/user-attachments/assets/8fbc8725-bbbf-47e1-a5cc-a23d3ab63083"><img width=280 srC="https://github.com/user-attachments/assets/8fbc8725-bbbf-47e1-a5cc-a23d3ab63083"></a>
