### PR TITLE
fix: Make circle members visible again by moving them out of the modal

### DIFF
--- a/src/components/AppContent/CircleContent.vue
+++ b/src/components/AppContent/CircleContent.vue
@@ -4,41 +4,20 @@
 -->
 
 <template>
-	<AppContent v-if="!circle">
-		<EmptyContent :name="t('contacts', 'Please select a team')">
+	<AppContent>
+		<EmptyContent v-if="!circle" :name="t('contacts', 'Please select a team')">
 			<template #icon>
 				<AccountGroup :size="20" />
 			</template>
 		</EmptyContent>
-	</AppContent>
 
-	<AppContent v-else-if="loading">
-		<EmptyContent class="empty-content" :name="t('contacts', 'Loading team…')">
+		<EmptyContent v-else-if="loading" class="empty-content" :name="t('contacts', 'Loading team…')">
 			<template #icon>
 				<IconLoading :size="20" />
 			</template>
 		</EmptyContent>
-	</AppContent>
 
-	<AppContent v-else :show-details.sync="showDetails">
-		<!-- main contacts details -->
-		<CircleDetails :circle="circle">
-			<!-- not a member -->
-			<template v-if="!circle.isMember">
-				<!-- Pending request validation -->
-				<EmptyContent v-if="circle.isPendingMember" :name="t('contacts', 'Your request to join this team is pending approval')">
-					<template #icon>
-						<IconLoading :size="20" />
-					</template>
-				</EmptyContent>
-
-				<EmptyContent v-else :name="t('contacts', 'You are not a member of {circle}', { circle: circle.displayName})">
-					<template #icon>
-						<AccountGroup :size="20" />
-					</template>
-				</EmptyContent>
-			</template>
-		</CircleDetails>
+		<CircleDetails v-else :circle="circle" />
 	</AppContent>
 </template>
 <script>
@@ -76,7 +55,6 @@ export default {
 	data() {
 		return {
 			loadingList: false,
-			showDetails: false,
 		}
 	},
 
@@ -129,11 +107,6 @@ export default {
 			} finally {
 				this.loadingList = false
 			}
-		},
-
-		// Hide the circle details
-		hideDetails() {
-			this.showDetails = false
 		},
 	},
 }

--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -72,41 +72,7 @@
 				@update:value="onDescriptionChangeDebounce" />
 		</section>
 
-		<section v-if="circle.isMember" class="circle-details-section">
-			<ContentHeading>
-				{{ t('contacts', 'Members') }}
-			</ContentHeading>
-			<div class="avatar-box">
-				<div ref="avatarList" class="avatar-list">
-					<Avatar v-for="member in membersLimited"
-						:key="member.singleId"
-						:user="member.userId"
-						:display-name="member.displayName"
-						:is-no-user="!member.isUser"
-						:icon-class="member.isUser ? null : 'icon-group-white'"
-						:size="avatarSize" />
-					<Avatar v-if="hasExtraMembers">
-						<template #icon>
-							<DotsHorizontal :size="16" />
-						</template>
-					</Avatar>
-				</div>
-				<Button class="members-button" @click="showMembersModal = true">
-					<template #icon>
-						<AccountMultiplePlus :size="20" />
-					</template>
-					{{ t('contacts', 'Manage members') }}
-				</Button>
-			</div>
-			<Modal v-if="showMembersModal" @close="showMembersModal=false">
-				<div class="members-modal">
-					<h2>{{ t('contacts', 'Team members') }}</h2>
-					<MemberList :list="members" />
-				</div>
-			</Modal>
-		</section>
-
-		<section>
+		<section v-if="circle.isMember">
 			<ContentHeading>
 				{{ t('contacts', 'Team resources') }}
 			</ContentHeading>
@@ -134,6 +100,13 @@
 					</ListItem>
 				</ul>
 			</div>
