### PR TITLE
fix: fix team members colum layout in chromium based browsers

### DIFF
--- a/src/components/MemberList/MemberListItem.vue
+++ b/src/components/MemberList/MemberListItem.vue
@@ -345,5 +345,6 @@ export default {
 .members-list-item {
 	user-select: none;
 	box-sizing: border-box;
+	page-break-inside: avoid;
 }
 </style>


### PR DESCRIPTION
Looks like chrome has some issues, taken the solution from https://stackoverflow.com/questions/3322891/why-is-chrome-cutting-off-text-in-my-css3-multi-column-layout.

Before:

![Screenshot_20250312_195902](https://github.com/user-attachments/assets/62b9c420-b375-4dcb-80de-5420b3660d95)

After: 

![Screenshot_20250312_195706](https://github.com/user-attachments/assets/65166d82-5c27-4da4-85ea-94d2612c1895)
