### PR TITLE
fix: check if photo property is set before downloading

### DIFF
--- a/src/components/ContactsList/ContactsListItem.vue
+++ b/src/components/ContactsList/ContactsListItem.vue
@@ -141,7 +141,7 @@ export default {
 					return
 				}
 				this.avatarUrl = photoUrl
-			} else if (this.source.url) {
+			} else if (this.source.hasPhoto && this.source.url) {
 				this.avatarUrl = `${this.source.url}?photo`
 			}
 		},

--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -210,6 +210,16 @@ export default class Contact {
 	}
 
 	/**
+	 * Return whether a photo is available
+	 *
+	 * @readonly
+	 * @memberof Contact
+ 	 */
+	get hasPhoto() {
+		return this.dav && this.dav.hasphoto
+	}
+
+	/**
 	 * Return the photo usable url
 	 * We cannot fetch external url because of csp policies
 	 *


### PR DESCRIPTION
Check if has photo DAV property is set to true before trying to download the photo, to stop 404 errors.

Before:
![image](https://github.com/user-attachments/assets/48f8255e-3dd5-41c7-95e6-fca52be0ceef)

After:
![image](https://github.com/user-attachments/assets/8a98cca4-b927-4804-a2ae-51f22129addf)