+		</section>
+
+		<section v-if="members.length > 0">
+			<ContentHeading>
+				{{ t('contacts', 'Team members') }}
+			</ContentHeading>
+			<MemberList :list="members" />
 		</section>
 
 		<Modal v-if="(circle.isOwner || circle.isAdmin) && !circle.isPersonal && showSettingsModal" @close="showSettingsModal=false">
@@ -216,8 +189,6 @@ import Cog from 'vue-material-design-icons/Cog.vue'
 import Login from 'vue-material-design-icons/Login.vue'
 import Logout from 'vue-material-design-icons/Logout.vue'
 import IconDelete from 'vue-material-design-icons/Delete.vue'
-import AccountMultiplePlus from 'vue-material-design-icons/AccountMultiplePlus.vue'
-import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 
 import { CircleEdit, editCircle } from '../services/circles.ts'
 import CircleActionsMixin from '../mixins/CircleActionsMixin.js'
@@ -239,14 +210,12 @@ export default {
 		CirclePasswordSettings,
 		ContentHeading,
 		DetailsHeader,
-		DotsHorizontal,
 		ListItem,
 		Cog,
 		Login,
 		Logout,
 		Modal,
 		IconDelete,
-		AccountMultiplePlus,
 		RichContenteditable,
 	},
 
@@ -445,17 +414,9 @@ export default {
 	gap: 12px;
 }
 
