### PR TITLE
fix(circles): misaligned member modal headings

### DIFF
--- a/src/components/MembersList/MembersListItem.vue
+++ b/src/components/MembersList/MembersListItem.vue
@@ -347,7 +347,6 @@ export default {
 	display: flex;
 	overflow: hidden;
 	flex-shrink: 0;
-	order: 1;
 	padding-top: 22px;
 	padding-left: 8px;
 	user-select: none;


### PR DESCRIPTION
The headings inside the member modal are misaligned.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/b72af470-3967-468f-9bb1-6885c60df908) | ![image](https://github.com/user-attachments/assets/ae268b8c-0721-47e1-a809-6b9524540b60) |