-.members-modal {
-	padding: 12px;
-
-	h2 {
-		margin-bottom: 16px;
-	}
-
-	:deep(.app-content-list) {
-		max-width: 100%;
-		border: 0;
-	}
+:deep(.app-content-list) {
+	max-width: 100%;
+	border: 0;
 }
 
 .circle-settings {

--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<AppContentDetails>
+	<div class="circle-details">
 		<!-- contact header -->
 		<DetailsHeader>
 			<!-- avatar and upload photo -->
@@ -72,7 +72,25 @@
 				@update:value="onDescriptionChangeDebounce" />
 		</section>
 
-		<section v-if="circle.isMember">
+		<!-- not a member -->
+		<template v-if="!circle.isMember">
+			<!-- Pending request validation -->
+			<NcEmptyContent v-if="circle.isPendingMember"
+				:name="t('contacts', 'Your request to join this team is pending approval')">
+				<template #icon>
+					<NcLoadingIcon :size="20" />
+				</template>
+			</NcEmptyContent>
+
+			<NcEmptyContent v-else
+				:name="t('contacts', 'You are not a member of {circle}', { circle: circle.displayName})">
+				<template #icon>
+					<IconAccountGroup :size="20" />
+				</template>
+			</NcEmptyContent>
+		</template>
+
+		<section v-else>
 			<ContentHeading>
 				{{ t('contacts', 'Team resources') }}
 			</ContentHeading>
@@ -102,12 +120,7 @@
 			</div>
 		</section>
 
-		<section v-if="members.length > 0">
-			<ContentHeading>
-				{{ t('contacts', 'Team members') }}
-			</ContentHeading>
-			<MemberList :list="members" />
-		</section>
+		<MemberList v-if="members.length" :list="members" />
 
 		<Modal v-if="(circle.isOwner || circle.isAdmin) && !circle.isPersonal && showSettingsModal" @close="showSettingsModal=false">
 			<div class="circle-settings">
@@ -161,11 +174,7 @@
 				</Button>
 			</div>
 		</Modal>
-
-		<section v-else>
-			<slot />
-		</section>
-	</AppContentDetails>
+	</div>
 </template>
 
 <script>
@@ -177,10 +186,11 @@ import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
 
 import {
-	NcAppContentDetails as AppContentDetails,
 	NcAvatar as Avatar,
 	NcButton as Button,
+	NcEmptyContent,
 	NcListItem as ListItem,
+	NcLoadingIcon,
 	NcModal as Modal,
 	NcRichContenteditable as RichContenteditable,
 } from '@nextcloud/vue'
@@ -189,12 +199,13 @@ import Cog from 'vue-material-design-icons/Cog.vue'
 import Login from 'vue-material-design-icons/Login.vue'
 import Logout from 'vue-material-design-icons/Logout.vue'
 import IconDelete from 'vue-material-design-icons/Delete.vue'
+import IconAccountGroup from 'vue-material-design-icons/AccountGroup.vue'
 
 import { CircleEdit, editCircle } from '../services/circles.ts'
 import CircleActionsMixin from '../mixins/CircleActionsMixin.js'
 import DetailsHeader from './DetailsHeader.vue'
 import CircleConfigs from './CircleDetails/CircleConfigs.vue'
-import MemberList from './MemberList.vue'
+import MemberList from './MemberList/MemberList.vue'
 import ContentHeading from './CircleDetails/ContentHeading.vue'
 import CirclePasswordSettings from './CircleDetails/CirclePasswordSettings.vue'
 
@@ -202,9 +213,7 @@ export default {
 	name: 'CircleDetails',
 
 	components: {
-		AppContentDetails,
 		Avatar,
-		MemberList,
 		Button,
 		CircleConfigs,
 		CirclePasswordSettings,
@@ -212,10 +221,14 @@ export default {
 		DetailsHeader,
 		ListItem,
 		Cog,
+		IconAccountGroup,
+		IconDelete,
 		Login,
 		Logout,
+		MemberList,
 		Modal,
-		IconDelete,
+		NcEmptyContent,
+		NcLoadingIcon,
 		RichContenteditable,
 	},
 
@@ -382,6 +395,10 @@ export default {
 
 .circle-name__loader {
 	margin-left: 8px;
+}
+
+.circle-details {
+	padding-inline: 20px;
 }
 
 .circle-details-section {

--- a/src/components/DetailsHeader.vue
+++ b/src/components/DetailsHeader.vue
@@ -75,6 +75,7 @@ $top-padding: 50px;
 .contact-header {
 	display: flex;
 	align-items: center;
+	flex-wrap: wrap;
 	padding: $top-padding 0 20px;
 	gap: $contact-details-row-gap;
 	&__quick-actions{

--- a/src/components/MemberList.vue
+++ b/src/components/MemberList.vue
@@ -28,7 +28,7 @@
 		</template>
 	</AppContentList>
 
-	<AppContentList v-else :class="{ showdetails: showDetails }">
+	<AppContentList v-else>
 		<div class="members-list__new">
 			<Button v-if="circle.canManageMembers"
 				@click="onShowPicker(circle.id)">
@@ -37,13 +37,6 @@
 					<IconAdd :size="20" />
 				</template>
 				{{ t('contacts', 'Add members') }}
-			</Button>
-			<Button v-if="isMobile"
-				@click="showCircleDetails">
-				<template #icon>
-					<IconInfo :size="20" />
-				</template>
-				{{ t('contacts', 'Show team details') }}
 			</Button>
 		</div>
 
@@ -78,7 +71,6 @@ import MembersListItem from './MembersList/MembersListItem.vue'
 import EntityPicker from './EntityPicker/EntityPicker.vue'
 import IconContact from 'vue-material-design-icons/AccountMultiple.vue'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
-import IconInfo from 'vue-material-design-icons/InformationOutline.vue'
 import RouterMixin from '../mixins/RouterMixin.js'
 
 import { getRecommendations, getSuggestions } from '../services/collaborationAutocompletion.js'
@@ -96,7 +88,6 @@ export default {
 		EmptyContent,
 		IconContact,
 		IconAdd,
-		IconInfo,
 		IconLoading,
 		MembersListItem,
 	},
@@ -109,11 +100,6 @@ export default {
 		},
 
 		loading: {
-			type: Boolean,
-			default: false,
-		},
-
-		showDetails: {
 			type: Boolean,
 			default: false,
 		},
@@ -154,11 +140,15 @@ export default {
 		},
 
 		filteredList() {
+			const groupList = CIRCLES_MEMBER_GROUPING.map((group) => {
+				group.label = group.labelStandalone
+				return group
+			})
 			return Object.keys(this.groupedList)
 				// Object.keys returns string
 				.map(type => parseInt(type, 10))
 				// Map populated types to the group entry
-				.map(type => CIRCLES_MEMBER_GROUPING.find(group => group.type === type))
+				.map(type => groupList.find(group => group.type === type))
 				// Removed undefined group
 				.filter(group => group !== undefined)
 				// Injecting headings
@@ -288,10 +278,6 @@ export default {
 			this.pickerData = []
 			this.pickerSelection = {}
 		},
-
-		showCircleDetails() {
-			this.$emit('update:showDetails', true)
-		},
 	},
 }
 </script>
@@ -304,12 +290,12 @@ export default {
 
 	&__new {
 		padding: 10px;
+		display: inline-flex;
 
 		button {
-			height: 44px;
 			background-position: 14px center;
 			text-align: left;
-			width: 100%;
+
 		}
 	}
 

--- a/src/components/MemberList/MemberListGroup.vue
+++ b/src/components/MemberList/MemberListGroup.vue
@@ -1,0 +1,61 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import type Member from '../../models/member'
+import MemberListItem from './MemberListItem.vue'
+
+defineProps<{
+	label: string
+	type: number
+	members: Member[]
+}>()
+</script>
+
+<template>
+	<div class="member-list-group">
+		<h4 :id="`member-list-group-${type}`"
+			class="member-list-group__heading">
+			{{ label }}
+		</h4>
+		<ul :aria-labelledby="`member-list-group-${type}`" class="member-list-group__list">
+			<MemberListItem v-for="member in members"
+				:key="member.singleId"
+				:source="member" />
+		</ul>
+	</div>
+</template>
+
+<style scoped lang="scss">
+.member-list-group {
+	&__heading {
+		display: flex;
+		overflow: hidden;
+		flex-shrink: 0;
+		padding-top: 22px;
+		padding-inline-start: 8px;
+		margin-bottom: 0;
+		user-select: none;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		font-size: 1.1rem;
+		color: var(--color-primary-element);
+	}
+
+	&__list {
+		-webkit-columns: 2;
+		-moz-columns: 2;
+		columns: 2;
+	}
+}
+
+@media screen and (max-width: 700px) {
+	.member-list-group__list {
+		-webkit-columns: 1;
+		-moz-columns: 1;
+		columns: 1;
+	}
+}
+</style>

--- a/src/components/MemberList/MemberListItem.vue
+++ b/src/components/MemberList/MemberListItem.vue
@@ -4,118 +4,116 @@
 -->
 
 <template>
-	<span v-if="source.heading" class="members-list__heading">
-		{{ source.label }}
-	</span>
-
-	<ListItemIcon v-else
-		:id="source.singleId"
-		:avatar-size="avatarSize"
-		:display-name="source.displayName"
-		:icon-class="source.isUser ? null : 'icon-group-white'"
-		:is-no-user="!source.isUser"
-		:subname="levelName"
+	<NcListItem compact
 		:name="source.displayName"
-		class="members-list__item">
-		<!-- Accept invite -->
-		<template v-if="!loading && isPendingApproval && circle.canManageMembers">
-			<Actions>
-				<ActionButton @click="acceptMember">
-					<template #icon>
-						<IconCheck :size="20" />
-					</template>
-					{{ t('contacts', 'Accept membership request') }}
-				</ActionButton>
-			</Actions>
-			<Actions>
-				<ActionButton @click="deleteMember">
-					<template #icon>
-						<IconClose :size="20" />
-					</template>
-					{{ t('contacts', 'Reject membership request') }}
-				</ActionButton>
-			</Actions>
+		class="members-list-item">
+		<template #icon>
+			<NcAvatar disable-menu
+				:size="avatarSize"
+				:display-name="source.displayName"
+				:is-no-user="!source.isUser" />
 		</template>
 
-		<Actions v-else @close="onMenuClose">
-			<ActionText v-if="loading" icon="icon-loading-small">
+		<!-- Level -->
+		<template #subname>
+			{{ levelName }}
+		</template>
+
+		<!-- Accept invite -->
+		<template v-if="!loading && isPendingApproval && circle.canManageMembers" #extra-actions>
+			<NcButton @click="acceptMember">
+				<template #icon>
+					<IconCheck :size="20" />
+				</template>
+				{{ t('contacts', 'Accept membership request') }}
+			</NcButton>
+			<NcButton @click="deleteMember">
+				<template #icon>
+					<IconClose :size="20" />
+				</template>
+				{{ t('contacts', 'Reject membership request') }}
+			</NcButton>
+		</template>
+
+		<template v-else #actions>
+			<NcActionText v-if="loading" icon="icon-loading-small">
 				{{ t('contacts', 'Loading …') }}
-			</ActionText>
+			</NcActionText>
 
 			<!-- Normal menu -->
 			<template v-else>
 				<!-- Level picker -->
 				<template v-if="canChangeLevel">
-					<ActionText>
+					<NcActionText>
 						{{ t('contacts', 'Manage level') }}
 						<template #icon>
-							<ShieldCheck :size="16" />
+							<IconShieldCheck :size="16" />
 						</template>
-					</ActionText>
-					<ActionButton v-for="level in availableLevelsChange"
+					</NcActionText>
+					<NcActionButton v-for="level in availableLevelsChange"
 						:key="level"
 						icon=""
 						@click="changeLevel(level)">
 						{{ levelChangeLabel(level) }}
-					</ActionButton>
+					</NcActionButton>
 
-					<ActionSeparator />
+					<NcActionSeparator />
 				</template>
 
 				<!-- Leave or delete member from circle -->
-				<ActionButton v-if="isCurrentUser && !circle.isOwner" @click="deleteMember">
+				<NcActionButton v-if="isCurrentUser && !circle.isOwner" @click="deleteMember">
 					{{ t('contacts', 'Leave team') }}
 					<template #icon>
-						<ExitToApp :size="16" />
+						<IconExitToApp :size="16" />
 					</template>
-				</ActionButton>
-				<ActionButton v-else-if="canDelete" @click="deleteMember">
+				</NcActionButton>
+				<NcActionButton v-else-if="canDelete" @click="deleteMember">
 					<template #icon>
 						<IconDelete :size="20" />
 					</template>
 					{{ t('contacts', 'Remove member') }}
-				</ActionButton>
+				</NcActionButton>
 			</template>
-		</Actions>
-	</ListItemIcon>
+		</template>
+	</NcListItem>
 </template>
 
 <script>
 import { CIRCLES_MEMBER_LEVELS, MemberLevels, MemberStatus } from '../../models/constants.ts'
 
 import {
-	NcActions as Actions,
-	NcListItemIcon as ListItemIcon,
-	NcActionSeparator as ActionSeparator,
-	NcActionButton as ActionButton,
-	NcActionText as ActionText,
+	NcAvatar,
+	NcListItem,
+	NcActionSeparator,
+	NcActionButton,
+	NcActionText,
 } from '@nextcloud/vue'
-import IconDelete from 'vue-material-design-icons/Delete.vue'
 import IconCheck from 'vue-material-design-icons/Check.vue'
 import IconClose from 'vue-material-design-icons/Close.vue'
-
-import ExitToApp from 'vue-material-design-icons/ExitToApp.vue'
-import ShieldCheck from 'vue-material-design-icons/ShieldCheck.vue'
+import IconDelete from 'vue-material-design-icons/Delete.vue'
+import IconExitToApp from 'vue-material-design-icons/ExitToApp.vue'
+import IconShieldCheck from 'vue-material-design-icons/ShieldCheck.vue'
 
 import { changeMemberLevel } from '../../services/circles.ts'
 import { showError } from '@nextcloud/dialogs'
 import RouterMixin from '../../mixins/RouterMixin.js'
 
 export default {
-	name: 'MembersListItem',
+	name: 'MemberListItem',
 
 	components: {
-		Actions,
-		ActionButton,
-		ActionSeparator,
-		ActionText,
-		IconDelete,
 		IconCheck,
 		IconClose,
-		ExitToApp,
-		ListItemIcon,
-		ShieldCheck,
+		IconDelete,
+		IconExitToApp,
+		IconShieldCheck,
+		NcListItem,
+		NcActionButton,
+		NcActionSeparator,
+		NcActionText,
+		NcAvatar,
 	},
+
 	mixins: [RouterMixin],
 
 	props: {
@@ -342,32 +340,10 @@ export default {
 	},
 }
 </script>
-<style lang="scss">
-.members-list__heading {
-	display: flex;
-	overflow: hidden;
-	flex-shrink: 0;
-	padding-top: 22px;
-	padding-left: 8px;
-	user-select: none;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	pointer-events: none;
-	color: var(--color-primary-element);
-	line-height: 22px;
-}
 
-.members-list__item {
-	padding: 8px;
+<style lang="scss">
+.members-list-item {
 	user-select: none;
 	box-sizing: border-box;
-	margin-bottom: 8px;
-	border-radius: var(--border-radius-rounded);
-
-	&:focus,
-	&:hover {
-		background-color: var(--color-background-hover);
-	}
 }
-
 </style>

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -111,18 +111,20 @@ export const PUBLIC_CIRCLE_CONFIG = {
 	},
 }
 
-// Represents the picker options but also the
-// sorting of the members list
+// Represents the picker options (label is used lower case in a list of options: Search users, groups, teams, ...)
+// labelStandalone is used as heading for the member list where we need it starting captialized
 export const CIRCLES_MEMBER_GROUPING = [
 	{
 		id: `picker-${ShareType.User}`,
 		label: t('contacts', 'users'),
+		labelStandalone: t('contacts', 'Users'),
 		share: ShareType.User,
 		type: MEMBER_TYPE_USER,
 	},
 	{
 		id: `picker-${ShareType.Group}`,
 		label: t('contacts', 'groups'),
+		labelStandalone: t('contacts', 'Groups'),
 		share: ShareType.Group,
 		type: MEMBER_TYPE_GROUP,
 	},
@@ -142,19 +144,22 @@ export const CIRCLES_MEMBER_GROUPING = [
 	{
 		id: `picker-${ShareType.Team}`,
 		label: t('contacts', 'teams'),
+		labelStandalone: t('contacts', 'Teams'),
 		share: ShareType.Team,
 		type: MEMBER_TYPE_CIRCLE,
 	},
 	{
 		id: `picker-${ShareType.Email}`,
 		label: t('contacts', 'email addresses'),
+		labelStandalone: t('contacts', 'Email addresses'),
 		share: ShareType.Email,
 		type: MEMBER_TYPE_MAIL,
 	},
 	// TODO: implement SHARE_TYPE_CONTACT
 	{
 		id: 'picker-contact',
-		label: t('contacts', 'teams'),
+		label: t('contacts', 'contacts'),
+		labelStandalone: t('contacts', 'Contacts'),
 		share: ShareType.Email,
 		type: MEMBER_TYPE_CONTACT,
 	},

--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -214,7 +214,7 @@ export default class Contact {
 	 *
 	 * @readonly
 	 * @memberof Contact
- 	 */
+	 */
 	get hasPhoto() {
 		return this.dav && this.dav.hasphoto
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,14 @@
 {
 	"compilerOptions": {
-		"module": "ES6",
-		"moduleResolution": "node",
-		"target": "ES6",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ESNext",
 		"strictNullChecks": true,
 		"sourceMap": true,
 		"allowSyntheticDefaultImports": true,
 		"declaration": true,
 	},
-    "include": [
-        "./src/**/*"
-    ]
+	"include": [
+		"./src/**/*"
+	]
 }


### PR DESCRIPTION
As discussed between @sorbaugh and @jancborchardt this moves the team member list out of the modal and onto the team page again.

![Screenshot 2025-02-07 at 09 58 57](https://github.com/user-attachments/assets/94dbe145-5085-47e6-b336-a179b84c20b9)

