### PR TITLE
feat: exchange cloud ID

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -49,6 +49,8 @@
 
 	<background-jobs>
 		<job>OCA\Contacts\Cron\SocialUpdateRegistration</job>
+		<job>OCA\Contacts\Cron\UpdateOcmProviders</job>
+		<job>OCA\Contacts\Cron\UpdateDeltaOcmProviders</job>
 	</background-jobs>
 
 	<settings>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -7,10 +7,13 @@
 namespace OCA\Contacts\AppInfo;
 
 use OCA\Contacts\Capabilities;
+use OCA\Contacts\ConfigLexicon;
 use OCA\Contacts\Dav\PatchPlugin;
 use OCA\Contacts\Event\LoadContactsOcaApiEvent;
+use OCA\Contacts\Listener\FederatedInviteAcceptedListener;
 use OCA\Contacts\Listener\LoadContactsFilesActions;
 use OCA\Contacts\Listener\LoadContactsOcaApi;
+use OCA\Contacts\Listener\OcmDiscoveryListener;
 use OCA\DAV\Events\SabrePluginAddEvent;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCP\AppFramework\App;
@@ -18,6 +21,9 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\OCM\Events\LocalOCMDiscoveryEvent;
+use OCP\OCM\Events\OCMEndpointRequestEvent;
+use OCP\OCM\Events\ResourceTypeRegisterEvent;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'contacts';
@@ -33,8 +39,15 @@ class Application extends App implements IBootstrap {
 	#[\Override]
 	public function register(IRegistrationContext $context): void {
 		$context->registerCapability(Capabilities::class);
+		$context->registerConfigLexicon(ConfigLexicon::class);
+
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LoadContactsFilesActions::class);
 		$context->registerEventListener(LoadContactsOcaApiEvent::class, LoadContactsOcaApi::class);
+		$context->registerEventListener(OCMEndpointRequestEvent::class, FederatedInviteAcceptedListener::class);
+		$ocmDiscoveryEvent = class_exists(LocalOCMDiscoveryEvent::class)
+			? LocalOCMDiscoveryEvent::class
+			: ResourceTypeRegisterEvent::class;
+		$context->registerEventListener($ocmDiscoveryEvent, OcmDiscoveryListener::class);
 	}
 
 	#[\Override]

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -4,13 +4,17 @@
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Contacts\AppInfo;
 
 use OCA\Contacts\Capabilities;
+use OCA\Contacts\ConfigLexicon;
 use OCA\Contacts\Dav\PatchPlugin;
 use OCA\Contacts\Event\LoadContactsOcaApiEvent;
+use OCA\Contacts\Listener\FederatedInviteAcceptedListener;
 use OCA\Contacts\Listener\LoadContactsFilesActions;
 use OCA\Contacts\Listener\LoadContactsOcaApi;
+use OCA\Contacts\Listener\OcmDiscoveryListener;
 use OCA\DAV\Events\SabrePluginAddEvent;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCP\AppFramework\App;
@@ -18,6 +22,9 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\OCM\Events\LocalOCMDiscoveryEvent;
+use OCP\OCM\Events\OCMEndpointRequestEvent;
+use OCP\OCM\Events\ResourceTypeRegisterEvent;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'contacts';
@@ -37,8 +44,15 @@ class Application extends App implements IBootstrap {
 	#[\Override]
 	public function register(IRegistrationContext $context): void {
 		$context->registerCapability(Capabilities::class);
+		$context->registerConfigLexicon(ConfigLexicon::class);
+
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LoadContactsFilesActions::class);
 		$context->registerEventListener(LoadContactsOcaApiEvent::class, LoadContactsOcaApi::class);
+		$context->registerEventListener(OCMEndpointRequestEvent::class, FederatedInviteAcceptedListener::class);
+		$ocmDiscoveryEvent = class_exists(LocalOCMDiscoveryEvent::class)
+			? LocalOCMDiscoveryEvent::class
+			: ResourceTypeRegisterEvent::class;
+		$context->registerEventListener($ocmDiscoveryEvent, OcmDiscoveryListener::class);
 	}
 
 	#[\Override]

--- a/lib/ConfigLexicon.php
+++ b/lib/ConfigLexicon.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts;
+
+use OCP\Config\Lexicon\Entry;
+use OCP\Config\Lexicon\ILexicon;
+use OCP\Config\Lexicon\Strictness;
+use OCP\Config\ValueType;
+use OCP\IAppConfig;
+
+/**
+ * Config Lexicon for contacts.
+ *
+ * Please add and manage your config keys in this file and keep the
+ * Lexicon up to date.
+ *
+ * {@see ILexicon}
+ */
+class ConfigLexicon implements ILexicon {
+	public const OCM_INVITES_ENABLED = 'ocm_invites_enabled';
+	public const OCM_INVITES_OPTIONAL_MAIL = 'ocm_invites_optional_mail';
+	public const OCM_INVITES_ENCODED_COPY_BUTTON = 'ocm_invites_encoded_copy_button';
+	public const OCM_INVITES_DISABLE_SSRF_GUARD = 'ocm_invites_disable_ssrf_guard';
+	public const MESH_PROVIDERS_SERVICE = 'mesh_providers_service';
+	public const WAYF_ENDPOINT = 'wayf_endpoint';
+	public const FEDERATIONS_CACHE = 'federations_cache';
+	public const FEDERATIONS_CACHE_EXPIRES = 'expires';
+	public const FEDERATIONS_CACHE_DELTA_EXPIRES = 'delta_expires';
+
+	#[\Override]
+	public function getStrictness(): Strictness {
+		return Strictness::NOTICE;
+	}
+
+	#[\Override]
+	public function getAppConfigs(): array {
+		return [
+			new Entry(
+				self::OCM_INVITES_ENABLED,
+				ValueType::BOOL,
+				defaultRaw: false,
+				definition: 'Whether OCM invites for contacts are enabled.',
+				lazy: true,
+			),
+			new Entry(
+				self::OCM_INVITES_OPTIONAL_MAIL,
+				ValueType::BOOL,
+				defaultRaw: false,
+				definition: 'Whether the recipient email field is optional when creating an OCM invite.',
+				lazy: true,
+			),
+			new Entry(
+				self::OCM_INVITES_ENCODED_COPY_BUTTON,
+				ValueType::BOOL,
+				defaultRaw: false,
+				definition: 'Whether the invite email "Open invite" button uses the encoded WAYF URL instead of the raw token.',
+				lazy: true,
+			),
+			new Entry(
+				self::OCM_INVITES_DISABLE_SSRF_GUARD,
+				ValueType::BOOL,
+				defaultRaw: false,
+				definition: 'Unsafe development override that disables private-host and localhost checks for OCM invite discovery.',
+				lazy: true,
+			),
+			new Entry(
+				self::MESH_PROVIDERS_SERVICE,
+				ValueType::STRING,
+				defaultRaw: '',
+				definition: 'Space-separated list of mesh provider service URLs used for WAYF discovery.',
+				lazy: true,
+			),
+			new Entry(
+				self::WAYF_ENDPOINT,
+				ValueType::STRING,
+				defaultRaw: '',
+				definition: 'Optional override for the base WAYF endpoint used in invite links.',
+				note: 'If empty, the app route is used at runtime.',
+				lazy: true,
+			),
+			new Entry(
+				self::FEDERATIONS_CACHE,
+				ValueType::ARRAY,
+				defaultRaw: [],
+				definition: 'Internal cron-maintained cache for discovered federations and expiry metadata.',
+				flags: IAppConfig::FLAG_SENSITIVE,
+				lazy: true,
+			),
+			new Entry(
+				self::FEDERATIONS_CACHE_EXPIRES,
+				ValueType::INT,
+				defaultRaw: 0,
+				definition: 'Federations cache refresh expiration time.',
+				lazy: true,
+			),
+			new Entry(
+				self::FEDERATIONS_CACHE_DELTA_EXPIRES,
+				ValueType::INT,
+				defaultRaw: 0,
+				definition: 'Federations cache update (delta) expiration time.',
+				lazy: true,
+			),
+		];
+	}
+
+	#[\Override]
+	public function getUserConfigs(): array {
+		return [];
+	}
+}

--- a/lib/Controller/ContactsController.php
+++ b/lib/Controller/ContactsController.php
@@ -24,7 +24,6 @@ class ContactsController extends Controller {
 		parent::__construct(Application::APP_ID, $request);
 	}
 
-
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
@@ -43,7 +42,6 @@ class ContactsController extends Controller {
 		);
 		return new RedirectResponse($url);
 	}
-
 
 	/**
 	 * @NoAdminRequired

--- a/lib/Controller/FederatedInvitesController.php
+++ b/lib/Controller/FederatedInvitesController.php
@@ -1,0 +1,985 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Controller;
+
+use Exception;
+use GuzzleHttp\Exception\RequestException;
+use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\Db\FederatedInvite;
+use OCA\Contacts\Db\FederatedInviteMapper;
+use OCA\Contacts\Exception\ContactAlreadyExistsException;
+use OCA\Contacts\Service\FederatedInvitesService;
+use OCA\Contacts\WayfProvider;
+use OCA\FederatedFileSharing\AddressHandler;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
+use OCP\AppFramework\Http\Attribute\BruteForceProtection;
+use OCP\AppFramework\Http\Attribute\FrontpageRoute;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\Attribute\UserRateLimit;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Defaults;
+use OCP\Http\Client\IClientService;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+use OCP\Mail\IMailer;
+use OCP\Mail\IMessage;
+use OCP\OCM\Exceptions\OCMProviderException;
+use OCP\OCM\Exceptions\OCMRequestException;
+use OCP\OCM\IOCMDiscoveryService;
+use OCP\Util;
+use Psr\Log\LoggerInterface;
+use Sabre\DAV\UUIDUtil;
+use Throwable;
+
+/**
+ * Controller for federated invites related routes.
+ *
+ */
+
+class FederatedInvitesController extends Controller {
+	public function __construct(
+		IRequest $request,
+		private AddressHandler $addressHandler,
+		private Defaults $defaults,
+		private FederatedInviteMapper $federatedInviteMapper,
+		private FederatedInvitesService $federatedInvitesService,
+		private IClientService $httpClient,
+		private IInitialState $initialState,
+		private IMailer $mailer,
+		private IOCMDiscoveryService $discovery,
+		private IUserSession $userSession,
+		private WayfProvider $wayfProvider,
+		private ITimeFactory $timeFactory,
+		private IL10N $il10,
+		private IURLGenerator $urlGenerator,
+		private LoggerInterface $logger,
+	) {
+		parent::__construct(Application::APP_ID, $request);
+	}
+
+	/**
+	 * Returns all open (not yet accepted) invites.
+	 *
+	 * @return JSONResponse
+	 */
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'GET', url: '/ocm/invitations')]
+	public function getInvites(): JSONResponse {
+		if (($disabled = $this->requireOcmInvitesEnabled()) !== null) {
+			return $disabled;
+		}
+
+		$uid = $this->userSession->getUser()->getUID();
+		try {
+			$_invites = $this->federatedInviteMapper->findOpenInvitesByUid($uid);
+			$invites = [];
+			foreach ($_invites as $invite) {
+				if ($invite instanceof FederatedInvite) {
+					array_push(
+						$invites,
+						$invite->jsonSerialize()
+					);
+				}
+			}
+			return new JSONResponse($invites, Http::STATUS_OK);
+		} catch (Exception $e) {
+			$this->logger->error("An unexpected error occurred loading invites for user with uid=$uid. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			return new JSONResponse([
+				'code' => 'ocm_invites_fetch_failed',
+				'message' => 'Could not load invites.',
+			], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * Deletes the invite with the specified token.
+	 *
+	 * @param string $token the token of the invite to delete
+	 * @return JSONResponse with data signature ['token' | 'message'] - the token of the deleted invitation or an error message in case of error
+	 */
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'DELETE', url: '/ocm/invitations/{token}')]
+	public function deleteInvite(string $token): JSONResponse {
+		if (($disabled = $this->requireOcmInvitesEnabled()) !== null) {
+			return $disabled;
+		}
+
+		$uid = $this->userSession->getUser()->getUID();
+		try {
+			$invite = $this->federatedInviteMapper->findInviteByTokenAndUid($token, $uid);
+			$this->federatedInviteMapper->delete($invite);
+			return new JSONResponse(['token' => $token], Http::STATUS_OK);
+		} catch (DoesNotExistException $e) {
+			$this->logger->warning("Could not find invite with token=$token for user with uid=$uid", ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'Invite not found'], Http::STATUS_NOT_FOUND);
+		} catch (Exception $e) {
+			$this->logger->error("An unexpected error occurred deleting invite with token=$token. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'An unexpected error occurred trying to delete the invite'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * Results in displaying the invite accept dialog upon following the invite link
+	 * by redirecting to the index page with the required invite accept dialog parameters.
+	 *
+	 * @param string $token
+	 * @param string $providerDomain
+	 * @return RedirectResponse
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[FrontpageRoute(verb: 'GET', url: FederatedInvitesService::OCM_INVITE_ACCEPT_DIALOG_ROUTE)]
+	public function inviteAcceptDialog(string $token = '', string $providerDomain = ''): RedirectResponse {
+		return new RedirectResponse($this->urlGenerator->linkToRoute('contacts.page.index', [
+			'token' => $token,
+			'providerDomain' => $providerDomain,
+		]));
+	}
+
+	/**
+	 * Creates an invitation to exchange contact info with the remote user.
+	 *
+	 * @param string $email the recipient email address to send the invitation to (optional)
+	 * @param string $message the optional message to send with the invitation
+	 * @return JSONResponse with data signature ['invite' | 'message'] - the invite url or an error message in case of error.
+	 */
+	#[NoAdminRequired]
+	#[UserRateLimit(limit: 60, period: 3600)]
+	#[BruteForceProtection(action: 'ocmInviteCreate')]
+	#[FrontpageRoute(verb: 'POST', url: '/ocm/invitations')]
+	public function createInvite(string $email = '', string $message = ''): JSONResponse {
+		if (($disabled = $this->requireOcmInvitesEnabled()) !== null) {
+			return $disabled;
+		}
+
+		// Enforce email required when optional mail is disabled
+		if (empty($email) && !$this->federatedInvitesService->isOptionalMailEnabled()) {
+			return new JSONResponse(['message' => $this->il10->t('Email address is required.')], Http::STATUS_BAD_REQUEST);
+		}
+
+		$uid = $this->userSession->getUser()->getUID();
+		if (!empty($email)) {
+			$validationError = $this->validateEmail($email);
+			if ($validationError !== null) {
+				return $validationError;
+			}
+
+			$this->cleanupSupersededInvitesForRecipient($uid, $email);
+
+			// check for existing open invite for the specified email, only if email provided
+			$existingInvites = $this->federatedInviteMapper->findOpenInvitesByRecipientEmail(
+				$uid,
+				$email,
+			);
+			if (count($existingInvites) > 0) {
+				$this->logger->error("An open invite already exists for user with uid $uid and for recipient email $email", ['app' => Application::APP_ID]);
+				return new JSONResponse(['message' => $this->il10->t('An open invite already exists.')], Http::STATUS_CONFLICT);
+			}
+		}
+
+		$invite = new FederatedInvite();
+		$invite->setUserId($uid);
+		$token = UUIDUtil::getUUID();
+		$invite->setToken($token);
+		// created-/expiredAt in seconds
+		$invite->setCreatedAt($this->timeFactory->now()->getTimestamp());
+		$invite->setExpiredAt($this->federatedInvitesService->getInviteExpirationDate($invite->getCreatedAt()));
+		if (!empty($email)) {
+			$invite->setRecipientEmail($email);
+		}
+		$invite->setAccepted(false);
+		$inserted = false;
+		try {
+			$this->federatedInviteMapper->insert($invite);
+			$inserted = true;
+		} catch (Throwable $e) {
+			if ($this->isDuplicateConstraintException($e)) {
+				if (!empty($email) && $this->cleanupSupersededInvitesForRecipient($uid, $email) > 0) {
+					try {
+						$this->federatedInviteMapper->insert($invite);
+						$inserted = true;
+					} catch (Throwable $retry) {
+						if (!$this->isDuplicateConstraintException($retry)) {
+							$this->logger->error('An unexpected error occurred saving a new invite after stale cleanup. Stacktrace: ' . $retry->getTraceAsString(), ['app' => Application::APP_ID]);
+							return new JSONResponse(['message' => 'An unexpected error occurred creating the invite.'], Http::STATUS_INTERNAL_SERVER_ERROR);
+						}
+					}
+				}
+				if (!$inserted) {
+					return new JSONResponse(['message' => $this->il10->t('An open invite already exists.')], Http::STATUS_CONFLICT);
+				}
+			} else {
+				$this->logger->error('An unexpected error occurred saving a new invite. Stacktrace: ' . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+				return new JSONResponse(['message' => 'An unexpected error occurred creating the invite.'], Http::STATUS_INTERNAL_SERVER_ERROR);
+			}
+		}
+		$senderProvider = $this->federatedInvitesService->getProviderFQDN();
+
+		// Only send email if email address provided
+		if (!empty($email)) {
+			/** @var JSONResponse */
+			$response = $this->sendInvitationEmail($token, $senderProvider, $email, $message);
+			if ($response->getStatus() !== Http::STATUS_OK) {
+				// delete invite in case sending the email has failed
+				try {
+					$this->federatedInviteMapper->delete($invite);
+				} catch (Exception $e) {
+					$this->logger->error("An unexpected error occurred deleting invite with token $token. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+					return new JSONResponse(['message' => 'An unexpected error occurred creating the invite.'], Http::STATUS_INTERNAL_SERVER_ERROR);
+				}
+				return $response;
+			}
+		}
+
+		// invite url, use token instead of email for routing
+		$inviteUrl = $this->urlGenerator->getAbsoluteURL(
+			$this->urlGenerator->linkToRoute('contacts.page.index') . 'ocm-invites/' . $token
+		);
+		return new JSONResponse(['invite' => $inviteUrl], Http::STATUS_OK);
+	}
+
+	/**
+	 * Accepts the invite and creates a new contact from the inviter.
+	 * On success the user is redirected to the new contact url.
+	 *
+	 * @param string $token the token of the invite
+	 * @param string $provider the provider of the sender of the invite
+	 * @return JSONResponse with data signature ['contact' | 'message'] - the new contact url or an error message in case of error
+	 */
+	#[NoAdminRequired]
+	#[UserRateLimit(limit: 60, period: 3600)]
+	#[BruteForceProtection(action: 'ocmInviteAccept')]
+	#[FrontpageRoute(verb: 'PATCH', url: '/ocm/invitations/{token}/accept')]
+	public function acceptInvite(string $token = '', string $provider = ''): JSONResponse {
+		if (($disabled = $this->requireOcmInvitesEnabled()) !== null) {
+			return $disabled;
+		}
+
+		if ($token === '' || $provider === '') {
+			$this->logger->error("Both token and provider must be specified. Received: token=$token, provider=$provider", ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'Both invite code and provider must be specified.'], Http::STATUS_BAD_REQUEST);
+		}
+		$localUser = $this->userSession->getUser();
+		if ($localUser === null) {
+			return new JSONResponse(['message' => $this->il10->t('Could not accept invite because no authenticated user was found.')], Http::STATUS_UNAUTHORIZED);
+		}
+		$provider = $this->normalizeProviderBase($provider);
+		if ($provider === null) {
+			return new JSONResponse(['message' => $this->il10->t('The invite provider is invalid or not allowed.')], Http::STATUS_BAD_REQUEST);
+		}
+		$recipientProviderFqdn = $this->federatedInvitesService->getProviderFQDN();
+		// do not accept an invite from this instance
+		$senderProviderFqdn = parse_url($provider)['host'];
+		$this->logger->debug("acceptInvite() - $recipientProviderFqdn === $senderProviderFqdn");
+		if ($recipientProviderFqdn === $senderProviderFqdn) {
+			return new JSONResponse(['message' => $this->il10->t('Unable to accept this invitation. You are trying to accept an outgoing invitation.')], Http::STATUS_BAD_REQUEST);
+		}
+		$userId = $localUser->getUID();
+		$email = $localUser->getEMailAddress();
+		$name = $localUser->getDisplayName();
+		if ($recipientProviderFqdn === '' || $userId === '' || $email === '' || $name === '') {
+			$this->logger->error("All of these must be set: recipientProvider: $recipientProviderFqdn, email: $email, userId: $userId, name: $name", ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'Could not accept invite, user data is incomplete.'], Http::STATUS_UNPROCESSABLE_ENTITY);
+		}
+		$cloudId = '';
+		try {
+			// accept the invite by calling provider OCM /invite-accepted
+			// this returns a response with the following data signature: ['userID', 'email', 'name']
+			// @link https://cs3org.github.io/OCM-API/docs.html?branch=v1.1.0&repo=OCM-API&user=cs3org#/paths/~1invite-accepted/post
+			$client = $this->httpClient->newClient();
+			/**
+			 * @var \OCP\OCM\ICapabilityAwareOCMProvider $discovered
+			 *
+			 */
+			$discovered = $this->discovery->discover($provider);
+			if (
+				$discovered->hasCapability('invites')
+				|| $discovered->hasCapability('invite-accepted')
+				|| $discovered->hasCapability('/invite-accepted')
+			) {
+
+				$response = $this->discovery->requestRemoteOcmEndpoint(
+					null,
+					$provider,
+					'/invite-accepted',
+					[
+						'recipientProvider' => $recipientProviderFqdn,
+						'token' => $token,
+						'userID' => $userId,
+						'email' => $email,
+						'name' => $name
+					],
+					'POST',
+					$client
+				);
+				$responseData = $response->getBody();
+				$data = json_decode($responseData, true);
+				if (
+					!is_array($data)
+					|| !isset($data['userID'], $data['email'], $data['name'])
+					|| !is_string($data['userID'])
+					|| !is_string($data['email'])
+					|| !is_string($data['name'])
+					|| trim($data['userID']) === ''
+					|| trim($data['email']) === ''
+					|| trim($data['name']) === ''
+				) {
+					$this->logger->warning('Invalid /invite-accepted payload from provider', [
+						'app' => Application::APP_ID,
+						'provider' => $provider,
+						'payload' => $responseData,
+					]);
+					return new JSONResponse(['message' => $this->il10->t('Could not accept invite because the remote provider returned an invalid response.')], Http::STATUS_BAD_GATEWAY);
+				}
+
+				$cloudId = $data['userID'] . '@' . $this->addressHandler->removeProtocolFromUrl($provider);
+
+				$contactRef = $this->federatedInvitesService->createNewContact(
+					$cloudId,
+					$data['email'],
+					$data['name'],
+					null
+				);
+				if (!isset($contactRef)) {
+					$this->logger->error('Remote invite acceptance succeeded but local contact creation failed', [
+						'app' => Application::APP_ID,
+						'token' => $token,
+						'provider' => $provider,
+						'cloudId' => $cloudId,
+						'userId' => $userId,
+					]);
+					return new JSONResponse([
+						'code' => 'ocm_invite_local_contact_create_failed',
+						'message' => $this->il10->t('The remote provider accepted the invite, but this server could not create the local contact.'),
+					], Http::STATUS_BAD_GATEWAY);
+				}
+				$key = base64_encode($contactRef);
+				$contactUrl = $this->urlGenerator->getAbsoluteURL(
+					$this->urlGenerator->linkToRoute('contacts.page.index') . $this->il10->t('All contacts') . '/' . $key
+				);
+				return new JSONResponse(['contact' => $contactUrl], Http::STATUS_OK);
+			} else {
+				$this->logger->error('Provider: ' . $provider . ' does not support invites.', ['app' => Application::APP_ID]);
+				return new JSONResponse(['message' => 'Provider: ' . $provider . ' does not support invites.'], Http::STATUS_BAD_REQUEST);
+			}
+		} catch (ContactAlreadyExistsException $e) {
+			return new JSONResponse(['message' => 'Contact with cloudID ' . $cloudId . ' already exists.'], Http::STATUS_CONFLICT);
+		} catch (RequestException $e) { // this should catch OCM API request exceptions
+			$this->logger->error('/invite-accepted returned an error: ' . $e->getMessage(), ['app' => Application::APP_ID]);
+			/**
+			 * 400: Invalid or non existing token
+			 * 409: Invite already accepted
+			 */
+			$statusCode = $e->getResponse() !== null
+				? $e->getResponse()->getStatusCode()
+				: null;
+			switch ($statusCode) {
+				case Http::STATUS_BAD_REQUEST:
+					return new JSONResponse(['message' => 'Invalid, non-existing, or expired invite code.'], Http::STATUS_BAD_REQUEST);
+				case Http::STATUS_CONFLICT:
+					return new JSONResponse(['message' => 'Invite already accepted'], Http::STATUS_CONFLICT);
+			}
+			$this->logger->error("An unexpected error occurred accepting invite with token=$token and provider=$provider. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'An unexpected error occurred trying to accept invite.'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		} catch (OCMProviderException|OCMRequestException|Exception $e) {
+			$this->logger->error("An unexpected error occurred accepting invite with token=$token and provider=$provider. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'An unexpected error occurred trying to accept invite'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * Re-sends an existing invite email while preserving invite lifetime metadata.
+	 *
+	 */
+	#[NoAdminRequired]
+	#[UserRateLimit(limit: 30, period: 3600)]
+	#[BruteForceProtection(action: 'ocmInviteResend')]
+	#[FrontpageRoute(verb: 'PATCH', url: '/ocm/invitations/{token}/resend')]
+	public function resendInvite(string $token): JSONResponse {
+		if (($disabled = $this->requireOcmInvitesEnabled()) !== null) {
+			return $disabled;
+		}
+
+		$uid = $this->userSession->getUser()->getUID();
+		try {
+			$invite = $this->federatedInviteMapper->findInviteByTokenAndUid($token, $uid);
+		} catch (DoesNotExistException $e) {
+			$this->logger->warning("Could not find invite with token=$token for user with uid=$uid", ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'Invite not found'], Http::STATUS_NOT_FOUND);
+		} catch (Exception $e) {
+			$this->logger->error("An unexpected error occurred loading invite with token=$token. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'An unexpected error occurred trying to resend the invite'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+
+		// Cannot resend if no email address
+		if (empty($invite->getRecipientEmail())) {
+			return new JSONResponse(['message' => $this->il10->t('Cannot resend: no email address')], Http::STATUS_UNPROCESSABLE_ENTITY);
+		}
+		if ($this->isInviteAccepted($invite)) {
+			return new JSONResponse([
+				'code' => 'ocm_invite_already_accepted',
+				'message' => $this->il10->t('Invite has already been accepted.'),
+			], Http::STATUS_CONFLICT);
+		}
+		if ($this->isInviteExpired($invite)) {
+			return new JSONResponse([
+				'code' => 'ocm_invite_expired',
+				'message' => $this->il10->t('Invite has expired. Please create a new one.'),
+			], Http::STATUS_GONE);
+		}
+
+		$sendDate = date('Y-m-d', $invite->getCreatedAt());
+		$initiatorDisplayName = $this->userSession->getUser()->getDisplayName();
+		// a resend notification that refers to the previously sent invite
+		$message = $this->il10->t(
+			'This is a copy of an invite sent to you previously by %1$s on %2$s',
+			[
+				$initiatorDisplayName,
+				$sendDate
+			]
+		);
+		$senderProvider = $this->federatedInvitesService->getProviderFQDN();
+		/** @var JSONResponse */
+		$response = $this->sendInvitationEmail($token, $senderProvider, $invite->getRecipientEmail(), $message);
+		if ($response->getStatus() !== Http::STATUS_OK) {
+			$this->logger->error("An unexpected error occurred resending the invite with token $token. HTTP response status: " . $response->getStatus(), ['app' => Application::APP_ID]);
+			return $response;
+		}
+
+		// the invite url, use token instead of email for routing
+		$inviteUrl = $this->urlGenerator->getAbsoluteURL(
+			$this->urlGenerator->linkToRoute('contacts.page.index') . 'ocm-invites/' . $invite->getToken()
+		);
+		return new JSONResponse(['invite' => $inviteUrl], Http::STATUS_OK);
+	}
+
+	/**
+	 * Attaches a recipient email to an existing link-only invite and sends the
+	 * invitation email. Refreshes the creation and expiration timestamps so the
+	 * recipient receives a fresh expiry window. Reverts both the email and the
+	 * timestamps if the mailer fails, so a failed call leaves the invite as it
+	 * was before.
+	 *
+	 * @param string $token the invite token
+	 * @param string $email the recipient email address
+	 * @param string $message the optional message to include in the email
+	 * @return JSONResponse the serialized invite on success or an error message
+	 */
+	#[NoAdminRequired]
+	#[UserRateLimit(limit: 30, period: 3600)]
+	#[BruteForceProtection(action: 'ocmInviteAttachEmail')]
+	#[FrontpageRoute(verb: 'PATCH', url: '/ocm/invitations/{token}/email')]
+	public function attachEmailAndSend(string $token, string $email = '', string $message = ''): JSONResponse {
+		if (($disabled = $this->requireOcmInvitesEnabled()) !== null) {
+			return $disabled;
+		}
+
+		$uid = $this->userSession->getUser()->getUID();
+		try {
+			$invite = $this->federatedInviteMapper->findInviteByTokenAndUid($token, $uid);
+		} catch (DoesNotExistException $e) {
+			$this->logger->warning("Could not find invite with token=$token for user with uid=$uid", ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'Invite not found'], Http::STATUS_NOT_FOUND);
+		} catch (Exception $e) {
+			$this->logger->error("An unexpected error occurred loading invite with token=$token. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'An unexpected error occurred attaching the email.'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+
+		if ($this->isInviteAccepted($invite)) {
+			return new JSONResponse([
+				'code' => 'ocm_invite_already_accepted',
+				'message' => $this->il10->t('Invite has already been accepted.'),
+			], Http::STATUS_CONFLICT);
+		}
+		if (!empty($invite->getRecipientEmail())) {
+			return new JSONResponse([
+				'code' => 'ocm_invite_already_has_email',
+				'message' => $this->il10->t('Invite already has an email address.'),
+			], Http::STATUS_CONFLICT);
+		}
+
+		if (empty($email)) {
+			return new JSONResponse([
+				'code' => 'ocm_invite_email_required',
+				'message' => $this->il10->t('Email address is required.'),
+			], Http::STATUS_BAD_REQUEST);
+		}
+		$validationError = $this->validateEmail($email);
+		if ($validationError !== null) {
+			return $validationError;
+		}
+
+		$this->cleanupSupersededInvitesForRecipient($uid, $email);
+
+		// Reject when another open invite from this user already targets the same email.
+		// The current invite is excluded by construction: it has no recipient_email yet
+		// and findOpenInvitesByRecipientEmail() filters by recipient_email.
+		$existingInvites = $this->federatedInviteMapper->findOpenInvitesByRecipientEmail($uid, $email);
+		if (count($existingInvites) > 0) {
+			$this->logger->error("An open invite already exists for user with uid $uid and for recipient email $email", ['app' => Application::APP_ID]);
+			return new JSONResponse([
+				'code' => 'ocm_invite_duplicate_recipient_email',
+				'message' => $this->il10->t('An open invite for this email already exists.'),
+			], Http::STATUS_CONFLICT);
+		}
+
+		$previousCreatedAt = $invite->getCreatedAt();
+		$previousExpiredAt = $invite->getExpiredAt();
+		$newCreatedAt = $this->timeFactory->now()->getTimestamp();
+		$newExpiredAt = $this->federatedInvitesService->getInviteExpirationDate($newCreatedAt);
+
+		try {
+			$claimed = $this->federatedInviteMapper->claimInviteForEmail(
+				$token,
+				$uid,
+				$email,
+				$newCreatedAt,
+				$newExpiredAt,
+			);
+		} catch (Exception $e) {
+			$this->logger->error("An unexpected error occurred claiming invite with token=$token. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			return new JSONResponse([
+				'code' => 'ocm_invite_claim_exception',
+				'message' => 'An unexpected error occurred attaching the email.',
+			], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+
+		if ($claimed === false) {
+			// A concurrent attach won the race or the invite was accepted between
+			// the read and the conditional update. Treat as a 409 collision so the
+			// client can refresh and decide what to do next.
+			return new JSONResponse([
+				'code' => 'ocm_invite_claim_failed',
+				'message' => $this->il10->t('Could not claim invite for this email; please refresh and try again.'),
+			], Http::STATUS_CONFLICT);
+		}
+
+		$invite->setRecipientEmail($email);
+		$invite->setCreatedAt($newCreatedAt);
+		$invite->setExpiredAt($newExpiredAt);
+
+		$senderProvider = $this->federatedInvitesService->getProviderFQDN();
+		/** @var JSONResponse */
+		$response = $this->sendInvitationEmail($token, $senderProvider, $email, $message);
+		if ($response->getStatus() !== Http::STATUS_OK) {
+			$this->logger->error("An unexpected error occurred sending the invite with token $token. HTTP response status: " . $response->getStatus(), ['app' => Application::APP_ID]);
+			$reverted = false;
+			try {
+				$reverted = $this->federatedInviteMapper->revertInviteEmail(
+					$token,
+					$uid,
+					$email,
+					$previousCreatedAt,
+					$previousExpiredAt,
+				);
+			} catch (Exception $e) {
+				$this->logger->error("Could not revert invite with token=$token after mailer failure. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			}
+			if ($reverted !== true) {
+				$mailFailure = $response->getData();
+				$mailMessage = is_array($mailFailure) && isset($mailFailure['message']) && is_string($mailFailure['message'])
+					? $mailFailure['message']
+					: null;
+				return new JSONResponse([
+					'code' => 'ocm_invite_revert_failed',
+					'message' => $this->il10->t('Could not revert invite after delivery failure. Please refresh and try again.'),
+					'mailError' => $mailMessage,
+				], $response->getStatus());
+			}
+			return $response;
+		}
+
+		return new JSONResponse($invite->jsonSerialize(), Http::STATUS_OK);
+	}
+
+	/**
+	 * Do OCM discovery on behalf of VUE frontend to avoid CSRF issues
+	 * @param string $base base url to discover
+	 * @return DataResponse
+	 */
+	#[PublicPage]
+	#[AnonRateLimit(limit: 120, period: 3600)]
+	#[UserRateLimit(limit: 120, period: 3600)]
+	#[BruteForceProtection(action: 'ocmInviteDiscover')]
+	#[FrontpageRoute(verb: 'GET', url: '/discover')]
+	public function discover(string $base): DataResponse {
+		if (!$this->federatedInvitesService->isOcmInvitesEnabled()) {
+			return new DataResponse([
+				'code' => 'ocm_invites_disabled',
+				'error' => $this->il10->t('OCM invites are disabled.'),
+			], Http::STATUS_FORBIDDEN);
+		}
+
+		$base = $this->normalizeProviderBase($base);
+		if ($base === null) {
+			return new DataResponse(['error' => 'invalid base'], Http::STATUS_BAD_REQUEST);
+		}
+
+		try {
+			/**
+			 * @var \OCP\OCM\ICapabilityAwareOCMProvider $provider
+			 *
+			 */
+			$provider = $this->discovery->discover($base);
+			$dialog = trim($provider->getInviteAcceptDialog());
+			$absolute = $dialog === '' ? null : $this->buildInviteAcceptDialogAbsolute($base, $dialog);
+			if ($absolute === null) {
+				$dialog = $this->wayfProvider->getInviteAcceptDialogPath();
+				$absolute = $this->buildInviteAcceptDialogAbsolute($base, $dialog);
+			}
+			if ($absolute === null) {
+				return new DataResponse(['error' => 'OCM discovery failed', 'base' => $base], Http::STATUS_NOT_FOUND);
+			}
+
+			$baseHost = parse_url($base, PHP_URL_HOST);
+			return new DataResponse([
+				'base' => $base,
+				'inviteAcceptDialog' => $dialog,
+				'inviteAcceptDialogAbsolute' => $absolute,
+				'providerDomain' => is_string($baseHost) ? $baseHost : '',
+			], Http::STATUS_OK);
+		} catch (Throwable $e) {
+			$this->logger->warning('OCM discovery failed', [
+				'app' => Application::APP_ID,
+				'base' => $base,
+				'exception' => $e,
+			]);
+			return new DataResponse(['error' => 'OCM discovery failed', 'base' => $base], Http::STATUS_NOT_FOUND);
+		}
+	}
+
+	/**
+	 * Display the wayf page.
+	 *
+	 * @param string $token the token of the invite
+	 * @return TemplateResponse the WAYF page
+	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
+	#[FrontpageRoute(verb: 'GET', url: '/wayf')]
+	public function wayf(string $token = ''): TemplateResponse {
+		Util::addScript(Application::APP_ID, 'contacts-wayf');
+		Util::addStyle(Application::APP_ID, 'contacts-wayf');
+		try {
+			$federations = $this->wayfProvider->getMeshProviders();
+			$providerDomain = trim((string)$this->request->getParam('providerDomain', ''));
+			if ($providerDomain === '') {
+				$baseHost = parse_url($this->urlGenerator->getBaseUrl(), PHP_URL_HOST);
+				$providerDomain = is_string($baseHost) ? $baseHost : '';
+			}
+			$this->initialState->provideInitialState('wayf', [
+				'federations' => $federations,
+				'providerDomain' => $providerDomain,
+				'token' => $token,
+			]);
+		} catch (Exception $e) {
+			$this->logger->error($e->getMessage() . ' Trace: ' . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+		}
+		$template = new TemplateResponse('contacts', 'wayf', [], TemplateResponse::RENDER_AS_GUEST);
+		return $template;
+	}
+
+	/**
+	 * Persist an OCM invite bool admin setting. Admin-only by default since the
+	 * method is not marked with NoAdminRequired.
+	 *
+	 * @param string $key one of FederatedInvitesService::OCM_INVITES_BOOL_KEYS
+	 * @param bool $value the new value
+	 * @return JSONResponse empty body with the appropriate HTTP status
+	 */
+	#[FrontpageRoute(verb: 'PUT', url: '/ocm/admin/settings/{key}')]
+	public function setOcmInviteBoolSetting(string $key, bool $value): JSONResponse {
+		if (!$this->federatedInvitesService->setOcmInviteBoolSetting($key, $value)) {
+			return new JSONResponse(['message' => 'Unknown setting key'], Http::STATUS_FORBIDDEN);
+		}
+		return new JSONResponse([], Http::STATUS_OK);
+	}
+
+	/**
+	 * Validate a recipient email address against the configured mailer.
+	 *
+	 * @return JSONResponse|null Error response on invalid input, null when valid.
+	 */
+	private function validateEmail(string $address): ?JSONResponse {
+		if (!$this->mailer->validateMailAddress($address)) {
+			$this->logger->debug("Invalid recipient email address '$address'", ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => $this->il10->t('Recipient email address is invalid.')], Http::STATUS_UNPROCESSABLE_ENTITY);
+		}
+		return null;
+	}
+
+	/**
+	 * @param string $token the invite token
+	 * @param string $senderProvider this provider
+	 * @param string $recipientEmail the recipient email address to send the invitation to
+	 * @param string $message the optional message to send with the invitation
+	 * @param bool $isSenderCopy if true than a this is a copy of the invitation to be sent to the inviter
+	 * @return JSONResponse
+	 */
+	private function sendInvitationEmail(string $token, string $senderProvider, string $recipientEmail, string $message, bool $isSenderCopy = false): JSONResponse {
+		$validationError = $this->validateEmail($recipientEmail);
+		if ($validationError !== null) {
+			return $validationError;
+		}
+		/** @var IMessage */
+		$email = $this->mailer->createMessage();
+		$toAddress = $isSenderCopy ? $this->userSession->getUser()->getEMailAddress() : $recipientEmail;
+		$email->setTo([$toAddress]);
+
+		$instanceName = $this->defaults->getName();
+		$initiatorDisplayName = $this->userSession->getUser()->getDisplayName();
+		$senderName = $this->il10->t(
+			'%1$s via %2$s',
+			[
+				$initiatorDisplayName,
+				$instanceName
+			]
+		);
+		$email->setFrom([Util::getDefaultEmailAddress($instanceName) => $senderName]);
+		$subjectPrefix = $isSenderCopy ? '[Copy] ' : '';
+		$subject = $this->il10->t($subjectPrefix . '%1$s invites you to exchange contact information.', [$initiatorDisplayName]);
+		$email->setSubject($subject);
+
+		$wayfEndpoint = $this->wayfProvider->getWayfEndpoint();
+		if (empty($wayfEndpoint)) {
+			$this->logger->error('Invalid WAYF endpoint (null).', ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'Could not send invite.'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+		$inviteLink = $this->buildWayfInviteLink($wayfEndpoint, $token, $senderProvider);
+		$encoded = base64_encode("$token@$senderProvider");
+
+		$initiatorDisplayNameH = htmlspecialchars($initiatorDisplayName, ENT_QUOTES, 'UTF-8');
+		$inviteLinkH = htmlspecialchars($inviteLink, ENT_QUOTES, 'UTF-8');
+		$tokenSenderH = htmlspecialchars("$token@$senderProvider", ENT_QUOTES, 'UTF-8');
+		$encodedH = htmlspecialchars($encoded, ENT_QUOTES, 'UTF-8');
+		$messageH = nl2br(htmlspecialchars($message, ENT_QUOTES, 'UTF-8'), false);
+
+		$header = $isSenderCopy
+			? $this->il10->t('This is a copy of the invitation you\'ve sent to %1$s', [htmlspecialchars($recipientEmail, ENT_QUOTES, 'UTF-8')])
+			: '';
+		$greeting = $this->il10->t('Hi there,', []);
+		$explanationLine1 = $this->il10->t('%1$s invites you to exchange cloud accounts and contact information.', [$initiatorDisplayNameH]);
+		$explanationLine2 = $this->il10->t('This will allow you to share data with each other.', []);
+		$htmlHeader = $header === '' ? $header : "$header<br><hr><br>";
+		$htmlInvitation = "$htmlHeader$greeting<br><br>$explanationLine1<br>$explanationLine2";
+		$htmlPersonalMessage = trim($message) === '' ? '' : "<br>---<br>$messageH<br>---<br>";
+
+		$inviteLinkNote = $this->il10->t('To accept this invite, click the link below and sign in with your cloud provider:', []);
+		$htmlInviteLink = "<a href=\"$inviteLinkH\">$inviteLinkH</a>";
+
+		$technicalDetailsNote = $this->il10->t('Invitation details:', []);
+		$technicalDetailsInviteCode = $this->il10->t('Invite code: %1$s', [$tokenSenderH]);
+		$technicalDetailsEncodedInvite = $this->il10->t('Encoded invite: %1$s', [$encodedH]);
+		$htmlTechnicalDetails = "<small>$technicalDetailsNote<br>$technicalDetailsInviteCode<br>$technicalDetailsEncodedInvite</small>";
+		$htmlBody = "$htmlInvitation<br>$htmlPersonalMessage<br>$inviteLinkNote<br>$htmlInviteLink<br><br>$htmlTechnicalDetails";
+		$email->setHtmlBody($htmlBody);
+
+		$plainHeader = $header === '' ? $header : "$header\n---------\n\n";
+		$plainInvitation = "$plainHeader$greeting\n\n$explanationLine1\n$explanationLine2";
+		$plainPersonalMessage = trim($message) === '' ? '' : "\n---\n$message\n---\n";
+		$plainInviteLinkNote = $this->il10->t('To accept this invite, use the url below to sign in with your cloud provider:', []);
+		$plainTechnicalDetails = "$technicalDetailsNote\n$technicalDetailsInviteCode\n$technicalDetailsEncodedInvite";
+
+		$plainBody = "$plainInvitation\n$plainPersonalMessage\n$plainInviteLinkNote\n$inviteLink\n\n$plainTechnicalDetails\n";
+		$email->setPlainBody($plainBody);
+
+		try {
+			/** @var string[] $failedRecipients */
+			$failedRecipients = $this->mailer->send($email);
+		} catch (\Throwable $e) {
+			$this->logger->error("Mail transport failure while sending invite to '$toAddress': " . $e->getMessage(), [
+				'app' => Application::APP_ID,
+				'exception' => $e,
+			]);
+			return new JSONResponse(['message' => "Could not send invite to '$toAddress'"], Http::STATUS_BAD_GATEWAY);
+		}
+
+		if (!empty($failedRecipients)) {
+			$this->logger->error("Could not send invite to '$toAddress'", ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => "Could not send invite to '$toAddress'"], Http::STATUS_BAD_GATEWAY);
+		}
+
+		return new JSONResponse([], Http::STATUS_OK);
+	}
+
+	private function normalizeProviderBase(string $provider): ?string {
+		$candidate = trim($provider);
+		if ($candidate === '') {
+			return null;
+		}
+		if (!preg_match('#^https?://#i', $candidate)) {
+			$candidate = 'https://' . $candidate;
+		}
+
+		$parts = parse_url($candidate);
+		if (!is_array($parts) || !isset($parts['scheme'], $parts['host'])) {
+			return null;
+		}
+
+		$scheme = strtolower($parts['scheme']);
+		if (!in_array($scheme, ['http', 'https'], true)) {
+			return null;
+		}
+
+		$host = strtolower($parts['host']);
+		if ($host === '') {
+			return null;
+		}
+		if (!$this->federatedInvitesService->isSsrfGuardDisabled() && $this->isBlockedDiscoveryHost($host)) {
+			return null;
+		}
+
+		$port = '';
+		if (isset($parts['port'])) {
+			$portNumber = $parts['port'];
+			if ($portNumber < 1 || $portNumber > 65535) {
+				return null;
+			}
+			$port = ':' . $portNumber;
+		}
+
+		$path = '';
+		if (isset($parts['path']) && $parts['path'] !== '') {
+			$path = '/' . trim($parts['path'], '/');
+			$path = rtrim($path, '/');
+		}
+
+		return $scheme . '://' . $host . $port . $path;
+	}
+
+	private function isBlockedDiscoveryHost(string $host): bool {
+		$normalizedHost = strtolower(trim($host));
+		if ($normalizedHost === 'localhost' || str_ends_with($normalizedHost, '.localhost')) {
+			return true;
+		}
+
+		if (filter_var($normalizedHost, FILTER_VALIDATE_IP) === false) {
+			return false;
+		}
+
+		return filter_var(
+			$normalizedHost,
+			FILTER_VALIDATE_IP,
+			FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+		) === false;
+	}
+
+	private function buildInviteAcceptDialogAbsolute(string $base, string $dialog): ?string {
+		$trimmedDialog = trim($dialog);
+		if ($trimmedDialog === '') {
+			return null;
+		}
+
+		$baseParts = parse_url($base);
+		if (!is_array($baseParts) || !isset($baseParts['scheme'], $baseParts['host'])) {
+			return null;
+		}
+
+		if (preg_match('#^https?://#i', $trimmedDialog)) {
+			$dialogUrl = $this->normalizeProviderBase($trimmedDialog);
+			if ($dialogUrl === null) {
+				return null;
+			}
+			$dialogParts = parse_url($dialogUrl);
+			if (!is_array($dialogParts) || !isset($dialogParts['host'])) {
+				return null;
+			}
+
+			$basePort = $baseParts['port'] ?? null;
+			$dialogPort = $dialogParts['port'] ?? null;
+			if (strtolower($dialogParts['host']) !== strtolower($baseParts['host']) || $basePort !== $dialogPort) {
+				return null;
+			}
+
+			return $dialogUrl;
+		}
+
+		$origin = $baseParts['scheme'] . '://' . $baseParts['host'];
+		if (isset($baseParts['port'])) {
+			$origin .= ':' . $baseParts['port'];
+		}
+
+		if (str_starts_with($trimmedDialog, '/')) {
+			return $origin . $trimmedDialog;
+		}
+
+		return rtrim($base, '/') . '/' . ltrim($trimmedDialog, '/');
+	}
+
+	private function buildWayfInviteLink(string $wayfEndpoint, string $token, string $senderProvider): string {
+		$separator = str_contains($wayfEndpoint, '?') ? '&' : '?';
+		$query = http_build_query([
+			'token' => $token,
+			'providerDomain' => $senderProvider,
+		], '', '&', PHP_QUERY_RFC3986);
+		return $wayfEndpoint . $separator . $query;
+	}
+
+	private function requireOcmInvitesEnabled(): ?JSONResponse {
+		if ($this->federatedInvitesService->isOcmInvitesEnabled()) {
+			return null;
+		}
+
+		return new JSONResponse([
+			'code' => 'ocm_invites_disabled',
+			'message' => $this->il10->t('OCM invites are disabled.'),
+		], Http::STATUS_FORBIDDEN);
+	}
+
+	private function cleanupSupersededInvitesForRecipient(string $uid, string $email): int {
+		if ($email === '') {
+			return 0;
+		}
+
+		try {
+			return $this->federatedInviteMapper->deleteSupersededInvitesForRecipientEmail(
+				$uid,
+				$email,
+				$this->timeFactory->now()->getTimestamp(),
+			);
+		} catch (Exception $e) {
+			$this->logger->warning('Could not clean up superseded invites for recipient email.', [
+				'app' => Application::APP_ID,
+				'userId' => $uid,
+				'email' => $email,
+				'exception' => $e,
+			]);
+			return 0;
+		}
+	}
+
+	private function isInviteAccepted(FederatedInvite $invite): bool {
+		return $invite->isAccepted() === true || $invite->getAcceptedAt() !== null;
+	}
+
+	private function isInviteExpired(FederatedInvite $invite): bool {
+		$expiredAt = $invite->getExpiredAt();
+		return $expiredAt !== null && $expiredAt <= $this->timeFactory->now()->getTimestamp();
+	}
+
+	private function isDuplicateConstraintException(Throwable $e): bool {
+		$message = strtolower($e->getMessage());
+		return str_contains($message, 'duplicate')
+			|| str_contains($message, 'unique')
+			|| str_contains($message, 'constraint');
+	}
+}

--- a/lib/Controller/FederatedInvitesController.php
+++ b/lib/Controller/FederatedInvitesController.php
@@ -1,0 +1,985 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Controller;
+
+use Exception;
+use GuzzleHttp\Exception\RequestException;
+use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\Db\FederatedInvite;
+use OCA\Contacts\Db\FederatedInviteMapper;
+use OCA\Contacts\Exception\ContactAlreadyExistsException;
+use OCA\Contacts\Service\FederatedInvitesService;
+use OCA\Contacts\WayfProvider;
+use OCA\FederatedFileSharing\AddressHandler;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
+use OCP\AppFramework\Http\Attribute\BruteForceProtection;
+use OCP\AppFramework\Http\Attribute\FrontpageRoute;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\Attribute\UserRateLimit;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Defaults;
+use OCP\Http\Client\IClientService;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+use OCP\Mail\IMailer;
+use OCP\Mail\IMessage;
+use OCP\OCM\Exceptions\OCMProviderException;
+use OCP\OCM\Exceptions\OCMRequestException;
+use OCP\OCM\IOCMDiscoveryService;
+use OCP\Util;
+use Psr\Log\LoggerInterface;
+use Sabre\DAV\UUIDUtil;
+use Throwable;
+
+/**
+ * Controller for federated invites related routes.
+ *
+ */
+
+class FederatedInvitesController extends Controller {
+	public function __construct(
+		IRequest $request,
+		private AddressHandler $addressHandler,
+		private Defaults $defaults,
+		private FederatedInviteMapper $federatedInviteMapper,
+		private FederatedInvitesService $federatedInvitesService,
+		private IClientService $httpClient,
+		private IInitialState $initialState,
+		private IMailer $mailer,
+		private IOCMDiscoveryService $discovery,
+		private IUserSession $userSession,
+		private WayfProvider $wayfProvider,
+		private ITimeFactory $timeFactory,
+		private IL10N $il10,
+		private IURLGenerator $urlGenerator,
+		private LoggerInterface $logger,
+	) {
+		parent::__construct(Application::APP_ID, $request);
+	}
+
+	/**
+	 * Returns all open (not yet accepted) invites.
+	 *
+	 * @return JSONResponse
+	 */
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'GET', url: '/ocm/invitations')]
+	public function getInvites(): JSONResponse {
+		if (($disabled = $this->requireOcmInvitesEnabled()) !== null) {
+			return $disabled;
+		}
+
+		$uid = $this->userSession->getUser()->getUID();
+		try {
+			$_invites = $this->federatedInviteMapper->findOpenInvitesByUid($uid);
+			$invites = [];
+			foreach ($_invites as $invite) {
+				if ($invite instanceof FederatedInvite) {
+					array_push(
+						$invites,
+						$invite->jsonSerialize()
+					);
+				}
+			}
+			return new JSONResponse($invites, Http::STATUS_OK);
+		} catch (Exception $e) {
+			$this->logger->error("An unexpected error occurred loading invites for user with uid=$uid. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			return new JSONResponse([
+				'code' => 'ocm_invites_fetch_failed',
+				'message' => 'Could not load invites.',
+			], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * Deletes the invite with the specified token.
+	 *
+	 * @param string $token the token of the invite to delete
+	 * @return JSONResponse with data signature ['token' | 'message'] - the token of the deleted invitation or an error message in case of error
+	 */
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'DELETE', url: '/ocm/invitations/{token}')]
+	public function deleteInvite(string $token): JSONResponse {
+		if (($disabled = $this->requireOcmInvitesEnabled()) !== null) {
+			return $disabled;
+		}
+
+		$uid = $this->userSession->getUser()->getUID();
+		try {
+			$invite = $this->federatedInviteMapper->findInviteByTokenAndUid($token, $uid);
+			$this->federatedInviteMapper->delete($invite);
+			return new JSONResponse(['token' => $token], Http::STATUS_OK);
+		} catch (DoesNotExistException $e) {
+			$this->logger->warning("Could not find invite with token=$token for user with uid=$uid", ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'Invite not found'], Http::STATUS_NOT_FOUND);
+		} catch (Exception $e) {
+			$this->logger->error("An unexpected error occurred deleting invite with token=$token. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'An unexpected error occurred trying to delete the invite'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * Results in displaying the invite accept dialog upon following the invite link
+	 * by redirecting to the index page with the required invite accept dialog parameters.
+	 *
+	 * @param string $token
+	 * @param string $providerDomain
+	 * @return RedirectResponse
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[FrontpageRoute(verb: 'GET', url: FederatedInvitesService::OCM_INVITE_ACCEPT_DIALOG_ROUTE)]
+	public function inviteAcceptDialog(string $token = '', string $providerDomain = ''): RedirectResponse {
+		return new RedirectResponse($this->urlGenerator->linkToRoute('contacts.page.index', [
+			'token' => $token,
+			'providerDomain' => $providerDomain,
+		]));
+	}
+
+	/**
+	 * Creates an invitation to exchange contact info with the remote user.
+	 *
+	 * @param string $email the recipient email address to send the invitation to (optional)
+	 * @param string $message the optional message to send with the invitation
+	 * @return JSONResponse with data signature ['invite' | 'message'] - the invite url or an error message in case of error.
+	 */
+	#[NoAdminRequired]
+	#[UserRateLimit(limit: 60, period: 3600)]
+	#[BruteForceProtection(action: 'ocmInviteCreate')]
+	#[FrontpageRoute(verb: 'POST', url: '/ocm/invitations')]
+	public function createInvite(string $email = '', string $message = ''): JSONResponse {
+		if (($disabled = $this->requireOcmInvitesEnabled()) !== null) {
+			return $disabled;
+		}
+
+		// Enforce email required when optional mail is disabled
+		if (empty($email) && !$this->federatedInvitesService->isOptionalMailEnabled()) {
+			return new JSONResponse(['message' => $this->il10->t('Email address is required.')], Http::STATUS_BAD_REQUEST);
+		}
+
+		$uid = $this->userSession->getUser()->getUID();
+		if (!empty($email)) {
+			$validationError = $this->validateEmail($email);
+			if ($validationError !== null) {
+				return $validationError;
+			}
+
+			$this->cleanupSupersededInvitesForRecipient($uid, $email);
+
+			// check for existing open invite for the specified email, only if email provided
+			$existingInvites = $this->federatedInviteMapper->findOpenInvitesByRecipientEmail(
+				$uid,
+				$email,
+			);
+			if (count($existingInvites) > 0) {
+				$this->logger->error("An open invite already exists for user with uid $uid and for recipient email $email", ['app' => Application::APP_ID]);
+				return new JSONResponse(['message' => $this->il10->t('An open invite already exists.')], Http::STATUS_CONFLICT);
+			}
+		}
+
+		$invite = new FederatedInvite();
+		$invite->setUserId($uid);
+		$token = UUIDUtil::getUUID();
+		$invite->setToken($token);
+		// created-/expiredAt in seconds
+		$invite->setCreatedAt($this->timeFactory->now()->getTimestamp());
+		$invite->setExpiredAt($this->federatedInvitesService->getInviteExpirationDate($invite->getCreatedAt()));
+		if (!empty($email)) {
+			$invite->setRecipientEmail($email);
+		}
+		$invite->setAccepted(false);
+		$inserted = false;
+		try {
+			$this->federatedInviteMapper->insert($invite);
+			$inserted = true;
+		} catch (Throwable $e) {
+			if ($this->isDuplicateConstraintException($e)) {
+				if (!empty($email) && $this->cleanupSupersededInvitesForRecipient($uid, $email) > 0) {
+					try {
+						$this->federatedInviteMapper->insert($invite);
+						$inserted = true;
+					} catch (Throwable $retry) {
+						if (!$this->isDuplicateConstraintException($retry)) {
+							$this->logger->error('An unexpected error occurred saving a new invite after stale cleanup. Stacktrace: ' . $retry->getTraceAsString(), ['app' => Application::APP_ID]);
+							return new JSONResponse(['message' => 'An unexpected error occurred creating the invite.'], Http::STATUS_INTERNAL_SERVER_ERROR);
+						}
+					}
+				}
+				if (!$inserted) {
+					return new JSONResponse(['message' => $this->il10->t('An open invite already exists.')], Http::STATUS_CONFLICT);
+				}
+			} else {
+				$this->logger->error('An unexpected error occurred saving a new invite. Stacktrace: ' . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+				return new JSONResponse(['message' => 'An unexpected error occurred creating the invite.'], Http::STATUS_INTERNAL_SERVER_ERROR);
+			}
+		}
+		$senderProvider = $this->federatedInvitesService->getProviderFQDN();
+
+		// Only send email if email address provided
+		if (!empty($email)) {
+			/** @var JSONResponse */
+			$response = $this->sendInvitationEmail($token, $senderProvider, $email, $message);
+			if ($response->getStatus() !== Http::STATUS_OK) {
+				// delete invite in case sending the email has failed
+				try {
+					$this->federatedInviteMapper->delete($invite);
+				} catch (Exception $e) {
+					$this->logger->error("An unexpected error occurred deleting invite with token $token. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+					return new JSONResponse(['message' => 'An unexpected error occurred creating the invite.'], Http::STATUS_INTERNAL_SERVER_ERROR);
+				}
+				return $response;
+			}
+		}
+
+		// invite url, use token instead of email for routing
+		$inviteUrl = $this->urlGenerator->getAbsoluteURL(
+			$this->urlGenerator->linkToRoute('contacts.page.index') . 'ocm-invites/' . $token
+		);
+		return new JSONResponse(['invite' => $inviteUrl], Http::STATUS_OK);
+	}
+
+	/**
+	 * Accepts the invite and creates a new contact from the inviter.
+	 * On success the user is redirected to the new contact url.
+	 *
+	 * @param string $token the token of the invite
+	 * @param string $provider the provider of the sender of the invite
+	 * @return JSONResponse with data signature ['contact' | 'message'] - the new contact url or an error message in case of error
+	 */
+	#[NoAdminRequired]
+	#[UserRateLimit(limit: 60, period: 3600)]
+	#[BruteForceProtection(action: 'ocmInviteAccept')]
+	#[FrontpageRoute(verb: 'PATCH', url: '/ocm/invitations/{token}/accept')]
+	public function acceptInvite(string $token = '', string $provider = ''): JSONResponse {
+		if (($disabled = $this->requireOcmInvitesEnabled()) !== null) {
+			return $disabled;
+		}
+
+		if ($token === '' || $provider === '') {
+			$this->logger->error("Both token and provider must be specified. Received: token=$token, provider=$provider", ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'Both invite code and provider must be specified.'], Http::STATUS_BAD_REQUEST);
+		}
+		$localUser = $this->userSession->getUser();
+		if ($localUser === null) {
+			return new JSONResponse(['message' => $this->il10->t('Could not accept invite because no authenticated user was found.')], Http::STATUS_UNAUTHORIZED);
+		}
+		$provider = $this->normalizeProviderBase($provider);
+		if ($provider === null) {
+			return new JSONResponse(['message' => $this->il10->t('The invite provider is invalid or not allowed.')], Http::STATUS_BAD_REQUEST);
+		}
+		$recipientProviderFqdn = $this->federatedInvitesService->getProviderFQDN();
+		// do not accept an invite from this instance
+		$senderProviderFqdn = parse_url($provider)['host'];
+		$this->logger->debug("acceptInvite() - $recipientProviderFqdn === $senderProviderFqdn");
+		if ($recipientProviderFqdn === $senderProviderFqdn) {
+			return new JSONResponse(['message' => $this->il10->t('Unable to accept this invitation. You are trying to accept an outgoing invitation.')], Http::STATUS_BAD_REQUEST);
+		}
+		$email = $localUser->getEMailAddress();
+		if ($recipientProviderFqdn === '' || $email === '') {
+			$this->logger->error("All of these must be set: recipientProvider: $recipientProviderFqdn, email: $email", ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'Could not accept invite, user data is incomplete.'], Http::STATUS_UNPROCESSABLE_ENTITY);
+		}
+		$cloudId = '';
+		try {
+			// accept the invite by calling provider OCM /invite-accepted
+			// this returns a response with the following data signature: ['userID', 'email', 'name']
+			// @link https://cs3org.github.io/OCM-API/docs.html?branch=v1.1.0&repo=OCM-API&user=cs3org#/paths/~1invite-accepted/post
+			$client = $this->httpClient->newClient();
+			/**
+			 * @var \OCP\OCM\ICapabilityAwareOCMProvider $discovered
+			 *
+			 */
+			$discovered = $this->discovery->discover($provider);
+			if (
+				$discovered->hasCapability('invites')
+				|| $discovered->hasCapability('invite-accepted')
+				|| $discovered->hasCapability('/invite-accepted')
+			) {
+
+				$response = $this->discovery->requestRemoteOcmEndpoint(
+					null,
+					$provider,
+					'/invite-accepted',
+					[
+						'recipientProvider' => $recipientProviderFqdn,
+						'token' => $token,
+						'userID' => $localUser->getUID(),
+						'email' => $email,
+						'name' => $localUser->getDisplayName()
+					],
+					'POST',
+					$client,
+					null,
+					false
+				);
+				$responseData = $response->getBody();
+				$data = json_decode($responseData, true);
+				if (
+					!is_array($data)
+					|| !isset($data['userID'], $data['email'], $data['name'])
+					|| !is_string($data['userID'])
+					|| !is_string($data['email'])
+					|| !is_string($data['name'])
+					|| trim($data['userID']) === ''
+					|| trim($data['email']) === ''
+					|| trim($data['name']) === ''
+				) {
+					$this->logger->warning('Invalid /invite-accepted payload from provider', [
+						'app' => Application::APP_ID,
+						'provider' => $provider,
+						'payload' => $responseData,
+					]);
+					return new JSONResponse(['message' => $this->il10->t('Could not accept invite because the remote provider returned an invalid response.')], Http::STATUS_BAD_GATEWAY);
+				}
+
+				$cloudId = $data['userID'] . '@' . $this->addressHandler->removeProtocolFromUrl($provider);
+
+				$contactRef = $this->federatedInvitesService->createNewContact(
+					$cloudId,
+					$data['email'],
+					$data['name'],
+					null
+				);
+				if (!isset($contactRef)) {
+					$this->logger->error('Remote invite acceptance succeeded but local contact creation failed', [
+						'app' => Application::APP_ID,
+						'token' => $token,
+						'provider' => $provider,
+						'cloudId' => $cloudId,
+						'userId' => $localUser->getUID(),
+					]);
+					return new JSONResponse([
+						'code' => 'ocm_invite_local_contact_create_failed',
+						'message' => $this->il10->t('The remote provider accepted the invite, but this server could not create the local contact.'),
+					], Http::STATUS_BAD_GATEWAY);
+				}
+				$key = base64_encode($contactRef);
+				$contactUrl = $this->urlGenerator->getAbsoluteURL(
+					$this->urlGenerator->linkToRoute('contacts.page.index') . $this->il10->t('All contacts') . '/' . $key
+				);
+				return new JSONResponse(['contact' => $contactUrl], Http::STATUS_OK);
+			} else {
+				$this->logger->error('Provider: ' . $provider . ' does not support invites.', ['app' => Application::APP_ID]);
+				return new JSONResponse(['message' => 'Provider: ' . $provider . ' does not support invites.'], Http::STATUS_BAD_REQUEST);
+			}
+		} catch (ContactAlreadyExistsException $e) {
+			return new JSONResponse(['message' => 'Contact with cloudID ' . $cloudId . ' already exists.'], Http::STATUS_CONFLICT);
+		} catch (RequestException $e) { // this should catch OCM API request exceptions
+			$this->logger->error('/invite-accepted returned an error: ' . $e->getMessage(), ['app' => Application::APP_ID]);
+			/**
+			 * 400: Invalid or non existing token
+			 * 409: Invite already accepted
+			 */
+			$statusCode = $e->getResponse() !== null
+				? $e->getResponse()->getStatusCode()
+				: null;
+			switch ($statusCode) {
+				case Http::STATUS_BAD_REQUEST:
+					return new JSONResponse(['message' => 'Invalid, non-existing, or expired invite code.'], Http::STATUS_BAD_REQUEST);
+				case Http::STATUS_CONFLICT:
+					return new JSONResponse(['message' => 'Invite already accepted'], Http::STATUS_CONFLICT);
+			}
+			$this->logger->error("An unexpected error occurred accepting invite with token=$token and provider=$provider. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'An unexpected error occurred trying to accept invite.'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		} catch (OCMProviderException|OCMRequestException|Exception $e) {
+			$this->logger->error("An unexpected error occurred accepting invite with token=$token and provider=$provider. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'An unexpected error occurred trying to accept invite'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * Re-sends an existing invite email while preserving invite lifetime metadata.
+	 *
+	 */
+	#[NoAdminRequired]
+	#[UserRateLimit(limit: 30, period: 3600)]
+	#[BruteForceProtection(action: 'ocmInviteResend')]
+	#[FrontpageRoute(verb: 'PATCH', url: '/ocm/invitations/{token}/resend')]
+	public function resendInvite(string $token): JSONResponse {
+		if (($disabled = $this->requireOcmInvitesEnabled()) !== null) {
+			return $disabled;
+		}
+
+		$uid = $this->userSession->getUser()->getUID();
+		try {
+			$invite = $this->federatedInviteMapper->findInviteByTokenAndUid($token, $uid);
+		} catch (DoesNotExistException $e) {
+			$this->logger->warning("Could not find invite with token=$token for user with uid=$uid", ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'Invite not found'], Http::STATUS_NOT_FOUND);
+		} catch (Exception $e) {
+			$this->logger->error("An unexpected error occurred loading invite with token=$token. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'An unexpected error occurred trying to resend the invite'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+
+		// Cannot resend if no email address
+		if (empty($invite->getRecipientEmail())) {
+			return new JSONResponse(['message' => $this->il10->t('Cannot resend: no email address')], Http::STATUS_UNPROCESSABLE_ENTITY);
+		}
+		if ($this->isInviteAccepted($invite)) {
+			return new JSONResponse([
+				'code' => 'ocm_invite_already_accepted',
+				'message' => $this->il10->t('Invite has already been accepted.'),
+			], Http::STATUS_CONFLICT);
+		}
+		if ($this->isInviteExpired($invite)) {
+			return new JSONResponse([
+				'code' => 'ocm_invite_expired',
+				'message' => $this->il10->t('Invite has expired. Please create a new one.'),
+			], Http::STATUS_GONE);
+		}
+
+		$sendDate = date('Y-m-d', $invite->getCreatedAt());
+		$initiatorDisplayName = $this->userSession->getUser()->getDisplayName();
+		// a resend notification that refers to the previously sent invite
+		$message = $this->il10->t(
+			'This is a copy of an invite sent to you previously by %1$s on %2$s',
+			[
+				$initiatorDisplayName,
+				$sendDate
+			]
+		);
+		$senderProvider = $this->federatedInvitesService->getProviderFQDN();
+		/** @var JSONResponse */
+		$response = $this->sendInvitationEmail($token, $senderProvider, $invite->getRecipientEmail(), $message);
+		if ($response->getStatus() !== Http::STATUS_OK) {
+			$this->logger->error("An unexpected error occurred resending the invite with token $token. HTTP response status: " . $response->getStatus(), ['app' => Application::APP_ID]);
+			return $response;
+		}
+
+		// the invite url, use token instead of email for routing
+		$inviteUrl = $this->urlGenerator->getAbsoluteURL(
+			$this->urlGenerator->linkToRoute('contacts.page.index') . 'ocm-invites/' . $invite->getToken()
+		);
+		return new JSONResponse(['invite' => $inviteUrl], Http::STATUS_OK);
+	}
+
+	/**
+	 * Attaches a recipient email to an existing link-only invite and sends the
+	 * invitation email. Refreshes the creation and expiration timestamps so the
+	 * recipient receives a fresh expiry window. Reverts both the email and the
+	 * timestamps if the mailer fails, so a failed call leaves the invite as it
+	 * was before.
+	 *
+	 * @param string $token the invite token
+	 * @param string $email the recipient email address
+	 * @param string $message the optional message to include in the email
+	 * @return JSONResponse the serialized invite on success or an error message
+	 */
+	#[NoAdminRequired]
+	#[UserRateLimit(limit: 30, period: 3600)]
+	#[BruteForceProtection(action: 'ocmInviteAttachEmail')]
+	#[FrontpageRoute(verb: 'PATCH', url: '/ocm/invitations/{token}/email')]
+	public function attachEmailAndSend(string $token, string $email = '', string $message = ''): JSONResponse {
+		if (($disabled = $this->requireOcmInvitesEnabled()) !== null) {
+			return $disabled;
+		}
+
+		$uid = $this->userSession->getUser()->getUID();
+		try {
+			$invite = $this->federatedInviteMapper->findInviteByTokenAndUid($token, $uid);
+		} catch (DoesNotExistException $e) {
+			$this->logger->warning("Could not find invite with token=$token for user with uid=$uid", ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'Invite not found'], Http::STATUS_NOT_FOUND);
+		} catch (Exception $e) {
+			$this->logger->error("An unexpected error occurred loading invite with token=$token. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'An unexpected error occurred attaching the email.'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+
+		if ($this->isInviteAccepted($invite)) {
+			return new JSONResponse([
+				'code' => 'ocm_invite_already_accepted',
+				'message' => $this->il10->t('Invite has already been accepted.'),
+			], Http::STATUS_CONFLICT);
+		}
+		if (!empty($invite->getRecipientEmail())) {
+			return new JSONResponse([
+				'code' => 'ocm_invite_already_has_email',
+				'message' => $this->il10->t('Invite already has an email address.'),
+			], Http::STATUS_CONFLICT);
+		}
+
+		if (empty($email)) {
+			return new JSONResponse([
+				'code' => 'ocm_invite_email_required',
+				'message' => $this->il10->t('Email address is required.'),
+			], Http::STATUS_BAD_REQUEST);
+		}
+		$validationError = $this->validateEmail($email);
+		if ($validationError !== null) {
+			return $validationError;
+		}
+
+		$this->cleanupSupersededInvitesForRecipient($uid, $email);
+
+		// Reject when another open invite from this user already targets the same email.
+		// The current invite is excluded by construction: it has no recipient_email yet
+		// and findOpenInvitesByRecipientEmail() filters by recipient_email.
+		$existingInvites = $this->federatedInviteMapper->findOpenInvitesByRecipientEmail($uid, $email);
+		if (count($existingInvites) > 0) {
+			$this->logger->error("An open invite already exists for user with uid $uid and for recipient email $email", ['app' => Application::APP_ID]);
+			return new JSONResponse([
+				'code' => 'ocm_invite_duplicate_recipient_email',
+				'message' => $this->il10->t('An open invite for this email already exists.'),
+			], Http::STATUS_CONFLICT);
+		}
+
+		$previousCreatedAt = $invite->getCreatedAt();
+		$previousExpiredAt = $invite->getExpiredAt();
+		$newCreatedAt = $this->timeFactory->now()->getTimestamp();
+		$newExpiredAt = $this->federatedInvitesService->getInviteExpirationDate($newCreatedAt);
+
+		try {
+			$claimed = $this->federatedInviteMapper->claimInviteForEmail(
+				$token,
+				$uid,
+				$email,
+				$newCreatedAt,
+				$newExpiredAt,
+			);
+		} catch (Exception $e) {
+			$this->logger->error("An unexpected error occurred claiming invite with token=$token. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			return new JSONResponse([
+				'code' => 'ocm_invite_claim_exception',
+				'message' => 'An unexpected error occurred attaching the email.',
+			], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+
+		if ($claimed === false) {
+			// A concurrent attach won the race or the invite was accepted between
+			// the read and the conditional update. Treat as a 409 collision so the
+			// client can refresh and decide what to do next.
+			return new JSONResponse([
+				'code' => 'ocm_invite_claim_failed',
+				'message' => $this->il10->t('Could not claim invite for this email; please refresh and try again.'),
+			], Http::STATUS_CONFLICT);
+		}
+
+		$invite->setRecipientEmail($email);
+		$invite->setCreatedAt($newCreatedAt);
+		$invite->setExpiredAt($newExpiredAt);
+
+		$senderProvider = $this->federatedInvitesService->getProviderFQDN();
+		/** @var JSONResponse */
+		$response = $this->sendInvitationEmail($token, $senderProvider, $email, $message);
+		if ($response->getStatus() !== Http::STATUS_OK) {
+			$this->logger->error("An unexpected error occurred sending the invite with token $token. HTTP response status: " . $response->getStatus(), ['app' => Application::APP_ID]);
+			$reverted = false;
+			try {
+				$reverted = $this->federatedInviteMapper->revertInviteEmail(
+					$token,
+					$uid,
+					$email,
+					$previousCreatedAt,
+					$previousExpiredAt,
+				);
+			} catch (Exception $e) {
+				$this->logger->error("Could not revert invite with token=$token after mailer failure. Stacktrace: " . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+			}
+			if ($reverted !== true) {
+				$mailFailure = $response->getData();
+				$mailMessage = is_array($mailFailure) && isset($mailFailure['message']) && is_string($mailFailure['message'])
+					? $mailFailure['message']
+					: null;
+				return new JSONResponse([
+					'code' => 'ocm_invite_revert_failed',
+					'message' => $this->il10->t('Could not revert invite after delivery failure. Please refresh and try again.'),
+					'mailError' => $mailMessage,
+				], $response->getStatus());
+			}
+			return $response;
+		}
+
+		return new JSONResponse($invite->jsonSerialize(), Http::STATUS_OK);
+	}
+
+	/**
+	 * Do OCM discovery on behalf of VUE frontend to avoid CSRF issues
+	 * @param string $base base url to discover
+	 * @return DataResponse
+	 */
+	#[PublicPage]
+	#[AnonRateLimit(limit: 120, period: 3600)]
+	#[UserRateLimit(limit: 120, period: 3600)]
+	#[BruteForceProtection(action: 'ocmInviteDiscover')]
+	#[FrontpageRoute(verb: 'GET', url: '/discover')]
+	public function discover(string $base): DataResponse {
+		if (!$this->federatedInvitesService->isOcmInvitesEnabled()) {
+			return new DataResponse([
+				'code' => 'ocm_invites_disabled',
+				'error' => $this->il10->t('OCM invites are disabled.'),
+			], Http::STATUS_FORBIDDEN);
+		}
+
+		$base = $this->normalizeProviderBase($base);
+		if ($base === null) {
+			return new DataResponse(['error' => 'invalid base'], Http::STATUS_BAD_REQUEST);
+		}
+
+		try {
+			/**
+			 * @var \OCP\OCM\ICapabilityAwareOCMProvider $provider
+			 *
+			 */
+			$provider = $this->discovery->discover($base);
+			$dialog = trim($provider->getInviteAcceptDialog());
+			$absolute = $dialog === '' ? null : $this->buildInviteAcceptDialogAbsolute($base, $dialog);
+			if ($absolute === null) {
+				$dialog = $this->wayfProvider->getInviteAcceptDialogPath();
+				$absolute = $this->buildInviteAcceptDialogAbsolute($base, $dialog);
+			}
+			if ($absolute === null) {
+				return new DataResponse(['error' => 'OCM discovery failed', 'base' => $base], Http::STATUS_NOT_FOUND);
+			}
+
+			$baseHost = parse_url($base, PHP_URL_HOST);
+			return new DataResponse([
+				'base' => $base,
+				'inviteAcceptDialog' => $dialog,
+				'inviteAcceptDialogAbsolute' => $absolute,
+				'providerDomain' => is_string($baseHost) ? $baseHost : '',
+			], Http::STATUS_OK);
+		} catch (Throwable $e) {
+			$this->logger->warning('OCM discovery failed', [
+				'app' => Application::APP_ID,
+				'base' => $base,
+				'exception' => $e,
+			]);
+			return new DataResponse(['error' => 'OCM discovery failed', 'base' => $base], Http::STATUS_NOT_FOUND);
+		}
+	}
+
+	/**
+	 * Display the wayf page.
+	 *
+	 * @param string $token the token of the invite
+	 * @return TemplateResponse the WAYF page
+	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
+	#[FrontpageRoute(verb: 'GET', url: '/wayf')]
+	public function wayf(string $token = ''): TemplateResponse {
+		Util::addScript(Application::APP_ID, 'contacts-wayf');
+		Util::addStyle(Application::APP_ID, 'contacts-wayf');
+		try {
+			$federations = $this->wayfProvider->getMeshProviders();
+			$providerDomain = trim((string)$this->request->getParam('providerDomain', ''));
+			if ($providerDomain === '') {
+				$baseHost = parse_url($this->urlGenerator->getBaseUrl(), PHP_URL_HOST);
+				$providerDomain = is_string($baseHost) ? $baseHost : '';
+			}
+			$this->initialState->provideInitialState('wayf', [
+				'federations' => $federations,
+				'providerDomain' => $providerDomain,
+				'token' => $token,
+			]);
+		} catch (Exception $e) {
+			$this->logger->error($e->getMessage() . ' Trace: ' . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+		}
+		$template = new TemplateResponse('contacts', 'wayf', [], TemplateResponse::RENDER_AS_GUEST);
+		return $template;
+	}
+
+	/**
+	 * Persist an OCM invite bool admin setting. Admin-only by default since the
+	 * method is not marked with NoAdminRequired.
+	 *
+	 * @param string $key one of FederatedInvitesService::OCM_INVITES_BOOL_KEYS
+	 * @param bool $value the new value
+	 * @return JSONResponse empty body with the appropriate HTTP status
+	 */
+	#[FrontpageRoute(verb: 'PUT', url: '/ocm/admin/settings/{key}')]
+	public function setOcmInviteBoolSetting(string $key, bool $value): JSONResponse {
+		if (!$this->federatedInvitesService->setOcmInviteBoolSetting($key, $value)) {
+			return new JSONResponse(['message' => 'Unknown setting key'], Http::STATUS_FORBIDDEN);
+		}
+		return new JSONResponse([], Http::STATUS_OK);
+	}
+
+	/**
+	 * Validate a recipient email address against the configured mailer.
+	 *
+	 * @return JSONResponse|null Error response on invalid input, null when valid.
+	 */
+	private function validateEmail(string $address): ?JSONResponse {
+		if (!$this->mailer->validateMailAddress($address)) {
+			$this->logger->debug("Invalid recipient email address '$address'", ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => $this->il10->t('Recipient email address is invalid.')], Http::STATUS_UNPROCESSABLE_ENTITY);
+		}
+		return null;
+	}
+
+	/**
+	 * @param string $token the invite token
+	 * @param string $senderProvider this provider
+	 * @param string $recipientEmail the recipient email address to send the invitation to
+	 * @param string $message the optional message to send with the invitation
+	 * @param bool $isSenderCopy if true than a this is a copy of the invitation to be sent to the inviter
+	 * @return JSONResponse
+	 */
+	private function sendInvitationEmail(string $token, string $senderProvider, string $recipientEmail, string $message, bool $isSenderCopy = false): JSONResponse {
+		$validationError = $this->validateEmail($recipientEmail);
+		if ($validationError !== null) {
+			return $validationError;
+		}
+		/** @var IMessage */
+		$email = $this->mailer->createMessage();
+		$toAddress = $isSenderCopy ? $this->userSession->getUser()->getEMailAddress() : $recipientEmail;
+		$email->setTo([$toAddress]);
+
+		$instanceName = $this->defaults->getName();
+		$initiatorDisplayName = $this->userSession->getUser()->getDisplayName();
+		$senderName = $this->il10->t(
+			'%1$s via %2$s',
+			[
+				$initiatorDisplayName,
+				$instanceName
+			]
+		);
+		$email->setFrom([Util::getDefaultEmailAddress($instanceName) => $senderName]);
+		$subjectPrefix = $isSenderCopy ? '[Copy] ' : '';
+		$subject = $this->il10->t($subjectPrefix . '%1$s invites you to exchange contact information.', [$initiatorDisplayName]);
+		$email->setSubject($subject);
+
+		$wayfEndpoint = $this->wayfProvider->getWayfEndpoint();
+		if (empty($wayfEndpoint)) {
+			$this->logger->error('Invalid WAYF endpoint (null).', ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => 'Could not send invite.'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+		$inviteLink = $this->buildWayfInviteLink($wayfEndpoint, $token, $senderProvider);
+		$encoded = base64_encode("$token@$senderProvider");
+
+		$initiatorDisplayNameH = htmlspecialchars($initiatorDisplayName, ENT_QUOTES, 'UTF-8');
+		$inviteLinkH = htmlspecialchars($inviteLink, ENT_QUOTES, 'UTF-8');
+		$tokenSenderH = htmlspecialchars("$token@$senderProvider", ENT_QUOTES, 'UTF-8');
+		$encodedH = htmlspecialchars($encoded, ENT_QUOTES, 'UTF-8');
+		$messageH = nl2br(htmlspecialchars($message, ENT_QUOTES, 'UTF-8'), false);
+
+		$header = $isSenderCopy
+			? $this->il10->t('This is a copy of the invitation you\'ve sent to %1$s', [htmlspecialchars($recipientEmail, ENT_QUOTES, 'UTF-8')])
+			: '';
+		$greeting = $this->il10->t('Hi there,', []);
+		$explanationLine1 = $this->il10->t('%1$s invites you to exchange cloud accounts and contact information.', [$initiatorDisplayNameH]);
+		$explanationLine2 = $this->il10->t('This will allow you to share data with each other.', []);
+		$htmlHeader = $header === '' ? $header : "$header<br><hr><br>";
+		$htmlInvitation = "$htmlHeader$greeting<br><br>$explanationLine1<br>$explanationLine2";
+		$htmlPersonalMessage = trim($message) === '' ? '' : "<br>---<br>$messageH<br>---<br>";
+
+		$inviteLinkNote = $this->il10->t('To accept this invite, click the link below and sign in with your cloud provider:', []);
+		$htmlInviteLink = "<a href=\"$inviteLinkH\">$inviteLinkH</a>";
+
+		$technicalDetailsNote = $this->il10->t('Invitation details:', []);
+		$technicalDetailsInviteCode = $this->il10->t('Invite code: %1$s', [$tokenSenderH]);
+		$technicalDetailsEncodedInvite = $this->il10->t('Encoded invite: %1$s', [$encodedH]);
+		$htmlTechnicalDetails = "<small>$technicalDetailsNote<br>$technicalDetailsInviteCode<br>$technicalDetailsEncodedInvite</small>";
+		$htmlBody = "$htmlInvitation<br>$htmlPersonalMessage<br>$inviteLinkNote<br>$htmlInviteLink<br><br>$htmlTechnicalDetails";
+		$email->setHtmlBody($htmlBody);
+
+		$plainHeader = $header === '' ? $header : "$header\n---------\n\n";
+		$plainInvitation = "$plainHeader$greeting\n\n$explanationLine1\n$explanationLine2";
+		$plainPersonalMessage = trim($message) === '' ? '' : "\n---\n$message\n---\n";
+		$plainInviteLinkNote = $this->il10->t('To accept this invite, use the url below to sign in with your cloud provider:', []);
+		$plainTechnicalDetails = "$technicalDetailsNote\n$technicalDetailsInviteCode\n$technicalDetailsEncodedInvite";
+
+		$plainBody = "$plainInvitation\n$plainPersonalMessage\n$plainInviteLinkNote\n$inviteLink\n\n$plainTechnicalDetails\n";
+		$email->setPlainBody($plainBody);
+
+		try {
+			/** @var string[] $failedRecipients */
+			$failedRecipients = $this->mailer->send($email);
+		} catch (\Throwable $e) {
+			$this->logger->error("Mail transport failure while sending invite to '$toAddress': " . $e->getMessage(), [
+				'app' => Application::APP_ID,
+				'exception' => $e,
+			]);
+			return new JSONResponse(['message' => "Could not send invite to '$toAddress'"], Http::STATUS_BAD_GATEWAY);
+		}
+
+		if (!empty($failedRecipients)) {
+			$this->logger->error("Could not send invite to '$toAddress'", ['app' => Application::APP_ID]);
+			return new JSONResponse(['message' => "Could not send invite to '$toAddress'"], Http::STATUS_BAD_GATEWAY);
+		}
+
+		return new JSONResponse([], Http::STATUS_OK);
+	}
+
+	private function normalizeProviderBase(string $provider): ?string {
+		$candidate = trim($provider);
+		if ($candidate === '') {
+			return null;
+		}
+		if (!preg_match('#^https?://#i', $candidate)) {
+			$candidate = 'https://' . $candidate;
+		}
+
+		$parts = parse_url($candidate);
+		if (!is_array($parts) || !isset($parts['scheme'], $parts['host'])) {
+			return null;
+		}
+
+		$scheme = strtolower($parts['scheme']);
+		if (!in_array($scheme, ['http', 'https'], true)) {
+			return null;
+		}
+
+		$host = strtolower($parts['host']);
+		if ($host === '') {
+			return null;
+		}
+		if (!$this->federatedInvitesService->isSsrfGuardDisabled() && $this->isBlockedDiscoveryHost($host)) {
+			return null;
+		}
+
+		$port = '';
+		if (isset($parts['port'])) {
+			$portNumber = $parts['port'];
+			if ($portNumber < 1 || $portNumber > 65535) {
+				return null;
+			}
+			$port = ':' . $portNumber;
+		}
+
+		$path = '';
+		if (isset($parts['path']) && $parts['path'] !== '') {
+			$path = '/' . trim($parts['path'], '/');
+			$path = rtrim($path, '/');
+		}
+
+		return $scheme . '://' . $host . $port . $path;
+	}
+
+	private function isBlockedDiscoveryHost(string $host): bool {
+		$normalizedHost = strtolower(trim($host));
+		if ($normalizedHost === 'localhost' || str_ends_with($normalizedHost, '.localhost')) {
+			return true;
+		}
+
+		if (filter_var($normalizedHost, FILTER_VALIDATE_IP) === false) {
+			return false;
+		}
+
+		return filter_var(
+			$normalizedHost,
+			FILTER_VALIDATE_IP,
+			FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+		) === false;
+	}
+
+	private function buildInviteAcceptDialogAbsolute(string $base, string $dialog): ?string {
+		$trimmedDialog = trim($dialog);
+		if ($trimmedDialog === '') {
+			return null;
+		}
+
+		$baseParts = parse_url($base);
+		if (!is_array($baseParts) || !isset($baseParts['scheme'], $baseParts['host'])) {
+			return null;
+		}
+
+		if (preg_match('#^https?://#i', $trimmedDialog)) {
+			$dialogUrl = $this->normalizeProviderBase($trimmedDialog);
+			if ($dialogUrl === null) {
+				return null;
+			}
+			$dialogParts = parse_url($dialogUrl);
+			if (!is_array($dialogParts) || !isset($dialogParts['host'])) {
+				return null;
+			}
+
+			$basePort = $baseParts['port'] ?? null;
+			$dialogPort = $dialogParts['port'] ?? null;
+			if (strtolower($dialogParts['host']) !== strtolower($baseParts['host']) || $basePort !== $dialogPort) {
+				return null;
+			}
+
+			return $dialogUrl;
+		}
+
+		$origin = $baseParts['scheme'] . '://' . $baseParts['host'];
+		if (isset($baseParts['port'])) {
+			$origin .= ':' . $baseParts['port'];
+		}
+
+		if (str_starts_with($trimmedDialog, '/')) {
+			return $origin . $trimmedDialog;
+		}
+
+		return rtrim($base, '/') . '/' . ltrim($trimmedDialog, '/');
+	}
+
+	private function buildWayfInviteLink(string $wayfEndpoint, string $token, string $senderProvider): string {
+		$separator = str_contains($wayfEndpoint, '?') ? '&' : '?';
+		$query = http_build_query([
+			'token' => $token,
+			'providerDomain' => $senderProvider,
+		], '', '&', PHP_QUERY_RFC3986);
+		return $wayfEndpoint . $separator . $query;
+	}
+
+	private function requireOcmInvitesEnabled(): ?JSONResponse {
+		if ($this->federatedInvitesService->isOcmInvitesEnabled()) {
+			return null;
+		}
+
+		return new JSONResponse([
+			'code' => 'ocm_invites_disabled',
+			'message' => $this->il10->t('OCM invites are disabled.'),
+		], Http::STATUS_FORBIDDEN);
+	}
+
+	private function cleanupSupersededInvitesForRecipient(string $uid, string $email): int {
+		if ($email === '') {
+			return 0;
+		}
+
+		try {
+			return $this->federatedInviteMapper->deleteSupersededInvitesForRecipientEmail(
+				$uid,
+				$email,
+				$this->timeFactory->now()->getTimestamp(),
+			);
+		} catch (Exception $e) {
+			$this->logger->warning('Could not clean up superseded invites for recipient email.', [
+				'app' => Application::APP_ID,
+				'userId' => $uid,
+				'email' => $email,
+				'exception' => $e,
+			]);
+			return 0;
+		}
+	}
+
+	private function isInviteAccepted(FederatedInvite $invite): bool {
+		return $invite->isAccepted() === true || $invite->getAcceptedAt() !== null;
+	}
+
+	private function isInviteExpired(FederatedInvite $invite): bool {
+		$expiredAt = $invite->getExpiredAt();
+		return $expiredAt !== null && $expiredAt <= $this->timeFactory->now()->getTimestamp();
+	}
+
+	private function isDuplicateConstraintException(Throwable $e): bool {
+		$message = strtolower($e->getMessage());
+		return str_contains($message, 'duplicate')
+			|| str_contains($message, 'unique')
+			|| str_contains($message, 'constraint');
+	}
+}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -9,6 +9,7 @@ namespace OCA\Contacts\Controller;
 
 use OC\App\CompareVersion;
 use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\Service\FederatedInvitesService;
 use OCA\Contacts\Service\GroupSharingService;
 use OCA\Contacts\Service\SocialApiService;
 use OCP\App\IAppManager;
@@ -25,6 +26,7 @@ class PageController extends Controller {
 
 	public function __construct(
 		IRequest $request,
+		private FederatedInvitesService $federatedInvitesService,
 		private IConfig $config,
 		private IInitialState $initialState,
 		private IFactory $languageFactory,
@@ -41,9 +43,18 @@ class PageController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 *
-	 * Default routing
+	 * Default routing.
+	 *
+	 * @param string $token external invitation token
+	 * @param string $providerDomain external invitation provider domain
 	 */
-	public function index(): TemplateResponse {
+	public function index(string $token = '', string $providerDomain = ''): TemplateResponse {
+		if ($token !== '' && $providerDomain !== '') {
+			// if both token and providerDomain are set they will be provided to the template system for displaying the invite accept dialog
+			$this->initialState->provideInitialState('inviteToken', $token);
+			$this->initialState->provideInitialState('inviteProvider', $providerDomain);
+			$this->initialState->provideInitialState('acceptInviteDialogUrl', FederatedInvitesService::OCM_INVITE_ACCEPT_DIALOG_ROUTE);
+		}
 		$user = $this->userSession->getUser();
 		$userId = $user->getUid();
 
@@ -65,6 +76,8 @@ class PageController extends Controller {
 		$isTalkEnabled = $this->appManager->isEnabledForUser('spreed') === true;
 
 		$isTalkVersionCompatible = $this->compareVersion->isCompatible($talkVersion ? $talkVersion : '0.0.0', 2);
+		$isOcmInvitesEnabled = $this->federatedInvitesService->isOcmInvitesEnabled();
+		$ocmInvitesConfig = $this->federatedInvitesService->getOcmInvitesConfig();
 
 		$this->initialState->provideInitialState('isGroupSharingEnabled', $isGroupSharingEnabled);
 		$this->initialState->provideInitialState('locales', $locales);
@@ -75,6 +88,8 @@ class PageController extends Controller {
 		$this->initialState->provideInitialState('isContactsInteractionEnabled', $isContactsInteractionEnabled);
 		$this->initialState->provideInitialState('isCirclesEnabled', $isCirclesEnabled && $isCircleVersionCompatible);
 		$this->initialState->provideInitialState('isTalkEnabled', $isTalkEnabled && $isTalkVersionCompatible);
+		$this->initialState->provideInitialState('isOcmInvitesEnabled', $isOcmInvitesEnabled);
+		$this->initialState->provideInitialState('ocmInvitesConfig', $ocmInvitesConfig);
 
 		Util::addStyle(Application::APP_ID, 'contacts-main');
 		Util::addScript(Application::APP_ID, 'contacts-main');

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -9,6 +9,7 @@ namespace OCA\Contacts\Controller;
 
 use OC\App\CompareVersion;
 use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\Service\FederatedInvitesService;
 use OCA\Contacts\Service\GroupSharingService;
 use OCA\Contacts\Service\SocialApiService;
 use OCP\App\IAppManager;
@@ -26,6 +27,7 @@ class PageController extends Controller {
 
 	public function __construct(
 		IRequest $request,
+		private FederatedInvitesService $federatedInvitesService,
 		private IConfig $config,
 		private IInitialState $initialState,
 		private IFactory $languageFactory,
@@ -43,9 +45,18 @@ class PageController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 *
-	 * Default routing
+	 * Default routing.
+	 *
+	 * @param string $token external invitation token
+	 * @param string $providerDomain external invitation provider domain
 	 */
-	public function index(): TemplateResponse {
+	public function index(string $token = '', string $providerDomain = ''): TemplateResponse {
+		if ($token !== '' && $providerDomain !== '') {
+			// if both token and providerDomain are set they will be provided to the template system for displaying the invite accept dialog
+			$this->initialState->provideInitialState('inviteToken', $token);
+			$this->initialState->provideInitialState('inviteProvider', $providerDomain);
+			$this->initialState->provideInitialState('acceptInviteDialogUrl', FederatedInvitesService::OCM_INVITE_ACCEPT_DIALOG_ROUTE);
+		}
 		$user = $this->userSession->getUser();
 		$userId = $user->getUid();
 
@@ -70,6 +81,8 @@ class PageController extends Controller {
 		$isTalkEnabled = $this->appManager->isEnabledForUser('spreed') === true;
 
 		$isTalkVersionCompatible = $this->compareVersion->isCompatible($talkVersion ? $talkVersion : '0.0.0', 2);
+		$isOcmInvitesEnabled = $this->federatedInvitesService->isOcmInvitesEnabled();
+		$ocmInvitesConfig = $this->federatedInvitesService->getOcmInvitesConfig();
 
 		$this->initialState->provideInitialState('isGroupSharingEnabled', $isGroupSharingEnabled);
 		$this->initialState->provideInitialState('locales', $locales);
@@ -80,6 +93,8 @@ class PageController extends Controller {
 		$this->initialState->provideInitialState('isContactsInteractionEnabled', $isContactsInteractionEnabled);
 		$this->initialState->provideInitialState('isTeamManagementEnabled', $isCirclesEnabled && $isCircleVersionCompatible && $isServerVersionWithTeamManagement);
 		$this->initialState->provideInitialState('isTalkEnabled', $isTalkEnabled && $isTalkVersionCompatible);
+		$this->initialState->provideInitialState('isOcmInvitesEnabled', $isOcmInvitesEnabled);
+		$this->initialState->provideInitialState('ocmInvitesConfig', $ocmInvitesConfig);
 
 		Util::addStyle(Application::APP_ID, 'contacts-main');
 		Util::addScript(Application::APP_ID, 'contacts-main');

--- a/lib/Controller/SocialApiController.php
+++ b/lib/Controller/SocialApiController.php
@@ -30,7 +30,6 @@ class SocialApiController extends ApiController {
 		$this->appName = Application::APP_ID;
 	}
 
-
 	/**
 	 * update appconfig (admin setting)
 	 *
@@ -72,7 +71,6 @@ class SocialApiController extends ApiController {
 		return new JSONResponse([], Http::STATUS_OK);
 	}
 
-
 	/**
 	 * @NoAdminRequired
 	 *
@@ -91,7 +89,6 @@ class SocialApiController extends ApiController {
 		return $this->config->getUserValue($userId, $this->appName, $key, 'null');
 	}
 
-
 	/**
 	 * @NoAdminRequired
 	 *
@@ -102,7 +99,6 @@ class SocialApiController extends ApiController {
 	public function getSupportedNetworks() : array {
 		return $this->socialApiService->getSupportedNetworks();
 	}
-
 
 	/**
 	 * @NoAdminRequired

--- a/lib/Cron/SocialUpdate.php
+++ b/lib/Cron/SocialUpdate.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace OCA\Contacts\Cron;
 
 use OCA\Contacts\Service\SocialApiService;
-
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;

--- a/lib/Cron/SocialUpdateRegistration.php
+++ b/lib/Cron/SocialUpdateRegistration.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace OCA\Contacts\Cron;
 
 use OCA\Contacts\AppInfo\Application;
-
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\TimedJob;

--- a/lib/Cron/UpdateDeltaOcmProviders.php
+++ b/lib/Cron/UpdateDeltaOcmProviders.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Cron;
+
+use OCA\Contacts\ConfigLexicon;
+use OCA\Contacts\MeshProvidersCache;
+use OCA\Contacts\WayfProvider;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+
+/**
+ * This job runs periodically to update the list of providers in the mesh providers cache.
+ * The update is specified as follows:
+ *  - Retrieve the current list of providers from each Mesh Directory Service and update the cache to keep that list.
+ *    (Mesh Directory Services are specified as value, a string of url's separated by commas, of the 'mesh_providers_service' config key)
+ *  - Additionally, do a discovery on new providers and update the cache with the result.
+ */
+class UpdateDeltaOcmProviders extends TimedJob {
+	// Run every 15 minutes
+	private int $expire_time = 60 * 15;
+
+	public function __construct(
+		ITimeFactory $time,
+		private MeshProvidersCache $cache,
+		private WayfProvider $wayfProvider,
+	) {
+		parent::__construct($time);
+		$this->setInterval($this->expire_time);
+	}
+
+	#[\Override]
+	protected function run($argument) {
+		$this->wayfProvider->updateMeshProvidersCache(ConfigLexicon::FEDERATIONS_CACHE_DELTA_EXPIRES);
+		$this->cache->setExpirationTime(ConfigLexicon::FEDERATIONS_CACHE_DELTA_EXPIRES, time() + $this->expire_time);
+	}
+}

--- a/lib/Cron/UpdateOcmProviders.php
+++ b/lib/Cron/UpdateOcmProviders.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Cron;
+
+use OCA\Contacts\ConfigLexicon;
+use OCA\Contacts\MeshProvidersCache;
+use OCA\Contacts\WayfProvider;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\TimedJob;
+
+/**
+ * This job runs periodically to do a complete refresh of the list of providers in the mesh providers cache.
+ * The update is specified as follows:
+ *  - Retrieve the current list of providers from each Mesh Directory Service and update the cache to keep that list.
+ *    (Mesh Directory Services are specified as value, a string of url's separated by commas, of the 'mesh_providers_service' config key)
+ *  - Additionally, do a discovery on all providers and update the cache with the result.
+ */
+class UpdateOcmProviders extends TimedJob {
+	// Run every 24 hours
+	private int $expire_time = 60 * 60;
+
+	public function __construct(
+		ITimeFactory $time,
+		private MeshProvidersCache $cache,
+		private WayfProvider $wayfProvider,
+	) {
+		parent::__construct($time);
+		$this->setInterval($this->expire_time);
+		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+	}
+
+	#[\Override]
+	protected function run($argument) {
+		$this->wayfProvider->updateMeshProvidersCache(ConfigLexicon::FEDERATIONS_CACHE_EXPIRES);
+		$this->cache->setExpirationTime(ConfigLexicon::FEDERATIONS_CACHE_EXPIRES, time() + $this->expire_time);
+	}
+}

--- a/lib/Db/FederatedInvite.php
+++ b/lib/Db/FederatedInvite.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Db;
+
+use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
+
+/**
+ * @method bool isAccepted()
+ * @method void setAccepted(bool $accepted)
+ * @method int|null getAcceptedAt()
+ * @method void setAcceptedAt(?int $acceptedAt)
+ * @method int getCreatedAt()
+ * @method void setCreatedAt(int $createdAt)
+ * @method int|null getExpiredAt()
+ * @method void setExpiredAt(?int $expiredAt)
+ * @method string|null getRecipientEmail()
+ * @method void setRecipientEmail(?string $recipientEmail)
+ * @method string|null getRecipientName()
+ * @method void setRecipientName(?string $recipientName)
+ * @method string|null getRecipientProvider()
+ * @method void setRecipientProvider(?string $recipientProvider)
+ * @method string|null getRecipientUserId()
+ * @method void setRecipientUserId(?string $recipientUserId)
+ * @method string getToken()
+ * @method void setToken(string $token)
+ * @method string getUserId()
+ * @method void setUserId(string $userId)
+ */
+
+class FederatedInvite extends Entity {
+	protected bool $accepted = false;
+	protected ?int $acceptedAt = null;
+	protected int $createdAt = 0;
+	protected ?int $expiredAt = null;
+	protected ?string $recipientEmail = null;
+	protected ?string $recipientName = null;
+	protected ?string $recipientProvider = null;
+	protected ?string $recipientUserId = null;
+	protected string $token = '';
+	protected string $userId = '';
+
+	public function __construct() {
+		$this->addType('accepted', Types::BOOLEAN);
+		$this->addType('acceptedAt', Types::BIGINT);
+		$this->addType('createdAt', Types::BIGINT);
+		$this->addType('expiredAt', Types::BIGINT);
+		$this->addType('recipientEmail', Types::STRING);
+		$this->addType('recipientName', Types::STRING);
+		$this->addType('recipientProvider', Types::STRING);
+		$this->addType('recipientUserId', Types::STRING);
+		$this->addType('token', Types::STRING);
+		$this->addType('userId', Types::STRING);
+	}
+
+	public function jsonSerialize(): array {
+		return [
+			'accepted' => $this->accepted,
+			'acceptedAt' => $this->acceptedAt,
+			'createdAt' => $this->createdAt,
+			'expiredAt' => $this->expiredAt,
+			'recipientEmail' => $this->recipientEmail,
+			'recipientName' => $this->recipientName,
+			'recipientProvider' => $this->recipientProvider,
+			'recipientUserId' => $this->recipientUserId,
+			'token' => $this->token,
+			'userId' => $this->userId,
+		];
+	}
+
+}

--- a/lib/Db/FederatedInviteMapper.php
+++ b/lib/Db/FederatedInviteMapper.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Db;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * @template-extends QBMapper<FederatedInvite>
+ */
+class FederatedInviteMapper extends QBMapper {
+	public const TABLE_NAME = 'federated_invites';
+
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, self::TABLE_NAME);
+	}
+
+	/**
+	 * Returns the federated invite with the specified token
+	 *
+	 * @return FederatedInvite
+	 */
+	public function findByToken(string $token): FederatedInvite {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from(self::TABLE_NAME)
+			->where($qb->expr()->eq('token', $qb->createNamedParameter($token)));
+		return $this->findEntity($qb);
+	}
+
+	/**
+	 * Returns all open federated invites for the user with the specified user id
+	 *
+	 * @return list<FederatedInvite>
+	 */
+	public function findOpenInvitesByUid(string $userId, ?int $now = null): array {
+		$timestamp = $now ?? time();
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from(self::TABLE_NAME)
+			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+			->andWhere($qb->expr()->eq('accepted', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)))
+			->andWhere($qb->expr()->isNull('accepted_at'))
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->isNull('expired_at'),
+					$qb->expr()->gt('expired_at', $qb->createNamedParameter($timestamp, IQueryBuilder::PARAM_INT)),
+				),
+			);
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * Returns all open federated invites for the user with the specified user id and for the specified recipient email
+	 *
+	 * @return list<FederatedInvite>
+	 */
+	public function findOpenInvitesByRecipientEmail(string $userId, string $email, ?int $now = null): array {
+		$timestamp = $now ?? time();
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from(self::TABLE_NAME)
+			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+			->andWhere($qb->expr()->eq('recipient_email', $qb->createNamedParameter($email)))
+			->andWhere($qb->expr()->eq('accepted', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)))
+			->andWhere($qb->expr()->isNull('accepted_at'))
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->isNull('expired_at'),
+					$qb->expr()->gt('expired_at', $qb->createNamedParameter($timestamp, IQueryBuilder::PARAM_INT)),
+				),
+			);
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * Returns the federated invite with the specified token for the user with the specified user id.
+	 *
+	 * @return FederatedInvite the matching invite
+	 */
+	public function findInviteByTokenAndUid(string $token, string $userId):FederatedInvite {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from(self::TABLE_NAME)
+			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+			->andWhere($qb->expr()->eq('token', $qb->createNamedParameter($token, IQueryBuilder::PARAM_STR)));
+		return $this->findEntity($qb);
+	}
+
+	/**
+	 * Atomically claims an unclaimed (recipient_email IS NULL) and unaccepted
+	 * invite for the given email and refreshes its lifetime.
+	 *
+	 * Returns true when exactly one row was affected, meaning the caller now
+	 * owns the (token, recipient_email) pair. Returns false when the row no
+	 * longer matches the precondition (a concurrent attach already claimed
+	 * the invite, the invite was accepted, or the row vanished).
+	 */
+	public function claimInviteForEmail(
+		string $token,
+		string $userId,
+		string $email,
+		int $createdAt,
+		int $expiredAt,
+	): bool {
+		$qb = $this->db->getQueryBuilder();
+		$qb->update(self::TABLE_NAME)
+			->set('recipient_email', $qb->createNamedParameter($email))
+			->set('created_at', $qb->createNamedParameter($createdAt, IQueryBuilder::PARAM_INT))
+			->set('expired_at', $qb->createNamedParameter($expiredAt, IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->eq('token', $qb->createNamedParameter($token, IQueryBuilder::PARAM_STR)))
+			->andWhere($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+			->andWhere($qb->expr()->isNull('recipient_email'))
+			->andWhere($qb->expr()->eq('accepted', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)))
+			->andWhere($qb->expr()->isNull('accepted_at'));
+		return $qb->executeStatement() === 1;
+	}
+
+	/**
+	 * Best-effort revert of a previous claim made by claimInviteForEmail().
+	 * Scoped to the same sender (user_id) and only takes effect when the row
+	 * still has the email we set and is still unaccepted, so the revert
+	 * cannot undo a successful accept and cannot run if a concurrent attach
+	 * changed recipient_email between the claim and the revert.
+	 *
+	 * Returns true when the revert took effect (exactly one row updated).
+	 */
+	public function revertInviteEmail(
+		string $token,
+		string $userId,
+		string $email,
+		int $previousCreatedAt,
+		?int $previousExpiredAt,
+	): bool {
+		$qb = $this->db->getQueryBuilder();
+		$expiredParam = $previousExpiredAt === null
+			? $qb->createNamedParameter(null, IQueryBuilder::PARAM_NULL)
+			: $qb->createNamedParameter($previousExpiredAt, IQueryBuilder::PARAM_INT);
+		$qb->update(self::TABLE_NAME)
+			->set('recipient_email', $qb->createNamedParameter(null, IQueryBuilder::PARAM_NULL))
+			->set('created_at', $qb->createNamedParameter($previousCreatedAt, IQueryBuilder::PARAM_INT))
+			->set('expired_at', $expiredParam)
+			->where($qb->expr()->eq('token', $qb->createNamedParameter($token, IQueryBuilder::PARAM_STR)))
+			->andWhere($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+			->andWhere($qb->expr()->eq('recipient_email', $qb->createNamedParameter($email)))
+			->andWhere($qb->expr()->eq('accepted', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)))
+			->andWhere($qb->expr()->isNull('accepted_at'));
+		return $qb->executeStatement() === 1;
+	}
+
+	/**
+	 * Deletes invites that can no longer be acted on but would still block a
+	 * fresh invite for the same recipient email. This covers expired rows and
+	 * defensive cleanup for rows that already have an accepted_at timestamp.
+	 */
+	public function deleteSupersededInvitesForRecipientEmail(string $userId, string $email, ?int $now = null): int {
+		$timestamp = $now ?? time();
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete(self::TABLE_NAME)
+			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+			->andWhere($qb->expr()->eq('recipient_email', $qb->createNamedParameter($email)))
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->isNotNull('accepted_at'),
+					$qb->expr()->andX(
+						$qb->expr()->eq('accepted', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)),
+						$qb->expr()->isNotNull('expired_at'),
+						$qb->expr()->lte('expired_at', $qb->createNamedParameter($timestamp, IQueryBuilder::PARAM_INT)),
+					),
+				),
+			);
+		return $qb->executeStatement();
+	}
+
+}

--- a/lib/Exception/ContactAlreadyExistsException.php
+++ b/lib/Exception/ContactAlreadyExistsException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Exception;
+
+use Exception;
+
+class ContactAlreadyExistsException extends Exception {
+}

--- a/lib/Listener/FederatedInviteAcceptedListener.php
+++ b/lib/Listener/FederatedInviteAcceptedListener.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Listener;
+
+use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\Service\FederatedInvitesService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\OCM\Events\OCMEndpointRequestEvent;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Listener for the OCMEndpointRequestEvent.
+ *
+ * @template-implements IEventListener<OCMEndpointRequestEvent>
+ */
+class FederatedInviteAcceptedListener implements IEventListener {
+
+	public function __construct(
+		private FederatedInvitesService $federatedInvitesService,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Handles the OCMEndpointRequestEvent that is dispatched by the
+	 * OCMRequestController as response to an OCM request. This handler manages
+	 * the invite-accepted capability.
+	 */
+	#[\Override]
+	public function handle(Event $event): void {
+		if (!($event instanceof OCMEndpointRequestEvent)
+			|| $event->getRequestedCapability() !== 'invite-accepted') {
+			return;
+		}
+
+		$payload = $event->getPayload();
+		if (!$this->isValidInviteAcceptedPayload($payload)) {
+			$this->logger->error('Could not accept invite, user data is incomplete.', [
+				'app' => Application::APP_ID,
+				'payloadKeys' => array_keys($payload),
+			]);
+			$event->setResponse(new JSONResponse([
+				'message' => 'Could not accept invite, user data is incomplete.',
+			], Http::STATUS_NOT_FOUND));
+			return;
+		}
+
+		$event->setResponse($this->federatedInvitesService->inviteAccepted(
+			$payload['recipientProvider'],
+			$payload['token'],
+			$payload['userID'],
+			$payload['email'],
+			$payload['name'],
+		));
+	}
+
+	/**
+	 * The accepted-invite callback requires all documented OCM string fields to
+	 * be present and non-empty.
+	 *
+	 * @param array<string, mixed> $payload
+	 */
+	private function isValidInviteAcceptedPayload(array $payload): bool {
+		foreach (['recipientProvider', 'token', 'userID', 'email', 'name'] as $key) {
+			if (!array_key_exists($key, $payload) || !is_string($payload[$key])) {
+				return false;
+			}
+		}
+
+		return trim($payload['recipientProvider']) !== ''
+			&& trim($payload['token']) !== ''
+			&& trim($payload['userID']) !== ''
+			&& trim($payload['email']) !== ''
+			&& trim($payload['name']) !== '';
+	}
+}

--- a/lib/Listener/OcmDiscoveryListener.php
+++ b/lib/Listener/OcmDiscoveryListener.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Contacts\Listener;
+
+use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\ConfigLexicon as ContactsConfigLexicon;
+use OCA\Contacts\Service\FederatedInvitesService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IAppConfig;
+use OCP\IURLGenerator;
+use OCP\OCM\Events\LocalOCMDiscoveryEvent;
+use OCP\OCM\Events\ResourceTypeRegisterEvent;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/** @template-implements IEventListener<Event> */
+class OcmDiscoveryListener implements IEventListener {
+	public function __construct(
+		private IAppConfig $appConfig,
+		private IURLGenerator $urlGenerator,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Register the invite capability and dialog route on local OCM discovery.
+	 *
+	 * @param Event $event an event of type LocalOCMDiscoveryEvent or ResourceTypeRegisterEvent
+	 * @return void
+	 */
+	#[\Override]
+	public function handle(Event $event): void {
+		if (!$this->isOcmDiscoveryEvent($event)) {
+			return;
+		}
+
+		if (!$this->appConfig->getValueBool(Application::APP_ID, ContactsConfigLexicon::OCM_INVITES_ENABLED)) {
+			return;
+		}
+
+		if ($event instanceof LocalOCMDiscoveryEvent) {
+			$event->addCapability('invite-accepted');
+
+			try {
+				$event->getProvider()->setInviteAcceptDialog(
+					$this->urlGenerator->linkToRouteAbsolute(FederatedInvitesService::OCM_INVITE_ACCEPT_DIALOG_ROUTE_NAME),
+				);
+			} catch (Throwable $e) {
+				$this->logger->warning('OCM invites are enabled but invite accept dialog route cannot be resolved', [
+					'app' => Application::APP_ID,
+					'route' => FederatedInvitesService::OCM_INVITE_ACCEPT_DIALOG_ROUTE_NAME,
+					'exception' => $e,
+				]);
+			}
+		}
+	}
+
+	private function isOcmDiscoveryEvent(Event $event): bool {
+		return $event instanceof LocalOCMDiscoveryEvent
+			|| $event instanceof ResourceTypeRegisterEvent;
+	}
+}

--- a/lib/Listener/OcmDiscoveryListener.php
+++ b/lib/Listener/OcmDiscoveryListener.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Listener;
+
+use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\ConfigLexicon as ContactsConfigLexicon;
+use OCA\Contacts\Service\FederatedInvitesService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IAppConfig;
+use OCP\IURLGenerator;
+use OCP\OCM\Events\LocalOCMDiscoveryEvent;
+use OCP\OCM\Events\ResourceTypeRegisterEvent;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/** @template-implements IEventListener<Event> */
+class OcmDiscoveryListener implements IEventListener {
+	public function __construct(
+		private IAppConfig $appConfig,
+		private IURLGenerator $urlGenerator,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Register the invite capability and dialog route on local OCM discovery.
+	 *
+	 * @param Event $event an event of type LocalOCMDiscoveryEvent or ResourceTypeRegisterEvent
+	 * @return void
+	 */
+	#[\Override]
+	public function handle(Event $event): void {
+		if (!$this->isOcmDiscoveryEvent($event)) {
+			return;
+		}
+
+		if (!$this->appConfig->getValueBool(Application::APP_ID, ContactsConfigLexicon::OCM_INVITES_ENABLED)) {
+			return;
+		}
+
+		if ($event instanceof LocalOCMDiscoveryEvent) {
+			$event->addCapability('invite-accepted');
+
+			try {
+				$event->getProvider()->setInviteAcceptDialog(
+					$this->urlGenerator->linkToRouteAbsolute(FederatedInvitesService::OCM_INVITE_ACCEPT_DIALOG_ROUTE_NAME),
+				);
+			} catch (Throwable $e) {
+				$this->logger->warning('OCM invites are enabled but invite accept dialog route cannot be resolved', [
+					'app' => Application::APP_ID,
+					'route' => FederatedInvitesService::OCM_INVITE_ACCEPT_DIALOG_ROUTE_NAME,
+					'exception' => $e,
+				]);
+			}
+		}
+	}
+
+	private function isOcmDiscoveryEvent(Event $event): bool {
+		return $event instanceof LocalOCMDiscoveryEvent
+			|| $event instanceof ResourceTypeRegisterEvent;
+	}
+}

--- a/lib/MeshProvidersCache.php
+++ b/lib/MeshProvidersCache.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts;
+
+use OCA\Contacts\AppInfo\Application;
+use OCP\IAppConfig;
+
+/**
+ * The actual cache is implemented as an associative array containing all providers for each mesh and the expiration times:
+ *  [
+ * 	    'mesh 1' => [[...provider a...], [...]],
+ *      'mesh 2' => [[...]],
+ *      'expires' => 1781280096,
+ *      'delta_expires' => 1781280095
+ *  ]
+ *
+ * Two kinds of expirations are used:
+ *  - FEDERATIONS_CACHE_EXPIRES - should result in a full cache rebuild
+ *  - FEDERATIONS_CACHE_DELTA_EXPIRES - should update the cache for new or removed providers
+ */
+class MeshProvidersCache {
+
+	private array $expirationTimes;
+
+	public function __construct(
+		private IAppConfig $appConfig,
+	) {
+		$data = $this->appConfig->getValueArray(Application::APP_ID, ConfigLexicon::FEDERATIONS_CACHE, [], true);
+		$this->expirationTimes = [
+			ConfigLexicon::FEDERATIONS_CACHE_EXPIRES => $data[ConfigLexicon::FEDERATIONS_CACHE_EXPIRES] ?? 0,
+			ConfigLexicon::FEDERATIONS_CACHE_DELTA_EXPIRES => $data[ConfigLexicon::FEDERATIONS_CACHE_DELTA_EXPIRES] ?? 0
+		];
+	}
+
+	/**
+	 * Returns all federations as associative array:
+	 *  [
+	 * 	    'mesh_A' => [[...provider_a...], [...]],
+	 *      'mesh_B' => [[...]],
+	 *  ]
+	 *
+	 * @return array
+	 */
+	public function getFederations(): array {
+		$data = $this->appConfig->getValueArray(Application::APP_ID, ConfigLexicon::FEDERATIONS_CACHE, [], true);
+		unset($data[ConfigLexicon::FEDERATIONS_CACHE_EXPIRES]);
+		unset($data[ConfigLexicon::FEDERATIONS_CACHE_DELTA_EXPIRES]);
+		return $data;
+	}
+
+	/**
+	 * Replaces the federations in the cache with the specified ones.
+	 *
+	 * @param array $federations
+	 * @return void
+	 */
+	public function setFederations(array $federations): void {
+		$cachedData = $this->appConfig->getValueArray(Application::APP_ID, ConfigLexicon::FEDERATIONS_CACHE, [], true);
+		$federations[ConfigLexicon::FEDERATIONS_CACHE_EXPIRES] = $cachedData[ConfigLexicon::FEDERATIONS_CACHE_EXPIRES] ?? 0;
+		$federations[ConfigLexicon::FEDERATIONS_CACHE_DELTA_EXPIRES] = $cachedData[ConfigLexicon::FEDERATIONS_CACHE_DELTA_EXPIRES] ?? 0;
+		$this->appConfig->setValueArray(Application::APP_ID, ConfigLexicon::FEDERATIONS_CACHE, $federations, true);
+	}
+
+	/**
+	 * Sets the expiration time of the specified kind to the specified time.
+	 *
+	 * @param string $expirationTimeKey the kind of expiration to set
+	 * @param int $time
+	 * @return void
+	 */
+	public function setExpirationTime(string $expirationTimeKey, int $time): void {
+		$this->expirationTimes[$expirationTimeKey] = $time;
+		$data = $this->appConfig->getValueArray(Application::APP_ID, ConfigLexicon::FEDERATIONS_CACHE, [], true);
+		$data[$expirationTimeKey] = $time;
+		$this->appConfig->setValueArray(Application::APP_ID, ConfigLexicon::FEDERATIONS_CACHE, $data, true);
+	}
+
+	/**
+	 * Check the expiration time.
+	 *
+	 * @param $expirationTimeKey the key for which to check the expiration time
+	 * @return bool
+	 */
+	public function hasExpired(string $expirationTimeKey): bool {
+		$cachedData = $this->appConfig->getValueArray(Application::APP_ID, ConfigLexicon::FEDERATIONS_CACHE, [], true);
+		$deltaExpirationTime = $cachedData[ConfigLexicon::FEDERATIONS_CACHE_DELTA_EXPIRES] ?? 0;
+		if ($expirationTimeKey === ConfigLexicon::FEDERATIONS_CACHE_DELTA_EXPIRES && $deltaExpirationTime < time()) {
+			return true;
+		}
+		$expirationTime = $cachedData[ConfigLexicon::FEDERATIONS_CACHE_EXPIRES] ?? 0;
+		if ($expirationTimeKey === ConfigLexicon::FEDERATIONS_CACHE_EXPIRES && $expirationTime < time()) {
+			return true;
+		}
+		return false;
+	}
+}

--- a/lib/Migration/Version8004Date20260130131217.php
+++ b/lib/Migration/Version8004Date20260130131217.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\Attributes\CreateTable;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+#[CreateTable(table: 'federated_invites', columns: ['id', 'user_id', 'recipient_provider', 'recipient_user_id', 'recipient_name', 'recipient_email', 'token', 'accepted', 'created_at', 'expired_at', 'accepted_at'], description: 'Supporting the OCM Invitation Flow feature')]
+class Version8004Date20260130131217 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$table_name = 'federated_invites';
+
+		if (!$schema->hasTable($table_name)) {
+			$table = $schema->createTable($table_name);
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 11,
+				'unsigned' => true,
+			]);
+			$table->addColumn('user_id', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+
+			]);
+			// https://saturncloud.io/blog/what-is-the-maximum-length-of-a-url-in-different-browsers/#maximum-url-length-in-different-browsers
+			// We use the least common denominator, the minimum length supported by browsers
+			$table->addColumn('recipient_provider', Types::STRING, [
+				'notnull' => false,
+				'length' => 2083,
+			]);
+			$table->addColumn('recipient_user_id', Types::STRING, [
+				'notnull' => false,
+				'length' => 1024,
+			]);
+			$table->addColumn('recipient_name', Types::STRING, [
+				'notnull' => false,
+				'length' => 1024,
+			]);
+			// https://www.directedignorance.com/blog/maximum-length-of-email-address
+			$table->addColumn('recipient_email', Types::STRING, [
+				'notnull' => false,
+				'length' => 320,
+			]);
+			$table->addColumn('token', Types::STRING, [
+				'notnull' => true,
+				'length' => 60,
+			]);
+			$table->addColumn('accepted', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => false
+			]);
+			$table->addColumn('created_at', Types::BIGINT, [
+				'notnull' => true,
+			]);
+
+			$table->addColumn('expired_at', Types::BIGINT, [
+				'notnull' => false,
+			]);
+
+			$table->addColumn('accepted_at', Types::BIGINT, [
+				'notnull' => false,
+			]);
+
+			$table->addUniqueConstraint(['token']);
+			$table->setPrimaryKey(['id']);
+			return $schema;
+		}
+
+		return null;
+	}
+}

--- a/lib/Migration/Version8004Date20260130131217.php
+++ b/lib/Migration/Version8004Date20260130131217.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\Attributes\CreateTable;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+#[CreateTable(table: 'federated_invites', columns: ['id', 'user_id', 'recipient_provider', 'recipient_user_id', 'recipient_name', 'recipient_email', 'token', 'accepted', 'created_at', 'expired_at', 'accepted_at'], description: 'Supporting the OCM Invitation Flow feature')]
+class Version8004Date20260130131217 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$table_name = 'federated_invites';
+
+		if (!$schema->hasTable($table_name)) {
+			$table = $schema->createTable($table_name);
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 11,
+				'unsigned' => true,
+			]);
+			$table->addColumn('user_id', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			// https://saturncloud.io/blog/what-is-the-maximum-length-of-a-url-in-different-browsers/#maximum-url-length-in-different-browsers
+			// We use the least common denominator, the minimum length supported by browsers
+			$table->addColumn('recipient_provider', Types::STRING, [
+				'notnull' => false,
+				'length' => 2083,
+			]);
+			$table->addColumn('recipient_user_id', Types::STRING, [
+				'notnull' => false,
+				'length' => 1024,
+			]);
+			$table->addColumn('recipient_name', Types::STRING, [
+				'notnull' => false,
+				'length' => 1024,
+			]);
+			// https://www.directedignorance.com/blog/maximum-length-of-email-address
+			$table->addColumn('recipient_email', Types::STRING, [
+				'notnull' => false,
+				'length' => 320,
+			]);
+			$table->addColumn('token', Types::STRING, [
+				'notnull' => true,
+				'length' => 60,
+			]);
+			$table->addColumn('accepted', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => false
+			]);
+			$table->addColumn('created_at', Types::BIGINT, [
+				'notnull' => true,
+			]);
+
+			$table->addColumn('expired_at', Types::BIGINT, [
+				'notnull' => false,
+			]);
+
+			$table->addColumn('accepted_at', Types::BIGINT, [
+				'notnull' => false,
+			]);
+
+			$table->addUniqueConstraint(['token']);
+			$table->setPrimaryKey(['id']);
+			return $schema;
+		}
+
+		return null;
+	}
+}

--- a/lib/Migration/Version8005Date20260418120000.php
+++ b/lib/Migration/Version8005Date20260418120000.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\Attributes\AddIndex;
+use OCP\Migration\Attributes\IndexType;
+use OCP\Migration\Attributes\ModifyColumn;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Schema and config setup for the OCM invites feature.
+ *
+ *   1. Backfill NULL `accepted` rows to false and tighten the column to
+ *      NOT NULL DEFAULT false on `federated_invites`.
+ *   2. Add a partial UNIQUE index `(user_id, recipient_email)` for open
+ *      invites on Postgres and SQLite. This closes a Time-Of-Check to
+ *      Time-Of-Use (TOCTOU) race where two concurrent requests both
+ *      pass the application-level "is there already an open invite for
+ *      this email?" check in FederatedInviteMapper::claimInviteForEmail()
+ *      before either has inserted its row, and end up with two open
+ *      invites for the same recipient. The index makes the second
+ *      INSERT fail at the database. MySQL/MariaDB lack partial indexes,
+ *      so the application guard remains the only defence there.
+ *
+ * All steps are idempotent.
+ */
+#[ModifyColumn(table: 'federated_invites', name: 'accepted', description: 'Make the accepted flag NOT NULL after backfilling NULL rows to false')]
+#[AddIndex(table: 'federated_invites', type: IndexType::UNIQUE, description: 'Partial unique index on (user_id, recipient_email) for open invites; Postgres and SQLite only')]
+class Version8005Date20260418120000 extends SimpleMigrationStep {
+	private const INDEX_NAME = 'fed_inv_open_email_uniq';
+
+	public function __construct(
+		private IDBConnection $connection,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	#[\Override]
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->update('federated_invites')
+			->set('accepted', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL))
+			->where($qb->expr()->isNull('accepted'));
+		$qb->executeStatement();
+	}
+
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('federated_invites')) {
+			return null;
+		}
+
+		$table = $schema->getTable('federated_invites');
+		if (!$table->hasColumn('accepted')) {
+			return null;
+		}
+
+		$column = $table->getColumn('accepted');
+		if ($column->getNotnull() === true) {
+			return null;
+		}
+
+		$column->setNotnull(true);
+		$column->setDefault(false);
+
+		return $schema;
+	}
+
+	#[\Override]
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$this->createPartialUniqueIndex($output);
+	}
+
+	private function createPartialUniqueIndex(IOutput $output): void {
+		$provider = $this->connection->getDatabaseProvider();
+		if ($provider !== IDBConnection::PLATFORM_POSTGRES && $provider !== IDBConnection::PLATFORM_SQLITE) {
+			$output->info(sprintf(
+				'Skipping partial unique index %s on %s; application-level guard remains in effect.',
+				self::INDEX_NAME,
+				$provider,
+			));
+			$this->logger->info(
+				'Skipped partial unique index for federated_invites on database provider {provider}.',
+				['app' => 'contacts', 'provider' => $provider],
+			);
+			return;
+		}
+
+		$predicate = $provider === IDBConnection::PLATFORM_POSTGRES
+			? 'recipient_email IS NOT NULL AND accepted = false'
+			: 'recipient_email IS NOT NULL AND accepted = 0';
+
+		$sql = sprintf(
+			'CREATE UNIQUE INDEX IF NOT EXISTS %s ON %sfederated_invites (user_id, recipient_email) WHERE %s',
+			self::INDEX_NAME,
+			'*PREFIX*',
+			$predicate,
+		);
+
+		try {
+			$this->connection->executeStatement($sql);
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				'Failed to create partial unique index for federated_invites: {message}',
+				['app' => 'contacts', 'message' => $e->getMessage(), 'exception' => $e],
+			);
+			throw new \RuntimeException('Could not create required open-invite uniqueness index.', 0, $e);
+		}
+	}
+
+}

--- a/lib/Service/FederatedInvitesService.php
+++ b/lib/Service/FederatedInvitesService.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Service;
+
+use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\ConfigLexicon;
+use OCA\Contacts\Db\FederatedInviteMapper;
+use OCA\Contacts\Exception\ContactAlreadyExistsException;
+use OCA\DAV\CardDAV\CardDavBackend;
+use OCA\FederatedFileSharing\AddressHandler;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+class FederatedInvitesService {
+
+	// The default route of the invite accept dialog
+	public const OCM_INVITE_ACCEPT_DIALOG_ROUTE = '/ocm/invite-accept-dialog';
+	public const OCM_INVITE_ACCEPT_DIALOG_ROUTE_NAME = 'contacts.federatedinvites.inviteacceptdialog';
+	// The default expiration period of a new invite in seconds, ie. 30 days
+	private const INVITE_EXPIRATION_PERIOD_SECONDS = 2592000;
+
+	public function __construct(
+		private AddressHandler $addressHandler,
+		private IAppConfig $appConfig,
+		private ITimeFactory $timeFactory,
+		private IURLGenerator $urlGenerator,
+		private IUserManager $userManager,
+		private IUserSession $userSession,
+		private FederatedInviteMapper $federatedInviteMapper,
+		private LoggerInterface $logger,
+		private SocialApiService $socialApiService,
+	) {
+	}
+
+	public function isOcmInvitesEnabled(): bool {
+		return $this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::OCM_INVITES_ENABLED);
+	}
+
+	public function isOptionalMailEnabled(): bool {
+		return $this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::OCM_INVITES_OPTIONAL_MAIL);
+	}
+
+	public function isEncodedCopyButtonEnabled(): bool {
+		return $this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::OCM_INVITES_ENCODED_COPY_BUTTON);
+	}
+
+	public function isSsrfGuardDisabled(): bool {
+		return $this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::OCM_INVITES_DISABLE_SSRF_GUARD);
+	}
+
+	/**
+	 * The set of admin-toggleable OCM bool keys. Used to gate writes from the
+	 * admin settings page so callers cannot persist arbitrary keys.
+	 */
+	public const OCM_INVITES_BOOL_KEYS = [
+		ConfigLexicon::OCM_INVITES_OPTIONAL_MAIL,
+		ConfigLexicon::OCM_INVITES_ENCODED_COPY_BUTTON,
+		ConfigLexicon::OCM_INVITES_DISABLE_SSRF_GUARD,
+	];
+
+	/**
+	 * Persist an OCM admin bool toggle. Returns true when the key is allowed.
+	 */
+	public function setOcmInviteBoolSetting(string $key, bool $value): bool {
+		if (!in_array($key, self::OCM_INVITES_BOOL_KEYS, true)) {
+			return false;
+		}
+		$this->appConfig->setValueBool(Application::APP_ID, $key, $value);
+		return true;
+	}
+
+	/**
+	 * Returns all OCM invites config flags for frontend consumption
+	 */
+	public function getOcmInvitesConfig(): array {
+		return [
+			'optionalMail' => $this->isOptionalMailEnabled(),
+			'encodedCopyButton' => $this->isEncodedCopyButtonEnabled(),
+		];
+	}
+
+	/**
+	 * Returns the provider's server FQDN.
+	 * @return string the FQDN
+	 */
+	public function getProviderFQDN(): string {
+		$serverUrl = $this->urlGenerator->getAbsoluteURL('/');
+		$parts = parse_url($serverUrl);
+		if (!is_array($parts) || !isset($parts['host']) || $parts['host'] === '') {
+			return '';
+		}
+		return $parts['host'];
+	}
+
+	/**
+	 * Returns the expiration date.
+	 * @param int $creationDate
+	 * @return int the expiration date
+	 */
+	public function getInviteExpirationDate(int $creationDate): int {
+		return $creationDate + self::INVITE_EXPIRATION_PERIOD_SECONDS;
+	}
+
+	/**
+	 * Creates a new contact and adds it to the address book of the user with the specified userId or,
+	 * if null, the current logged-in user.
+	 *
+	 * @param string cloudId
+	 * @param string email
+	 * @param string name
+	 * @param ?string userId id of the user for which to create the new contact.
+	 * If null, this is the current logged-in user.
+	 *
+	 * @return string the ref of the new contact in the form
+	 *                'contactURI~addressBookUri'
+	 * @throws ContactAlreadyExistsException
+	 */
+	public function createNewContact(string $cloudId, string $email, string $name, ?string $userId): ?string {
+		$localUserId = $userId ? $userId : $this->userSession->getUser()->getUID();
+		$newContact = $this->socialApiService->createContact(
+			$cloudId,
+			$email,
+			$name,
+			$localUserId,
+		);
+		if (!isset($newContact)) {
+			$this->logger->error('Error creating contact for user {userId} with cloud id {cloudId}.', [
+				'app' => Application::APP_ID,
+				'userId' => $localUserId,
+				'cloudId' => $cloudId,
+			]);
+			return null;
+		}
+		$this->logger->info('Created new contact with UID: ' . $newContact['UID'] . ' for user with UID: ' . $localUserId, ['app' => Application::APP_ID]);
+		$addressBookUri = CardDavBackend::PERSONAL_ADDRESSBOOK_URI;
+		if (isset($newContact['ADDRESSBOOK_URI']) && is_string($newContact['ADDRESSBOOK_URI']) && $newContact['ADDRESSBOOK_URI'] !== '') {
+			$addressBookUri = $newContact['ADDRESSBOOK_URI'];
+		}
+		$contactRef = $newContact['UID'] . '~' . $addressBookUri;
+		return $contactRef;
+	}
+
+	/**
+	 * This is the invite-accepted capability implementation.
+	 */
+	public function inviteAccepted(string $recipientProvider, string $token, string $userID, string $email, string $name): JSONResponse {
+		$this->logger->debug('Processing share invitation for ' . $userID . ' with token ' . $token . ' and email ' . $email . ' and name ' . $name);
+
+		$updated = $this->timeFactory->getTime();
+
+		if ($token === '') {
+			$response = new JSONResponse(['message' => 'Invalid or non existing token', 'error' => true], Http::STATUS_BAD_REQUEST);
+			$response->throttle();
+			return $response;
+		}
+
+		if (trim($recipientProvider) === '' || trim($userID) === '' || trim($email) === '' || trim($name) === '') {
+			return new JSONResponse(['message' => 'Could not accept invite, user data is incomplete.', 'error' => true], Http::STATUS_BAD_REQUEST);
+		}
+
+		try {
+			$invitation = $this->federatedInviteMapper->findByToken($token);
+		} catch (DoesNotExistException) {
+			$response = ['message' => 'Invalid or non existing token', 'error' => true];
+			$response = new JSONResponse($response, Http::STATUS_BAD_REQUEST);
+			$response->throttle();
+			return $response;
+		}
+
+		if ($invitation->isAccepted() === true) {
+			$response = ['message' => 'Invite already accepted', 'error' => true];
+			return new JSONResponse($response, Http::STATUS_CONFLICT);
+		}
+
+		if ($invitation->getExpiredAt() !== null && $updated > $invitation->getExpiredAt()) {
+			$response = ['message' => 'Invitation expired', 'error' => true];
+			return new JSONResponse($response, Http::STATUS_BAD_REQUEST);
+		}
+		// Note that there is no user session; local user is the sender of the invite
+		$localUser = $this->userManager->get($invitation->getUserId());
+		if ($localUser === null) {
+			$response = ['message' => 'Invalid or non existing token', 'error' => true];
+			$response = new JSONResponse($response, Http::STATUS_BAD_REQUEST);
+			$response->throttle();
+			return $response;
+		}
+
+		$sharedFromEmail = $localUser->getEMailAddress();
+		if ($sharedFromEmail === null) {
+			$response = ['message' => 'Invalid or non existing token', 'error' => true];
+			$response = new JSONResponse($response, Http::STATUS_BAD_REQUEST);
+			$response->throttle();
+			return $response;
+		}
+		$sharedFromDisplayName = $localUser->getDisplayName();
+
+		$response = ['userID' => $localUser->getUID(), 'email' => $sharedFromEmail, 'name' => $sharedFromDisplayName];
+		$status = Http::STATUS_OK;
+
+		$cloudId = $userID . '@' . $this->addressHandler->removeProtocolFromUrl($recipientProvider);
+		try {
+			$contactRef = $this->createNewContact(
+				$cloudId,
+				$email,
+				$name,
+				$localUser->getUID()
+			);
+			if ($contactRef === null) {
+				$this->logger->error('Could not create sender-side contact after invite acceptance.', [
+					'app' => Application::APP_ID,
+					'userId' => $localUser->getUID(),
+					'cloudId' => $cloudId,
+					'token' => $token,
+				]);
+				return new JSONResponse([
+					'message' => 'Could not create sender-side contact after invite acceptance.',
+					'error' => true,
+				], Http::STATUS_INTERNAL_SERVER_ERROR);
+			}
+		} catch (ContactAlreadyExistsException $e) {
+			// A duplicate sender-side contact should not block invite acceptance.
+			$this->logger->info("Contact with cloud id $cloudId already exists. ");
+		}
+
+		$invitation->setAccepted(true);
+		$invitation->setRecipientEmail($email);
+		$invitation->setRecipientName($name);
+		$invitation->setRecipientProvider($recipientProvider);
+		$invitation->setRecipientUserId($userID);
+		$invitation->setAcceptedAt($updated);
+		$invitation = $this->federatedInviteMapper->update($invitation);
+		return new JSONResponse($response, $status);
+	}
+}

--- a/lib/Service/Social/FacebookProvider.php
+++ b/lib/Service/Social/FacebookProvider.php
@@ -7,6 +7,7 @@
 
 namespace OCA\Contacts\Service\Social;
 
+use OCP\AppFramework\Http;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 
@@ -120,7 +121,7 @@ class FacebookProvider implements ISocialProvider {
 	protected function findFacebookId(string $profileName):string {
 		try {
 			$result = $this->httpClient->get('https://facebook.com/' . $profileName);
-			if ($result->getStatusCode() !== 200) {
+			if ($result->getStatusCode() !== Http::STATUS_OK) {
 				return $profileName;
 			}
 			$htmlResult = $result->getBody();

--- a/lib/Service/Social/FacebookProvider.php
+++ b/lib/Service/Social/FacebookProvider.php
@@ -7,6 +7,7 @@
 
 namespace OCA\Contacts\Service\Social;
 
+use OCP\AppFramework\Http;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 
@@ -119,7 +120,7 @@ class FacebookProvider implements ISocialProvider {
 	protected function findFacebookId(string $profileName):string {
 		try {
 			$result = $this->httpClient->get('https://facebook.com/' . $profileName);
-			if ($result->getStatusCode() !== 200) {
+			if ($result->getStatusCode() !== Http::STATUS_OK) {
 				return $profileName;
 			}
 			$htmlResult = $result->getBody();

--- a/lib/Service/SocialApiService.php
+++ b/lib/Service/SocialApiService.php
@@ -9,8 +9,11 @@ declare(strict_types=1);
 
 namespace OCA\Contacts\Service;
 
+use Exception;
 use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\Exception\ContactAlreadyExistsException;
 use OCA\Contacts\Service\Social\CompositeSocialProvider;
+use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\ContactsManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -20,9 +23,10 @@ use OCP\Contacts\IManager;
 use OCP\Http\Client\IClientService;
 use OCP\IAddressBook;
 use OCP\IConfig;
-use OCP\IL10N;
+use OCP\ICreateContactFromString;
 use OCP\IURLGenerator;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use function in_array;
 
 class SocialApiService {
@@ -40,10 +44,10 @@ class SocialApiService {
 		private IManager $manager,
 		private IConfig $config,
 		private IClientService $clientService,
-		private IL10N $l10n,
 		private IURLGenerator $urlGen,
 		private ITimeFactory $timeFactory,
 		private ImageResizer $imageResizer,
+		private LoggerInterface $logger,
 	) {
 		$this->appName = Application::APP_ID;
 	}
@@ -107,30 +111,22 @@ class SocialApiService {
 	/**
 	 * Gets the address book of an addressBookId
 	 *
-	 * @param string $addressBookId the identifier of the addressbook
+	 * @param string $addressbookId the identifier of the addressbook
 	 * @param IManager|null $manager optional a ContactManager to use
 	 *
 	 * @return IAddressBook|null the corresponding addressbook or null
 	 */
-	protected function getAddressBook(string $addressBookId, ?IManager $manager = null) : ?IAddressBook {
+	protected function getAddressBook(string $addressbookId, ?IManager $manager = null) : ?IAddressBook {
 		$addressBook = null;
 		if ($manager === null) {
 			$manager = $this->manager;
 		}
 		$addressBooks = $manager->getUserAddressBooks();
 		foreach ($addressBooks as $ab) {
-			if ($ab->getUri() === $addressBookId) {
+			if ($ab->getUri() === $addressbookId) {
 				$addressBook = $ab;
 			}
 		}
-
-		$addressBookIsUpdatable = $addressBook !== null
-			&& ($addressBook->getPermissions() & Constants::PERMISSION_UPDATE);
-
-		if (!$addressBookIsUpdatable) {
-			return null;
-		}
-
 		return $addressBook;
 	}
 
@@ -183,7 +179,11 @@ class SocialApiService {
 			$contact = $contacts[0];
 
 			if ($network) {
-				$allConnectors = [$this->socialProvider->getSocialConnector($network)];
+				$connector = $this->socialProvider->getSocialConnector($network);
+				if ($connector === null) {
+					return new JSONResponse([], Http::STATUS_BAD_REQUEST);
+				}
+				$allConnectors = [$connector];
 			}
 
 			$connectors = array_filter($allConnectors, function ($connector) use ($contact) {
@@ -252,7 +252,131 @@ class SocialApiService {
 	}
 
 	/**
-	 * checks an address book is existing
+	 * Creates a contact and adds it to the address book of the local user with the specified userId,
+	 * unless a contact with the specified cloudId already exists for that local user.
+	 *
+	 * @param string $cloudId the cloud id of the contact
+	 * @param string $email the email of the contact
+	 * @param string $name the name of the contact
+	 * @param string $userId the uid of the local user
+	 * @throws ContactAlreadyExistsException
+	 */
+	public function createContact(string $cloudId, string $email, string $name, string $userId): ?array {
+		try {
+			// Set up the contacts provider for the user with the specified uid
+			$cm = $this->serverContainer->get(ContactsManager::class);
+			$cm->setupContactsProvider($this->manager, $userId, $this->urlGen);
+
+			// if contact already exists we throw ContactAlreadyExistsException
+			$searchResult = $this->manager->search($cloudId, ['CLOUD']);
+			if (count($searchResult) > 0) {
+				$this->logger->info('Contact with cloud id ' . $cloudId . ' already exists.', ['app' => Application::APP_ID]);
+				throw new ContactAlreadyExistsException('Contact with cloud id ' . $cloudId . ' already exists.');
+			}
+
+			$addressBook = $this->pickAddressBookForContactCreation($this->manager->getUserAddressBooks());
+			if (!isset($addressBook)) {
+				$this->logger->error('No suitable address book found. Unable to add the new contact on invite accepted.', ['app' => Application::APP_ID]);
+				return null;
+			}
+
+			$newContact = $this->manager->createOrUpdate(
+				[
+					'FN' => $name,
+					'EMAIL' => $email,
+					'CLOUD' => $cloudId,
+				],
+				$addressBook->getKey()
+			);
+			$newContact['ADDRESSBOOK_URI'] = $addressBook->getUri();
+			return $newContact;
+		} catch (ContactAlreadyExistsException $e) {
+			throw $e;
+		} catch (Exception $e) {
+			$this->logger->error('An exception occurred creating a new contact: ' . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+		}
+		return null;
+	}
+
+	/**
+	 * Creates a federated contact (no thrown exceptions; null on duplicate or
+	 * when no suitable writable address book exists).
+	 *
+	 * Used by the FederatedInviteAcceptedListener on the inviter side, where
+	 * there is no user session and the inviter UID must be passed explicitly.
+	 *
+	 * @param string $cloudId the cloud id of the federated contact
+	 * @param string $email the email of the federated contact
+	 * @param string $name the display name of the federated contact
+	 * @param string $userId the uid of the local (inviter) user
+	 *
+	 * @return array|null the created contact array, or null if a contact with
+	 *                    that cloud id already exists or there is no suitable
+	 *                    writable address book for the inviter
+	 */
+	public function createFederatedContact(string $cloudId, string $email, string $name, string $userId): ?array {
+		try {
+			$cm = $this->serverContainer->get(ContactsManager::class);
+			$cm->setupContactsProvider($this->manager, $userId, $this->urlGen);
+
+			$searchResult = $this->manager->search($cloudId, ['CLOUD']);
+			if (count($searchResult) > 0) {
+				$this->logger->info('Contact with cloud id ' . $cloudId . ' already exists.', ['app' => Application::APP_ID]);
+				return null;
+			}
+
+			$addressBook = $this->pickAddressBookForContactCreation($this->manager->getUserAddressBooks());
+			if (!isset($addressBook)) {
+				$this->logger->error('No suitable address book found. Unable to add the new contact on invite accepted.', ['app' => Application::APP_ID]);
+				return null;
+			}
+
+			$newContact = $this->manager->createOrUpdate(
+				[
+					'FN' => $name,
+					'EMAIL' => $email,
+					'CLOUD' => $cloudId,
+				],
+				$addressBook->getKey()
+			);
+			return $newContact;
+		} catch (Exception $e) {
+			$this->logger->error('An exception occurred creating a federated contact: ' . $e->getMessage(), ['exception' => $e]);
+		}
+		return null;
+	}
+
+	/**
+	 * Pick a destination book using the same order as ImportController:
+	 * personal address book first, then first writable non-shared.
+	 */
+	private function pickAddressBookForContactCreation(array $addressBooks): ?ICreateContactFromString {
+		$creatableAddressBooks = array_filter(
+			$addressBooks,
+			static fn (IAddressBook $addressBook): bool => $addressBook instanceof ICreateContactFromString,
+		);
+
+		foreach ($creatableAddressBooks as $addressBook) {
+			if ($addressBook->getUri() === CardDavBackend::PERSONAL_ADDRESSBOOK_URI) {
+				return $addressBook;
+			}
+		}
+
+		foreach ($creatableAddressBooks as $addressBook) {
+			if ($addressBook->isShared()) {
+				continue;
+			}
+			if (($addressBook->getPermissions() & Constants::PERMISSION_CREATE) === 0) {
+				continue;
+			}
+			return $addressBook;
+		}
+
+		return null;
+	}
+
+	/**
+	 * checks an addressbook is existing
 	 *
 	 * @param string $searchBookId the UID of the addressbook to verify
 	 * @param string $userId the user that should have access

--- a/lib/Service/SocialApiService.php
+++ b/lib/Service/SocialApiService.php
@@ -9,8 +9,11 @@ declare(strict_types=1);
 
 namespace OCA\Contacts\Service;
 
+use Exception;
 use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\Exception\ContactAlreadyExistsException;
 use OCA\Contacts\Service\Social\CompositeSocialProvider;
+use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\ContactsManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -20,9 +23,10 @@ use OCP\Contacts\IManager;
 use OCP\Http\Client\IClientService;
 use OCP\IAddressBook;
 use OCP\IConfig;
-use OCP\IL10N;
+use OCP\ICreateContactFromString;
 use OCP\IURLGenerator;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use function in_array;
 
 class SocialApiService {
@@ -40,10 +44,10 @@ class SocialApiService {
 		private IManager $manager,
 		private IConfig $config,
 		private IClientService $clientService,
-		private IL10N $l10n,
 		private IURLGenerator $urlGen,
 		private ITimeFactory $timeFactory,
 		private ImageResizer $imageResizer,
+		private LoggerInterface $logger,
 	) {
 		$this->appName = Application::APP_ID;
 	}
@@ -103,23 +107,22 @@ class SocialApiService {
 		}
 	}
 
-
 	/**
 	 * Gets the address book of an addressBookId
 	 *
-	 * @param string $addressBookId the identifier of the addressbook
+	 * @param string $addressbookId the identifier of the addressbook
 	 * @param IManager|null $manager optional a ContactManager to use
 	 *
 	 * @return IAddressBook|null the corresponding addressbook or null
 	 */
-	protected function getAddressBook(string $addressBookId, ?IManager $manager = null) : ?IAddressBook {
+	protected function getAddressBook(string $addressbookId, ?IManager $manager = null) : ?IAddressBook {
 		$addressBook = null;
 		if ($manager === null) {
 			$manager = $this->manager;
 		}
 		$addressBooks = $manager->getUserAddressBooks();
 		foreach ($addressBooks as $ab) {
-			if ($ab->getUri() === $addressBookId) {
+			if ($ab->getUri() === $addressbookId) {
 				$addressBook = $ab;
 			}
 		}
@@ -133,7 +136,6 @@ class SocialApiService {
 
 		return $addressBook;
 	}
-
 
 	/**
 	 * Retrieves and initiates all address books from a user
@@ -183,7 +185,11 @@ class SocialApiService {
 			$contact = $contacts[0];
 
 			if ($network) {
-				$allConnectors = [$this->socialProvider->getSocialConnector($network)];
+				$connector = $this->socialProvider->getSocialConnector($network);
+				if ($connector === null) {
+					return new JSONResponse([], Http::STATUS_BAD_REQUEST);
+				}
+				$allConnectors = [$connector];
 			}
 
 			$connectors = array_filter($allConnectors, function ($connector) use ($contact) {
@@ -252,7 +258,83 @@ class SocialApiService {
 	}
 
 	/**
-	 * checks an address book is existing
+	 * Creates a contact and adds it to the address book of the local user with the specified userId,
+	 * unless a contact with the specified cloudId already exists for that local user.
+	 *
+	 * @param string $cloudId the cloud id of the contact
+	 * @param string $email the email of the contact
+	 * @param string $name the name of the contact
+	 * @param string $userId the uid of the local user
+	 * @throws ContactAlreadyExistsException
+	 */
+	public function createContact(string $cloudId, string $email, string $name, string $userId): ?array {
+		try {
+			// Set up the contacts provider for the user with the specified uid
+			$cm = $this->serverContainer->get(ContactsManager::class);
+			$cm->setupContactsProvider($this->manager, $userId, $this->urlGen);
+
+			// if contact already exists we throw ContactAlreadyExistsException
+			$searchResult = $this->manager->search($cloudId, ['CLOUD']);
+			if (count($searchResult) > 0) {
+				$this->logger->info('Contact with cloud id ' . $cloudId . ' already exists.', ['app' => Application::APP_ID]);
+				throw new ContactAlreadyExistsException('Contact with cloud id ' . $cloudId . ' already exists.');
+			}
+
+			$addressBook = $this->pickAddressBookForContactCreation($this->manager->getUserAddressBooks());
+			if (!isset($addressBook)) {
+				$this->logger->error('No suitable address book found. Unable to add the new contact on invite accepted.', ['app' => Application::APP_ID]);
+				return null;
+			}
+
+			$newContact = $this->manager->createOrUpdate(
+				[
+					'FN' => $name,
+					'EMAIL' => $email,
+					'CLOUD' => $cloudId,
+				],
+				$addressBook->getKey()
+			);
+			$newContact['ADDRESSBOOK_URI'] = $addressBook->getUri();
+			return $newContact;
+		} catch (ContactAlreadyExistsException $e) {
+			throw $e;
+		} catch (Exception $e) {
+			$this->logger->error('An exception occurred creating a new contact: ' . $e->getTraceAsString(), ['app' => Application::APP_ID]);
+		}
+		return null;
+	}
+
+	/**
+	 * Pick a destination book using the same order as ImportController:
+	 * personal address book first, then first writable non-shared.
+	 */
+	private function pickAddressBookForContactCreation(array $addressBooks): ?ICreateContactFromString {
+		$creatableAddressBooks = array_filter(
+			$addressBooks,
+			static fn (IAddressBook $addressBook): bool => $addressBook instanceof ICreateContactFromString,
+		);
+
+		foreach ($creatableAddressBooks as $addressBook) {
+			if ($addressBook->getUri() === CardDavBackend::PERSONAL_ADDRESSBOOK_URI) {
+				return $addressBook;
+			}
+		}
+
+		foreach ($creatableAddressBooks as $addressBook) {
+			if ($addressBook->isShared()) {
+				continue;
+			}
+			if (($addressBook->getPermissions() & Constants::PERMISSION_CREATE) === 0) {
+				continue;
+			}
+			return $addressBook;
+		}
+
+		return null;
+	}
+
+	/**
+	 * checks an addressbook is existing
 	 *
 	 * @param string $searchBookId the UID of the addressbook to verify
 	 * @param string $userId the user that should have access

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -8,6 +8,7 @@
 namespace OCA\Contacts\Settings;
 
 use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\Service\FederatedInvitesService;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IConfig;
@@ -16,28 +17,24 @@ use OCP\Settings\ISettings;
 class AdminSettings implements ISettings {
 	protected $appName;
 
-	/**
-	 * Admin constructor.
-	 *
-	 * @param IConfig $config
-	 * @param IL10N $l
-	 */
 	public function __construct(
 		private IConfig $config,
 		private IInitialState $initialState,
+		private FederatedInvitesService $federatedInvitesService,
 	) {
 		$this->appName = Application::APP_ID;
 	}
 
-	/**
-	 * @return TemplateResponse
-	 */
 	#[\Override]
-	public function getForm() {
+	public function getForm(): TemplateResponse {
 		foreach (Application::AVAIL_SETTINGS as $key => $default) {
 			$data = $this->config->getAppValue($this->appName, $key, $default);
 			$this->initialState->provideInitialState($key, $data);
 		}
+		$this->initialState->provideInitialState(
+			'ocmInvitesConfig',
+			$this->federatedInvitesService->getOcmInvitesConfig(),
+		);
 		return new TemplateResponse($this->appName, 'settings/admin');
 	}
 

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -8,6 +8,7 @@
 namespace OCA\Contacts\Settings;
 
 use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\Service\FederatedInvitesService;
 use OCA\Contacts\Service\SocialApiService;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
@@ -17,15 +18,14 @@ class AdminSettings implements ISettings {
 	public function __construct(
 		private IInitialState $initialState,
 		private SocialApiService $socialApiService,
+		private FederatedInvitesService $federatedInvitesService,
 	) {
 	}
 
-	/**
-	 * @return TemplateResponse
-	 */
 	#[\Override]
 	public function getForm() {
 		$this->initialState->provideInitialState('allowSocialSync', $this->socialApiService->syncAllowedByAdmin());
+		$this->initialState->provideInitialState('ocmInvitesConfig', $this->federatedInvitesService->getOcmInvitesConfig());
 		return new TemplateResponse(Application::APP_ID, 'settings/admin');
 	}
 

--- a/lib/WayfProvider.php
+++ b/lib/WayfProvider.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts;
+
+use Exception;
+use OCA\Contacts\AppInfo\Application;
+use OCP\AppFramework\Http;
+use OCP\Http\Client\IClientService;
+use OCP\IAppConfig;
+use OCP\IURLGenerator;
+use OCP\OCM\IOCMDiscoveryService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class WayfProvider.
+ * Provides a basic WAYF (Where Are You From) login implementation build from the list of available mesh providers.
+ *
+ */
+class WayfProvider {
+
+	public function __construct(
+		private IAppConfig $appConfig,
+		private IClientService $httpClient,
+		private LoggerInterface $logger,
+		private IOCMDiscoveryService $discovery,
+		private IURLGenerator $urlGenerator,
+		private MeshProvidersCache $meshProvidersCache,
+	) {
+	}
+
+	/**
+	 * Updates the mesh providers cache by consulting the mesh directory service.
+	 * Complete refresh or only update cache with new/removed providers depends on the cache expiration time key specified.
+	 *
+	 * The providers are retrieved from the mesh directory service.
+	 * @see https://datatracker.ietf.org/doc/html/draft-ietf-ocm-open-cloud-mesh-04#name-appendix-c-directory-servic
+	 *
+	 * @param string $cacheExpirationTimeKey
+	 * @return void
+	 */
+	public function updateMeshProvidersCache(string $cacheExpirationTimeKey): void {
+		// determine whether to do a complete refresh
+		$refresh = false;
+		if ($cacheExpirationTimeKey === ConfigLexicon::FEDERATIONS_CACHE_EXPIRES && $this->meshProvidersCache->hasExpired(ConfigLexicon::FEDERATIONS_CACHE_EXPIRES)) {
+			$refresh = true;
+		}
+
+		$federationsCache = $this->meshProvidersCache->getFederations();
+		$urls = preg_split('/\s+/', trim($this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::MESH_PROVIDERS_SERVICE)));
+		$federations = [];
+		$ourServerUrlParts = parse_url($this->urlGenerator->getAbsoluteUrl('/'));
+		$ourFqdn = is_array($ourServerUrlParts) && isset($ourServerUrlParts['host']) ? $ourServerUrlParts['host'] : '';
+		$found = [];
+		foreach ($urls as $url) {
+			if ($url === '') {
+				continue;
+			}
+			try {
+				$res = $this->httpClient->newClient()->get($url);
+				$code = $res->getStatusCode();
+				if (!($code >= Http::STATUS_OK && $code < Http::STATUS_BAD_REQUEST)) {
+					$this->logger->error("Unable to retrieve providers from service at $url. Status returned was: " . $code, ['app' => Application::APP_ID]);
+					continue;
+				}
+				$data = json_decode($res->getBody(), true);
+				$fed = $data['federation'] ?? 'Unknown';
+				$federations[$fed] = $federations[$fed] ?? [];
+
+				$servers = is_array($data['servers'] ?? null) ? $data['servers'] : [];
+				foreach ($servers as $prov) {
+					$providerUrl = is_array($prov) && isset($prov['url']) ? (string)$prov['url'] : '';
+					if ($providerUrl === '') {
+						continue;
+					}
+					$fqdn = parse_url($providerUrl, PHP_URL_HOST);
+					if (!is_string($fqdn) || $fqdn === '') {
+						continue;
+					}
+					if (($ourFqdn !== '' && $ourFqdn === $fqdn) || in_array($fqdn, $found, true)) {
+						continue;
+					}
+					$cachedProvider = $this->getProviderFromCache($fqdn);
+
+					// allways discover a new provider
+					if (empty($cachedProvider) || $refresh) {
+						$inviteAcceptDialog = '';
+						try {
+							$disc = $this->discovery->discover($providerUrl, true);
+							$inviteAcceptDialog = $disc->getInviteAcceptDialog();
+						} catch (Exception $e) {
+							$this->logger->error('Discovery failed for ' . $providerUrl . ': ' . $e->getMessage(), ['app' => Application::APP_ID]);
+							continue;
+						}
+						if ($inviteAcceptDialog === '') {
+							// We fall back on Nextcloud default path
+							$inviteAcceptDialogPath = self::getInviteAcceptDialogPath();
+							$inviteAcceptDialog = rtrim($providerUrl, '/') . $inviteAcceptDialogPath;
+						}
+						$federations[$fed][] = [
+							'provider' => $disc->getProvider(),
+							'name' => (string)($prov['displayName'] ?? $fqdn),
+							'fqdn' => $fqdn,
+							'inviteAcceptDialog' => $inviteAcceptDialog,
+						];
+					} else {
+						// used cached data
+						$federations[$fed][] = $cachedProvider;
+					}
+					array_push($found, $fqdn);
+				}
+				usort($federations[$fed], fn ($a, $b) => strcmp($a['name'], $b['name']));
+			} catch (Exception $e) {
+				$this->logger->error('Fetch failed for ' . $url . ': ' . $e->getMessage(), ['app' => Application::APP_ID]);
+			}
+		}
+		$this->meshProvidersCache->setFederations($federations);
+	}
+
+	/**
+	 * Return the provider with the specified fqdn from the cache.
+	 *
+	 * @param string $fqdn
+	 * @return array
+	 */
+	private function getProviderFromCache(string $fqdn = ''): array {
+		$federations = $this->meshProvidersCache->getFederations();
+		$providerFound = null;
+		array_find($federations, function ($mesh) use ($fqdn, &$providerFound) {
+			if ($providerFound === null) {
+				$providerFound = array_find($mesh, function ($provider) use ($fqdn) {
+					return $provider['fqdn'] == $fqdn ? $provider['fqdn'] : null;
+				});
+			}
+			return $providerFound;
+		});
+		return $providerFound === null ? [] : $providerFound;
+	}
+
+	/**
+	 * Return the providers from the cache.
+	 *
+	 * @return array
+	 */
+	public function getMeshProviders(): array {
+		return $this->meshProvidersCache->getFederations();
+	}
+
+	/**
+	 * Returns the WAYF (Where Are You From) login page endpoint to be used in the invitation link.
+	 * Can be read from the app config key in ConfigLexicon::WAYF_ENDPOINT.
+	 * If not set the endpoint the WAYF page implementation of this app is returned.
+	 * Note that the invitation link still needs the token and provider parameters, eg. "https://<wayf-page-endpoint>?token=$token&provider=$provider"
+	 *
+	 * Security: the value of ConfigLexicon::WAYF_ENDPOINT is used as the base of every
+	 * outgoing invitation URL. It is administrator-only configuration and
+	 * must point to a trusted WAYF page that the recipient can safely visit.
+	 * Setting it to an attacker-controlled origin would let invite links
+	 * leak the token and provider query parameters to a third party.
+	 *
+	 * @return string|null the WAYF login page endpoint or null if it could not be created
+	 */
+	public function getWayfEndpoint(): ?string {
+		// default wayf endpoint
+		$defaultWayfEndpoint = $this->urlGenerator->linkToRouteAbsolute(Application::APP_ID . '.federatedinvites.wayf');
+		$configuredEndpoint = trim($this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::WAYF_ENDPOINT));
+		return $configuredEndpoint === '' ? $defaultWayfEndpoint : $configuredEndpoint;
+	}
+
+	/**
+	 * Returns the path of the invite accept dialog route.
+	 *
+	 * @return string
+	 */
+	public function getInviteAcceptDialogPath(): string {
+		return $this->urlGenerator->linkToRoute(Application::APP_ID . '.federatedinvites.inviteacceptdialog');
+	}
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -31,15 +31,19 @@
 	<issueHandlers>
 		<UndefinedClass>
 			<errorLevel type="suppress">
+				<referencedClass name="GuzzleHttp\Exception\RequestException" />
 				<referencedClass name="OCA\DAV\CardDAV\CardDavBackend" />
 				<referencedClass name="OCA\DAV\CardDAV\ContactsManager" />
+				<referencedClass name="OCA\FederatedFileSharing\AddressHandler" />
 				<referencedClass name="OCA\Files\Event\LoadAdditionalScriptsEvent" />
 				<referencedClass name="OC\App\CompareVersion" />
 				<referencedClass name="Sabre\DAV\Server" />
+				<referencedClass name="Sabre\DAV\UUIDUtil" />
 			</errorLevel>
 		</UndefinedClass>
 		<UndefinedDocblockClass>
 			<errorLevel type="suppress">
+				<referencedClass name="Doctrine\DBAL\Schema\Table" />
 				<referencedClass name="OCA\Files\Event\LoadAdditionalScriptsEvent" />
 				<referencedClass name="Sabre\DAV\Server" />
 			</errorLevel>

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -12,28 +12,66 @@
 				v-model="allowSocialSync"
 				type="checkbox"
 				class="checkbox"
-				@change="updateSetting('allowSocialSync')">
+				@change="updateSocialSetting('allowSocialSync')">
 			<label for="allow-social-sync">{{ t('contacts', 'Allow updating avatars from social media') }}</label>
+		</p>
+
+		<h3>{{ t('contacts', 'External invitations') }}</h3>
+		<p>
+			<input
+				id="ocm-invites-optional-mail"
+				v-model="ocmInvitesConfig.optionalMail"
+				type="checkbox"
+				class="checkbox"
+				@change="updateOcmSetting(ocmInviteConfigKeys.optionalMail, ocmInvitesConfig.optionalMail)">
+			<label for="ocm-invites-optional-mail">{{ t('contacts', 'Allow creating invites without an email address (link-only)') }}</label>
+		</p>
+		<p>
+			<input
+				id="ocm-invites-encoded-copy-button"
+				v-model="ocmInvitesConfig.encodedCopyButton"
+				type="checkbox"
+				class="checkbox"
+				@change="updateOcmSetting(ocmInviteConfigKeys.encodedCopyButton, ocmInvitesConfig.encodedCopyButton)">
+			<label for="ocm-invites-encoded-copy-button">{{ t('contacts', 'Show the "Copy encoded invite" button on invite details') }}</label>
 		</p>
 	</div>
 </template>
 
 <script>
 import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
 import { generateUrl } from '@nextcloud/router'
+import { OCM_INVITES_CONFIG_KEYS } from '../models/constants.ts'
+
 export default {
 	name: 'AdminSettings',
 	data() {
 		return {
 			allowSocialSync: loadState('contacts', 'allowSocialSync') === 'yes',
+			ocmInviteConfigKeys: OCM_INVITES_CONFIG_KEYS,
+			ocmInvitesConfig: loadState('contacts', 'ocmInvitesConfig', {
+				optionalMail: false,
+				encodedCopyButton: false,
+			}),
 		}
 	},
 
 	methods: {
-		updateSetting(setting) {
+		updateSocialSetting(setting) {
 			axios.put(generateUrl('apps/contacts/api/v1/social/config/global/' + setting), {
 				allow: this[setting] ? 'yes' : 'no',
+			}).catch(() => {
+				showError(t('contacts', 'Could not save the setting'))
+			})
+		},
+
+		updateOcmSetting(key, value) {
+			axios.put(generateUrl('apps/contacts/ocm/admin/settings/{key}', { key }), {
+				value: Boolean(value),
+			}).catch(() => {
+				showError(t('contacts', 'Could not save the setting'))
 			})
 		},
 	},

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -12,28 +12,66 @@
 				v-model="allowSocialSync"
 				type="checkbox"
 				class="checkbox"
-				@change="updateSetting('allowSocialSync')">
+				@change="updateSocialSetting('allowSocialSync')">
 			<label for="allow-social-sync">{{ t('contacts', 'Allow updating avatars from social media') }}</label>
+		</p>
+
+		<h3>{{ t('contacts', 'External invitations') }}</h3>
+		<p>
+			<input
+				id="ocm-invites-optional-mail"
+				v-model="ocmInvitesConfig.optionalMail"
+				type="checkbox"
+				class="checkbox"
+				@change="updateOcmSetting(ocmInviteConfigKeys.optionalMail, ocmInvitesConfig.optionalMail)">
+			<label for="ocm-invites-optional-mail">{{ t('contacts', 'Allow creating invites without an email address (link-only)') }}</label>
+		</p>
+		<p>
+			<input
+				id="ocm-invites-encoded-copy-button"
+				v-model="ocmInvitesConfig.encodedCopyButton"
+				type="checkbox"
+				class="checkbox"
+				@change="updateOcmSetting(ocmInviteConfigKeys.encodedCopyButton, ocmInvitesConfig.encodedCopyButton)">
+			<label for="ocm-invites-encoded-copy-button">{{ t('contacts', 'Show the "Copy encoded invite" button on invite details') }}</label>
 		</p>
 	</div>
 </template>
 
 <script>
 import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
 import { generateUrl } from '@nextcloud/router'
+import { OCM_INVITES_CONFIG_KEYS } from '../models/constants.ts'
+
 export default {
 	name: 'AdminSettings',
 	data() {
 		return {
 			allowSocialSync: loadState('contacts', 'allowSocialSync', true),
+			ocmInviteConfigKeys: OCM_INVITES_CONFIG_KEYS,
+			ocmInvitesConfig: loadState('contacts', 'ocmInvitesConfig', {
+				optionalMail: false,
+				encodedCopyButton: false,
+			}),
 		}
 	},
 
 	methods: {
-		updateSetting(setting) {
+		updateSocialSetting(setting) {
 			axios.put(generateUrl('apps/contacts/api/v1/social/config/global/' + setting), {
 				allow: this[setting] ? 'yes' : 'no',
+			}).catch(() => {
+				showError(t('contacts', 'Could not save the setting'))
+			})
+		},
+
+		updateOcmSetting(key, value) {
+			axios.put(generateUrl('apps/contacts/ocm/admin/settings/{key}', { key }), {
+				value: Boolean(value),
+			}).catch(() => {
+				showError(t('contacts', 'Could not save the setting'))
 			})
 		},
 	},

--- a/src/components/AppContent/OcmInvitesContent.vue
+++ b/src/components/AppContent/OcmInvitesContent.vue
@@ -1,0 +1,173 @@
+<!--
+  - SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<AppContent v-if="loading">
+		<EmptyContent class="empty-content" :name="t('contacts', 'Loading invitations…')">
+			<template #icon>
+				<IconLoading :size="20" />
+			</template>
+		</EmptyContent>
+	</AppContent>
+
+	<AppContent v-else-if="hasLoadError">
+		<EmptyContent class="empty-content" :name="t('contacts', 'Could not load invitations')">
+			<template #icon>
+				<IconAccountSwitchOutline :size="20" />
+			</template>
+		</EmptyContent>
+		<div class="invite-retry__buttons-row">
+			<NcButton @click="retryLoad">
+				{{ t('contacts', 'Retry') }}
+			</NcButton>
+		</div>
+	</AppContent>
+
+	<AppContent v-else-if="isEmptyGroup">
+		<EmptyContent class="empty-content" :name="t('contacts', 'There are no invitations')">
+			<template #icon>
+				<IconAccountSwitchOutline :size="20" />
+			</template>
+			<template #action>
+				<NcButton variant="primary" @click="openCreateInvite()">
+					{{ t('contacts', 'Create invitation') }}
+				</NcButton>
+			</template>
+		</EmptyContent>
+	</AppContent>
+
+	<AppContent v-else :show-details="showDetails">
+		<!-- OCM invites list -->
+		<template #list>
+			<OcmInvitesList
+				:list="invitesList"
+				:invites="invites"
+				:search-query="searchQuery" />
+		</template>
+
+		<!-- OCM invite details -->
+		<OcmInviteDetails :invite-key="selectedInvite" />
+	</AppContent>
+</template>
+
+<script>
+import {
+	NcAppContent as AppContent,
+	NcEmptyContent as EmptyContent,
+	NcLoadingIcon as IconLoading,
+	NcButton,
+} from '@nextcloud/vue'
+import { mapStores } from 'pinia'
+import IconAccountSwitchOutline from 'vue-material-design-icons/AccountSwitchOutline.vue'
+import OcmInviteDetails from '../Ocm/OcmInviteDetails.vue'
+import OcmInvitesList from '../Ocm/OcmInvitesList.vue'
+import RouterMixin from '../../mixins/RouterMixin.js'
+import useOcmInvitesStore from '../../store/ocminvites.ts'
+
+export default {
+	name: 'OcmInvitesContent',
+
+	components: {
+		AppContent,
+		EmptyContent,
+		IconAccountSwitchOutline,
+		IconLoading,
+		NcButton,
+		OcmInviteDetails,
+		OcmInvitesList,
+	},
+
+	mixins: [RouterMixin],
+
+	props: {
+		loading: {
+			type: Boolean,
+			default: false,
+		},
+
+		invitesList: {
+			type: Array,
+			required: true,
+		},
+
+		inviteActionsEnabled: {
+			type: Boolean,
+			default: false,
+		},
+
+		errorMessage: {
+			type: String,
+			default: '',
+		},
+	},
+
+	emits: ['retry-load', 'open-create-invite'],
+
+	data() {
+		return {
+			searchQuery: '',
+		}
+	},
+
+	computed: {
+		...mapStores(useOcmInvitesStore),
+
+		// store variables
+		invites() {
+			return this.ocminvitesStore.ocmInvites
+		},
+
+		selectedInvite() {
+			return this.$route.params.selectedInvite
+		},
+
+		/**
+		 * Is the invites group empty
+		 *
+		 * @return {boolean}
+		 */
+		isEmptyGroup() {
+			return this.invitesList.length === 0
+		},
+
+		hasLoadError() {
+			return this.errorMessage.trim() !== ''
+		},
+
+		showDetails() {
+			return !!this.selectedInvite
+		},
+	},
+
+	methods: {
+		retryLoad() {
+			this.$emit('retry-load')
+		},
+
+		openCreateInvite() {
+			if (!this.inviteActionsEnabled) {
+				return
+			}
+			this.$emit('open-create-invite')
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.empty-content {
+	height: 100%;
+}
+
+.invite-retry__buttons-row {
+	display: flex;
+	justify-content: center;
+	padding-bottom: calc(var(--default-grid-baseline) * 3);
+}
+
+.empty-content button {
+	margin: var(--default-grid-baseline);
+}
+</style>

--- a/src/components/AppContent/OcmInvitesContent.vue
+++ b/src/components/AppContent/OcmInvitesContent.vue
@@ -1,0 +1,173 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<AppContent v-if="loading">
+		<EmptyContent class="empty-content" :name="t('contacts', 'Loading invitations…')">
+			<template #icon>
+				<IconLoading :size="20" />
+			</template>
+		</EmptyContent>
+	</AppContent>
+
+	<AppContent v-else-if="hasLoadError">
+		<EmptyContent class="empty-content" :name="t('contacts', 'Could not load invitations')">
+			<template #icon>
+				<IconAccountSwitchOutline :size="20" />
+			</template>
+		</EmptyContent>
+		<div class="invite-retry__buttons-row">
+			<NcButton @click="retryLoad">
+				{{ t('contacts', 'Retry') }}
+			</NcButton>
+		</div>
+	</AppContent>
+
+	<AppContent v-else-if="isEmptyGroup">
+		<EmptyContent class="empty-content" :name="t('contacts', 'There are no invitations')">
+			<template #icon>
+				<IconAccountSwitchOutline :size="20" />
+			</template>
+			<template #action>
+				<NcButton variant="primary" @click="openCreateInvite()">
+					{{ t('contacts', 'Create invitation') }}
+				</NcButton>
+			</template>
+		</EmptyContent>
+	</AppContent>
+
+	<AppContent v-else :show-details="showDetails">
+		<!-- OCM invites list -->
+		<template #list>
+			<OcmInvitesList
+				:list="invitesList"
+				:invites="invites"
+				:search-query="searchQuery" />
+		</template>
+
+		<!-- OCM invite details -->
+		<OcmInviteDetails :invite-key="selectedInvite" />
+	</AppContent>
+</template>
+
+<script>
+import {
+	NcAppContent as AppContent,
+	NcEmptyContent as EmptyContent,
+	NcLoadingIcon as IconLoading,
+	NcButton,
+} from '@nextcloud/vue'
+import { mapStores } from 'pinia'
+import IconAccountSwitchOutline from 'vue-material-design-icons/AccountSwitchOutline.vue'
+import OcmInviteDetails from '../Ocm/OcmInviteDetails.vue'
+import OcmInvitesList from '../Ocm/OcmInvitesList.vue'
+import RouterMixin from '../../mixins/RouterMixin.js'
+import useOcmInvitesStore from '../../store/ocminvites.ts'
+
+export default {
+	name: 'OcmInvitesContent',
+
+	components: {
+		AppContent,
+		EmptyContent,
+		IconAccountSwitchOutline,
+		IconLoading,
+		NcButton,
+		OcmInviteDetails,
+		OcmInvitesList,
+	},
+
+	mixins: [RouterMixin],
+
+	props: {
+		loading: {
+			type: Boolean,
+			default: false,
+		},
+
+		invitesList: {
+			type: Array,
+			required: true,
+		},
+
+		inviteActionsEnabled: {
+			type: Boolean,
+			default: false,
+		},
+
+		errorMessage: {
+			type: String,
+			default: '',
+		},
+	},
+
+	emits: ['retry-load', 'open-create-invite'],
+
+	data() {
+		return {
+			searchQuery: '',
+		}
+	},
+
+	computed: {
+		...mapStores(useOcmInvitesStore),
+
+		// store variables
+		invites() {
+			return this.ocminvitesStore.ocmInvites
+		},
+
+		selectedInvite() {
+			return this.$route.params.selectedInvite
+		},
+
+		/**
+		 * Is the invites group empty
+		 *
+		 * @return {boolean}
+		 */
+		isEmptyGroup() {
+			return this.invitesList.length === 0
+		},
+
+		hasLoadError() {
+			return this.errorMessage.trim() !== ''
+		},
+
+		showDetails() {
+			return !!this.selectedInvite
+		},
+	},
+
+	methods: {
+		retryLoad() {
+			this.$emit('retry-load')
+		},
+
+		openCreateInvite() {
+			if (!this.inviteActionsEnabled) {
+				return
+			}
+			this.$emit('open-create-invite')
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.empty-content {
+	height: 100%;
+}
+
+.invite-retry__buttons-row {
+	display: flex;
+	justify-content: center;
+	padding-bottom: calc(var(--default-grid-baseline) * 3);
+}
+
+.empty-content button {
+	margin: var(--default-grid-baseline);
+}
+</style>

--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -94,6 +94,26 @@
 				</template>
 			</AppNavigationItem>
 
+			<!-- OCM invitations -->
+			<AppNavigationItem
+				v-if="isOcmInvitesEnabled"
+				id="ocm-invites"
+				:name="GROUP_ALL_OCM_INVITES"
+				:to="{
+					name: ROUTE_NAME_ALL_OCM_INVITES,
+				}"
+				:active="routeState === 'ocm-invites'"
+				@click="updateRouteState('ocm-invites')">
+				<template #icon>
+					<IconAccountSwitchOutline :size="20" />
+				</template>
+				<template #counter>
+					<NcCounterBubble
+						v-if="pendingOcmInvitesCount"
+						:count="pendingOcmInvitesCount" />
+				</template>
+			</AppNavigationItem>
+
 			<AppNavigationCaption
 				id="newgroup"
 				v-model:menu-open="isNewGroupMenuOpen"
@@ -218,6 +238,7 @@ import IconUserFilled from 'vue-material-design-icons/Account.vue'
 import IconContactFilled from 'vue-material-design-icons/AccountMultiple.vue'
 import IconContact from 'vue-material-design-icons/AccountMultipleOutline.vue'
 import IconUser from 'vue-material-design-icons/AccountOutline.vue'
+import IconAccountSwitchOutline from 'vue-material-design-icons/AccountSwitchOutline.vue'
 import IconError from 'vue-material-design-icons/AlertCircleOutline.vue'
 import Cog from 'vue-material-design-icons/CogOutline.vue'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
@@ -227,9 +248,11 @@ import CircleNavigationItem from './CircleNavigationItem.vue'
 import ContactsSettings from './ContactsSettings.vue'
 import GroupNavigationItem from './GroupNavigationItem.vue'
 import RouterMixin from '../../mixins/RouterMixin.js'
-import { CHART_ALL_CONTACTS, CIRCLE_DESC, CONTACTS_SETTINGS, ELLIPSIS_COUNT, GROUP_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS, GROUP_RECENTLY_CONTACTED } from '../../models/constants.ts'
+import { CHART_ALL_CONTACTS, CIRCLE_DESC, CONTACTS_SETTINGS, ELLIPSIS_COUNT, GROUP_ALL_CONTACTS, GROUP_ALL_OCM_INVITES, GROUP_NO_GROUP_CONTACTS, GROUP_RECENTLY_CONTACTED, ROUTE_NAME_ALL_OCM_INVITES, ROUTE_NAME_OCM_INVITE } from '../../models/constants.ts'
 import isCirclesEnabled from '../../services/isCirclesEnabled.js'
 import isContactsInteractionEnabled from '../../services/isContactsInteractionEnabled.js'
+import isOcmInvitesEnabled from '../../services/isOcmInvitesEnabled.js'
+import useOcmInvitesStore from '../../store/ocminvites.ts'
 import useUserGroupStore from '../../store/userGroup.ts'
 
 export default {
@@ -247,6 +270,7 @@ export default {
 		Cog,
 		ContactsSettings,
 		GroupNavigationItem,
+		IconAccountSwitchOutline,
 		IconContact,
 		IconContactFilled,
 		IconUser,
@@ -277,6 +301,8 @@ export default {
 			CHART_ALL_CONTACTS,
 			GROUP_NO_GROUP_CONTACTS,
 			GROUP_RECENTLY_CONTACTED,
+			GROUP_ALL_OCM_INVITES,
+			ROUTE_NAME_ALL_OCM_INVITES,
 
 			// create group
 			isNewGroupMenuOpen: false,
@@ -296,6 +322,7 @@ export default {
 			showSettings: false,
 
 			routeState: 'all',
+			isOcmInvitesEnabled,
 		}
 	},
 
@@ -325,6 +352,13 @@ export default {
 
 		userGroups() {
 			return this.userGroupStore.userGroupList
+		},
+
+		// Only invitations the recipient has not accepted yet should drive
+		// the navigation badge, so it reads as a pending-action count.
+		pendingOcmInvitesCount() {
+			return Object.values(this.ocminvitesStore.ocmInvites)
+				.filter((invite) => !invite.accepted).length
 		},
 
 		// list all the contacts that doesn't have a group
@@ -422,7 +456,7 @@ export default {
 				: t('contacts', 'Collapse teams')
 		},
 
-		...mapStores(useUserGroupStore),
+		...mapStores(useOcmInvitesStore, useUserGroupStore),
 	},
 
 	methods: {
@@ -526,6 +560,7 @@ $caption-padding: 22px;
 	padding: calc(var(--default-grid-baseline, 4px) * 2);
 }
 
+#external-invitations,
 #newgroup,
 #newcircle {
 	margin-top: $caption-padding;

--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -125,6 +125,26 @@
 				</template>
 			</AppNavigationItem>
 
+			<!-- OCM invitations -->
+			<AppNavigationItem
+				v-if="isOcmInvitesEnabled"
+				id="ocm-invites"
+				:name="GROUP_ALL_OCM_INVITES"
+				:to="{
+					name: ROUTE_NAME_ALL_OCM_INVITES,
+				}"
+				:active="routeState === 'ocm-invites'"
+				@click="updateRouteState('ocm-invites')">
+				<template #icon>
+					<IconAccountSwitchOutline :size="20" />
+				</template>
+				<template #counter>
+					<NcCounterBubble
+						v-if="pendingOcmInvitesCount"
+						:count="pendingOcmInvitesCount" />
+				</template>
+			</AppNavigationItem>
+
 			<AppNavigationCaption
 				id="newgroup"
 				v-model:menu-open="isNewGroupMenuOpen"
@@ -250,6 +270,7 @@ import IconUserFilled from 'vue-material-design-icons/Account.vue'
 import IconContactFilled from 'vue-material-design-icons/AccountMultiple.vue'
 import IconContact from 'vue-material-design-icons/AccountMultipleOutline.vue'
 import IconUser from 'vue-material-design-icons/AccountOutline.vue'
+import IconAccountSwitchOutline from 'vue-material-design-icons/AccountSwitchOutline.vue'
 import IconError from 'vue-material-design-icons/AlertCircleOutline.vue'
 import IconAddressBook from 'vue-material-design-icons/BookAccountOutline.vue'
 import Cog from 'vue-material-design-icons/CogOutline.vue'
@@ -261,9 +282,11 @@ import ContactsSettings from './ContactsSettings.vue'
 import GroupNavigationItem from './GroupNavigationItem.vue'
 import SettingsNewAddressbook from './Settings/SettingsNewAddressbook.vue'
 import RouterMixin from '../../mixins/RouterMixin.js'
-import { CHART_ALL_CONTACTS, CIRCLE_DESC, CONTACTS_SETTINGS, ELLIPSIS_COUNT, GROUP_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS, GROUP_RECENTLY_CONTACTED, ROUTE_ADDRESSBOOK } from '../../models/constants.ts'
+import { CHART_ALL_CONTACTS, CIRCLE_DESC, CONTACTS_SETTINGS, ELLIPSIS_COUNT, GROUP_ALL_CONTACTS, GROUP_ALL_OCM_INVITES, GROUP_NO_GROUP_CONTACTS, GROUP_RECENTLY_CONTACTED, ROUTE_ADDRESSBOOK, ROUTE_NAME_ALL_OCM_INVITES } from '../../models/constants.ts'
 import isContactsInteractionEnabled from '../../services/isContactsInteractionEnabled.js'
+import isOcmInvitesEnabled from '../../services/isOcmInvitesEnabled.js'
 import isTeamManagementEnabled from '../../services/isTeamManagementEnabled.js'
+import useOcmInvitesStore from '../../store/ocminvites.ts'
 import useUserGroupStore from '../../store/userGroup.ts'
 
 export default {
@@ -282,6 +305,7 @@ export default {
 		ContactsSettings,
 		GroupNavigationItem,
 		IconAddressBook,
+		IconAccountSwitchOutline,
 		IconContact,
 		IconContactFilled,
 		IconUser,
@@ -314,6 +338,8 @@ export default {
 			GROUP_NO_GROUP_CONTACTS,
 			GROUP_RECENTLY_CONTACTED,
 			ROUTE_ADDRESSBOOK,
+			GROUP_ALL_OCM_INVITES,
+			ROUTE_NAME_ALL_OCM_INVITES,
 
 			// create group
 			isNewGroupMenuOpen: false,
@@ -333,6 +359,7 @@ export default {
 			showSettings: false,
 
 			routeState: 'all',
+			isOcmInvitesEnabled,
 		}
 	},
 
@@ -370,6 +397,13 @@ export default {
 
 		userGroups() {
 			return this.userGroupStore.userGroupList
+		},
+
+		// Only invitations the recipient has not accepted yet should drive
+		// the navigation badge, so it reads as a pending-action count.
+		pendingOcmInvitesCount() {
+			return Object.values(this.ocminvitesStore.ocmInvites)
+				.filter((invite) => !invite.accepted).length
 		},
 
 		// list all the contacts that doesn't have a group
@@ -467,7 +501,7 @@ export default {
 				: t('contacts', 'Collapse teams')
 		},
 
-		...mapStores(useUserGroupStore),
+		...mapStores(useOcmInvitesStore, useUserGroupStore),
 	},
 
 	methods: {
@@ -576,6 +610,7 @@ $caption-padding: 22px;
 	padding: calc(var(--default-grid-baseline, 4px) * 2);
 }
 
+#external-invitations,
 #newgroup,
 #newcircle {
 	margin-top: $caption-padding;

--- a/src/components/AppNavigation/Settings/SettingsImportContacts.vue
+++ b/src/components/AppNavigation/Settings/SettingsImportContacts.vue
@@ -4,7 +4,9 @@
 -->
 
 <template>
-	<div class="import-contact">
+	<div
+		class="import-contact"
+		:class="{ 'ocm-invites-enabled': isOcmInvitesEnabled }">
 		<template v-if="!isNoAddressbookAvailable">
 			<NcButton class="import-contact__button-main" @click="toggleModal">
 				<template #icon>
@@ -116,6 +118,13 @@ export default {
 		IconError,
 		IconFolder,
 		IconLoading,
+	},
+
+	props: {
+		isOcmInvitesEnabled: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	data() {
@@ -306,6 +315,10 @@ export default {
 			this.isOpened = false
 			this.loading = false
 		},
+
+		getOcmInvitesActiveClass() {
+
+		},
 	},
 }
 </script>
@@ -361,6 +374,10 @@ export default {
 			background-color: transparent;
 		}
 	}
+}
+
+.import-contact.ocm-invites-enabled {
+	width: calc(50% - (var(--default-grid-baseline) + var(--default-clickable-area)) * .5);
 }
 
 </style>

--- a/src/components/AppNavigation/Settings/SettingsImportContacts.vue
+++ b/src/components/AppNavigation/Settings/SettingsImportContacts.vue
@@ -4,7 +4,9 @@
 -->
 
 <template>
-	<div class="import-contact">
+	<div
+		class="import-contact"
+		:class="{ 'ocm-invites-enabled': isOcmInvitesEnabled }">
 		<template v-if="!isNoAddressbookAvailable">
 			<NcButton class="import-contact__button-main" @click="toggleModal">
 				<template #icon>
@@ -117,6 +119,13 @@ export default {
 		IconError,
 		IconFolder,
 		IconLoading,
+	},
+
+	props: {
+		isOcmInvitesEnabled: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	data() {
@@ -362,6 +371,10 @@ export default {
 			background-color: transparent;
 		}
 	}
+}
+
+.import-contact.ocm-invites-enabled {
+	width: calc(50% - (var(--default-grid-baseline) + var(--default-clickable-area)) * .5);
 }
 
 </style>

--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -8,13 +8,10 @@
 		<div class="circle-details-grid" :class="{ 'is-editing': isEditing }">
 			<div class="circle-details__header-wrapper">
 				<div class="circle-details-grid__avatar">
-					<NcLoadingIcon v-if="loadingAvatar" :size="75" />
 					<Avatar
-						v-else
 						:disable-tooltip="true"
 						:display-name="circle.displayName"
 						:is-no-user="true"
-						:url="displayAvatarUrl"
 						:size="75" />
 				</div>
 				<div class="circle-details__header">
@@ -44,41 +41,6 @@
 							:placeholder="descriptionPlaceholder"
 							label="Description"
 							:maxlength="1024" />
-					</div>
-					<div v-if="avatarSupported" class="circle-avatar-buttons-wrapper">
-						<NcButton
-							v-if="isEditing"
-							:disabled="loadingAvatar"
-							@click="openLocalFilePicker">
-							<template #icon>
-								<TrayArrowUpIcon :size="20" />
-							</template>
-							{{ t('contacts', 'Upload team picture') }}
-						</NcButton>
-						<NcButton
-							v-if="isEditing"
-							:disabled="loadingAvatar"
-							@click="openFilePicker">
-							<template #icon>
-								<FolderIcon :size="20" />
-							</template>
-							{{ t('contacts', 'Choose from Nextcloud Files') }}
-						</NcButton>
-						<NcButton
-							v-if="isEditing && displayAvatarUrl !== undefined"
-							:disabled="loadingAvatar"
-							@click="removeAvatar">
-							<template #icon>
-								<TrashCanOutlineIcon :size="20" />
-							</template>
-							{{ t('contacts', 'Delete picture') }}
-						</NcButton>
-						<input
-							ref="avatarInput"
-							type="file"
-							:accept="avatarAccept"
-							class="hidden-visually"
-							@change="onAvatarInputChange">
 					</div>
 					<div class="actions">
 						<template v-if="!isEditing">
@@ -256,44 +218,20 @@
 				</section>
 			</div>
 		</div>
-
-		<!-- Avatar cropper dialog -->
-		<NcDialog
-			v-if="showCropper"
-			class="circle-avatar-cropper-dialog"
-			:name="t('contacts', 'Edit team picture')"
-			:open="showCropper"
-			size="normal"
-			@closing="cancelSetAvatar">
-			<VueCropper
-				ref="cropper"
-				class="circle-avatar-cropper"
-				v-bind="cropperOptions" />
-			<template #actions>
-				<NcButton @click="cancelSetAvatar">
-					{{ t('contacts', 'Cancel') }}
-				</NcButton>
-				<NcButton variant="primary" @click="setAvatar">
-					{{ t('contacts', 'Apply') }}
-				</NcButton>
-			</template>
-		</NcDialog>
 	</div>
 </template>
 
 <script>
 import { getCurrentUser } from '@nextcloud/auth'
 import axios from '@nextcloud/axios'
-import { FilePickerClosed, FilePickerType, getFilePickerBuilder, showError, showSuccess } from '@nextcloud/dialogs'
-import { encodePath } from '@nextcloud/paths'
-import { generateOcsUrl, generateRemoteUrl, generateUrl } from '@nextcloud/router'
+import { showError, showSuccess } from '@nextcloud/dialogs'
+import { generateOcsUrl, generateUrl } from '@nextcloud/router'
 import {
 	NcAvatar as Avatar,
 	NcListItem as ListItem,
 	NcActionButton,
 	NcActions,
 	NcButton,
-	NcDialog,
 	NcEmptyContent,
 	NcLoadingIcon,
 	NcPopover,
@@ -303,7 +241,6 @@ import {
 } from '@nextcloud/vue'
 import { useElementSize } from '@vueuse/core'
 import { reactive, ref } from 'vue'
-import VueCropper from 'vue-cropperjs'
 import IconAccountGroup from 'vue-material-design-icons/AccountGroupOutline.vue'
 import AccountPlusIcon from 'vue-material-design-icons/AccountPlusOutline.vue'
 import BookOpenPageVariantIcon from 'vue-material-design-icons/BookOpenPageVariant.vue'
@@ -312,14 +249,11 @@ import CheckIcon from 'vue-material-design-icons/Check.vue'
 import CogIcon from 'vue-material-design-icons/CogOutline.vue'
 import CopyIcon from 'vue-material-design-icons/ContentCopy.vue'
 import FileDocumentOutline from 'vue-material-design-icons/FileDocumentOutline.vue'
-import FolderIcon from 'vue-material-design-icons/Folder.vue'
-import FolderOutlineIcon from 'vue-material-design-icons/FolderOutline.vue'
+import FolderIcon from 'vue-material-design-icons/FolderOutline.vue'
 import LoginIcon from 'vue-material-design-icons/Login.vue'
 import LogoutIcon from 'vue-material-design-icons/Logout.vue'
 import MessageIcon from 'vue-material-design-icons/MessageOutline.vue'
 import PencilIcon from 'vue-material-design-icons/PencilOutline.vue'
-import TrashCanOutlineIcon from 'vue-material-design-icons/TrashCanOutline.vue'
-import TrayArrowUpIcon from 'vue-material-design-icons/TrayArrowUp.vue'
 import ViewDashboardIcon from 'vue-material-design-icons/ViewDashboard.vue'
 import CircleSettings from './CircleDetails/CircleSettings.vue'
 import ContentHeading from './CircleDetails/ContentHeading.vue'
@@ -328,22 +262,6 @@ import MemberList from './MemberList/MemberList.vue'
 import CircleActionsMixin from '../mixins/CircleActionsMixin.js'
 import { CircleEdit, editCircle } from '../services/circles.ts'
 
-import 'cropperjs/dist/cropper.css'
-
-const VALID_MIME_TYPES = ['image/png', 'image/jpeg']
-
-const AVATAR_ACTIONS = Object.freeze({
-	SET: 'set',
-	DELETE: 'delete',
-})
-
-const picker = getFilePickerBuilder(t('contacts', 'Choose a team picture'))
-	.setMultiSelect(false)
-	.setMimeTypeFilter(VALID_MIME_TYPES)
-	.setType(FilePickerType.Choose)
-	.allowDirectories(false)
-	.build()
-
 export default {
 	name: 'CircleDetails',
 
@@ -351,7 +269,6 @@ export default {
 		AccountPlusIcon,
 		Avatar,
 		NcButton,
-		NcDialog,
 		ContentHeading,
 		ListItem,
 		CogIcon,
@@ -372,16 +289,12 @@ export default {
 		NcTextArea,
 		NcActions,
 		NcActionButton,
-		FolderOutlineIcon,
+		FolderIcon,
 		MessageIcon,
 		CalendarIcon,
 		ViewDashboardIcon,
 		BookOpenPageVariantIcon,
 		CheckIcon,
-		FolderIcon,
-		TrashCanOutlineIcon,
-		TrayArrowUpIcon,
-		VueCropper,
 	},
 
 	mixins: [CircleActionsMixin],
@@ -389,10 +302,7 @@ export default {
 	setup() {
 		const avatarList = ref()
 		const { width } = useElementSize(avatarList)
-		const avatarAccept = VALID_MIME_TYPES.join(',')
-		const nextcloudMajorVersion = parseInt(window.OC.config.version.split('.')[0])
-		const avatarSupported = nextcloudMajorVersion >= 34
-		return { avatarList, width, avatarAccept, avatarSupported }
+		return { avatarList, width }
 	},
 
 	data() {
@@ -418,24 +328,6 @@ export default {
 			createdCalendar: null,
 			showCalendarSuccessNotification: false,
 			createdCalendarName: '',
-
-			// Avatar
-			avatarUrl: undefined,
-			pendingAvatarBlob: null,
-			pendingAvatarAction: null,
-			pendingAvatarPreviewUrl: undefined,
-			showCropper: false,
-			loadingAvatar: false,
-			cropperOptions: {
-				aspectRatio: 1 / 1,
-				viewMode: 1,
-				guides: false,
-				center: false,
-				highlight: false,
-				autoCropArea: 1,
-				minContainerWidth: 300,
-				minContainerHeight: 300,
-			},
 		}
 	},
 
@@ -464,19 +356,6 @@ export default {
 
 		circleUrl() {
 			return window.location.href
-		},
-
-		displayAvatarUrl() {
-			if (!this.avatarSupported) {
-				return undefined
-			}
-			if (this.pendingAvatarAction === AVATAR_ACTIONS.DELETE) {
-				return undefined
-			}
-			if (this.pendingAvatarPreviewUrl) {
-				return this.pendingAvatarPreviewUrl
-			}
-			return this.avatarUrl
 		},
 
 		canManageTeam() {
@@ -538,7 +417,7 @@ export default {
 					inputLabel: t('contacts', 'New folder'),
 					placeholder: t('contacts', 'Folder name'),
 					helperText: t('contacts', 'This will create a regular folder shared with the team. To create a Team Folder, please contact your {productName} administrator', { productName: OC.theme.name }),
-					icon: 'FolderOutlineIcon',
+					icon: 'FolderIcon',
 					apiPath: 'files',
 					enabled: enabledApps.files !== undefined,
 				},
@@ -570,6 +449,15 @@ export default {
 					apiPath: 'calendar',
 					enabled: enabledApps.calendar !== undefined,
 				},
+				{
+					id: 'deck',
+					label: t('contacts', 'Deck board'),
+					inputLabel: t('contacts', 'New Deck board'),
+					placeholder: t('contacts', 'Board name'),
+					icon: 'ViewDashboardIcon',
+					apiPath: 'deck',
+					enabled: enabledApps.deck !== undefined,
+				},
 			].filter((resource) => resource.enabled)
 		},
 	},
@@ -577,26 +465,11 @@ export default {
 	watch: {
 		'circle.id': {
 			handler() {
-				this.isEditing = false
 				this.fetchTeamResources()
-				if (this.avatarSupported) {
-					this.cancelSetAvatar()
-					this.clearPendingAvatar()
-					this.loadAvatarUrl()
-				}
 			},
 
 			immediate: true,
 		},
-	},
-
-	beforeUnmount() {
-		if (this.avatarUrl !== undefined) {
-			URL.revokeObjectURL(this.avatarUrl)
-		}
-		if (this.pendingAvatarPreviewUrl !== undefined) {
-			URL.revokeObjectURL(this.pendingAvatarPreviewUrl)
-		}
 	},
 
 	methods: {
@@ -661,6 +534,7 @@ export default {
 
 					case 'calendar': {
 						const DavClient = (await import('@nextcloud/cdav-library')).default
+						const { generateRemoteUrl } = await import('@nextcloud/router')
 
 						const client = new DavClient({
 							rootUrl: generateRemoteUrl('dav'),
@@ -683,6 +557,11 @@ export default {
 							throw new Error(`CALENDAR_EXISTS:${name}`)
 						}
 						break
+					}
+
+					case 'deck': {
+						showError(t('contacts', 'Deck app is not installed. Please install it to create team boards.'))
+						return
 					}
 
 					default: {
@@ -772,104 +651,6 @@ export default {
 			}
 		},
 
-		openLocalFilePicker() {
-			this.$refs.avatarInput.value = null
-			this.$refs.avatarInput.click()
-		},
-
-		async onAvatarInputChange(e) {
-			try {
-				const file = e.target.files[0]
-				if (!VALID_MIME_TYPES.includes(file.type)) {
-					showError(t('contacts', 'Please select a valid png or jpg file'))
-					return
-				}
-				const reader = new FileReader()
-				reader.onload = async (e) => {
-					this.showCropper = true
-					await this.$nextTick()
-					this.$refs.cropper.replace(e.target.result)
-				}
-				reader.readAsDataURL(file)
-			} catch (error) {
-				console.error('Error picking avatar file', error)
-				showError(t('contacts', 'Error picking team picture'))
-			}
-		},
-
-		async openFilePicker() {
-			try {
-				const path = await picker.pick()
-				if (!path) {
-					return
-				}
-				const fileResponse = await axios.get(
-					generateRemoteUrl(`dav/files/${getCurrentUser().uid}`) + encodePath(path),
-					{ responseType: 'blob' },
-				)
-				const reader = new FileReader()
-				reader.onload = async (e) => {
-					this.showCropper = true
-					await this.$nextTick()
-					this.$refs.cropper.replace(e.target.result)
-				}
-				reader.readAsDataURL(fileResponse.data)
-			} catch (error) {
-				if (error instanceof FilePickerClosed) {
-					return
-				}
-				console.error('Error picking avatar file', error)
-				showError(t('contacts', 'Error picking team picture'))
-			}
-		},
-
-		setAvatar() {
-			this.showCropper = false
-			this.$refs.cropper.getCroppedCanvas({
-				minWidth: 16,
-				minHeight: 16,
-				maxWidth: 512,
-				maxHeight: 512,
-			}).toBlob(async (blob) => {
-				if (blob === null) {
-					showError(t('contacts', 'Error cropping avatar picture'))
-					this.cancelSetAvatar()
-					return
-				}
-				if (this.pendingAvatarPreviewUrl) {
-					URL.revokeObjectURL(this.pendingAvatarPreviewUrl)
-				}
-				this.pendingAvatarBlob = blob
-				this.pendingAvatarAction = AVATAR_ACTIONS.SET
-				this.pendingAvatarPreviewUrl = URL.createObjectURL(blob)
-			})
-		},
-
-		cancelSetAvatar() {
-			this.showCropper = false
-			if (this.$refs.avatarInput) {
-				this.$refs.avatarInput.value = null
-			}
-		},
-
-		removeAvatar() {
-			if (this.pendingAvatarPreviewUrl) {
-				URL.revokeObjectURL(this.pendingAvatarPreviewUrl)
-			}
-			this.pendingAvatarBlob = null
-			this.pendingAvatarAction = AVATAR_ACTIONS.DELETE
-			this.pendingAvatarPreviewUrl = undefined
-		},
-
-		clearPendingAvatar() {
-			if (this.pendingAvatarPreviewUrl) {
-				URL.revokeObjectURL(this.pendingAvatarPreviewUrl)
-			}
-			this.pendingAvatarBlob = null
-			this.pendingAvatarAction = null
-			this.pendingAvatarPreviewUrl = undefined
-		},
-
 		onLeave() {
 			this.isSettingsPopoverShown = false
 			this.confirmLeaveCircle()
@@ -893,8 +674,6 @@ export default {
 		cancelEditing() {
 			this.circle.displayName = this.originalDisplayName
 			this.circle.description = this.originalDescription
-			this.cancelSetAvatar()
-			this.clearPendingAvatar()
 			this.isEditing = false
 		},
 
@@ -902,27 +681,6 @@ export default {
 			const response = await axios.get(generateOcsUrl(`/teams/${this.circle.id}/resources`))
 			this.resources = response.data.ocs.data.resources
 			console.debug('Team resources', this.resources)
-		},
-
-		async loadAvatarUrl() {
-			if (!this.avatarSupported) {
-				return
-			}
-			try {
-				const response = await axios.get(
-					generateOcsUrl(`/apps/circles/circles/${this.circle.id}/avatar`),
-					{ responseType: 'blob' },
-				)
-				if (this.avatarUrl !== undefined) {
-					URL.revokeObjectURL(this.avatarUrl)
-				}
-				this.avatarUrl = URL.createObjectURL(response.data)
-			} catch {
-				if (this.avatarUrl !== undefined) {
-					URL.revokeObjectURL(this.avatarUrl)
-					this.avatarUrl = undefined
-				}
-			}
 		},
 
 		/**
@@ -940,10 +698,7 @@ export default {
 		async saveChanges() {
 			const errors = []
 
-			// Close avatar cropper if still open/pending on save
-			this.cancelSetAvatar()
-
-			// Save name, description and avatar sequentially to avoid race conditions
+			// Save name and description sequentially to avoid race conditions
 			// Save name if changed
 			if (this.circle.displayName !== this.originalDisplayName) {
 				this.loadingName = true
@@ -971,38 +726,6 @@ export default {
 					this.circle.description = this.originalDescription
 				} finally {
 					this.loadingDescription = false
-				}
-			}
-
-			// Upload pending avatar if set
-			if (this.avatarSupported && this.pendingAvatarAction === AVATAR_ACTIONS.SET && this.pendingAvatarBlob) {
-				this.loadingAvatar = true
-				const formData = new FormData()
-				formData.append('file', this.pendingAvatarBlob)
-				try {
-					await axios.post(generateOcsUrl(`/apps/circles/circles/${this.circle.id}/avatar`), formData)
-					this.clearPendingAvatar()
-					await this.loadAvatarUrl()
-				} catch {
-					console.error('Unable to save avatar picture')
-					errors.push('avatar')
-				} finally {
-					this.loadingAvatar = false
-				}
-			}
-
-			// Delete avatar if marked for deletion
-			if (this.avatarSupported && this.pendingAvatarAction === AVATAR_ACTIONS.DELETE) {
-				this.loadingAvatar = true
-				try {
-					await axios.delete(generateOcsUrl(`/apps/circles/circles/${this.circle.id}/avatar`))
-					this.clearPendingAvatar()
-					await this.loadAvatarUrl()
-				} catch {
-					console.error('Unable to remove avatar')
-					errors.push('avatar')
-				} finally {
-					this.loadingAvatar = false
 				}
 			}
 
@@ -1042,14 +765,6 @@ export default {
 			.circle-description-wrapper {
 				width: 100%;
 			}
-
-			.actions {
-				width: 100%;
-
-				:deep(.button-vue) {
-					flex: 1;
-				}
-			}
 		}
 
 		.circle-details__header-wrapper {
@@ -1075,7 +790,6 @@ export default {
 		align-items: flex-start;
 		gap: 2px;
 		width: 100%;
-		max-width: 500px;
 
 		.circle-description-wrapper {
 			margin-bottom: 4px;
@@ -1204,56 +918,6 @@ export default {
 		}
 	}
 
-	.circle-avatar-buttons-wrapper {
-		width: 100%;
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-		margin-bottom: 16px;
-
-		:deep(.button-vue) {
-			width: 100%;
-		}
-
-		@media (max-width: 768px) {
-			width: 100%;
-		}
-	}
 }
 
-.circle-avatar-cropper {
-	width: 300px;
-	height: 300px;
-	overflow: hidden;
-	margin-inline: auto;
-	margin-top: calc(-1 * var(--default-clickable-area));
-	margin-bottom: 16px;
-
-	:deep(.cropper-view-box) {
-		border-radius: 50%;
-	}
-}
-
-:deep(.dialog .dialog__content) {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-:deep(.dialog .dialog__actions) {
-	width: 100%;
-	gap: 8px;
-
-	.button-vue {
-		flex: 1;
-	}
-}
-</style>
-
-<style lang="scss">
-@media only screen and (min-width: 513px) {
-    .circle-avatar-cropper-dialog .modal-wrapper--normal .modal-container {
-        width: 324px !important;
-    }
-}
 </style>

--- a/src/components/Ocm/OcmAcceptForm.vue
+++ b/src/components/Ocm/OcmAcceptForm.vue
@@ -1,0 +1,191 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="ocm_manual_form">
+		<div class="ocm_manual_form__heading">
+			<h3 class="ocm_manual_form__title">
+				{{ t('contacts', 'Accept invitation') }}
+			</h3>
+		</div>
+		<p>
+			{{ t('contacts', 'Accepting will add the inviter to your contacts list and in return, your contact info will be sent to the inviter. From there on you can start sharing data with each other.') }}
+		</p>
+
+		<NcTextField
+			v-model="invite"
+			:label="t('contacts', 'Invite link or code (required)')"
+			type="text"
+			:error="Boolean(error)"
+			:helper-text="error || t('contacts', 'Paste the invite link, or an invite code (token@provider), you received from the other person.')"
+			:required="true" />
+
+		<div class="ocm_manual_buttons">
+			<NcButton variant="tertiary" :disabled="loadingUpdate" @click="cancel">
+				{{ t('contacts', 'Cancel') }}
+			</NcButton>
+			<NcButton variant="primary" :disabled="loadingUpdate" @click="accept">
+				<template #icon>
+					<NcLoadingIcon v-if="loadingUpdate" :size="20" />
+					<IconCheck v-else :size="20" />
+				</template>
+				{{ t('contacts', 'Accept') }}
+			</NcButton>
+		</div>
+	</div>
+</template>
+
+<script>
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import NcTextField from '@nextcloud/vue/components/NcTextField'
+import IconCheck from 'vue-material-design-icons/Check.vue'
+
+export default {
+	name: 'OcmAcceptForm',
+	components: {
+		NcTextField,
+		NcButton,
+		NcLoadingIcon,
+		IconCheck,
+	},
+
+	props: {
+		loadingUpdate: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	emits: ['accept', 'cancel'],
+	data() {
+		return {
+			invite: '',
+			error: '',
+		}
+	},
+
+	methods: {
+		parseInvite(str) {
+			function looksLikeUrl(s) {
+				return /^[a-z][a-z0-9+.-]*:\/\//i.test(s)
+			}
+
+			// Try to parse token@provider format
+			function tryParseTokenProvider(s) {
+				const idx = s.lastIndexOf('@')
+				if (idx === -1) {
+					return null
+				}
+				const token = s.slice(0, idx).trim()
+				const provider = s.slice(idx + 1).trim()
+				if (!token || !provider) {
+					return null
+				}
+				return { provider, token }
+			}
+
+			// Try to parse as URL with token query parameter
+			function tryParseUrl(s) {
+				try {
+					const url = new URL(s)
+					const token = url.searchParams.get('token')
+					if (!token) {
+						return null
+					}
+					// Provider must come from the invite payload itself. Falling back
+					// to the current URL host silently turns incomplete links into the
+					// wrong remote target.
+					const provider = url.searchParams.get('providerDomain') || url.searchParams.get('provider')
+					if (!provider) {
+						return null
+					}
+					return { provider, token }
+				} catch (e) {
+					return null
+				}
+			}
+
+			const s = String(str || '').trim()
+			if (looksLikeUrl(s)) {
+				const result = tryParseUrl(s)
+				if (result) {
+					return result
+				}
+				throw new Error('Could not parse invite')
+			}
+
+			// 1. Try token@provider format first
+			let result = tryParseTokenProvider(s)
+			if (result) {
+				return result
+			}
+
+			// 2. Try base64 decoding then token@provider
+			try {
+				const decoded = atob(s)
+				if (looksLikeUrl(decoded)) {
+					result = tryParseUrl(decoded)
+					if (result) {
+						return result
+					}
+				}
+				result = tryParseTokenProvider(decoded)
+				if (result) {
+					return result
+				}
+			} catch (e) {
+				// Not base64, continue
+			}
+
+			// 3. Try as URL
+			result = tryParseUrl(s)
+			if (result) {
+				return result
+			}
+
+			throw new Error('Could not parse invite')
+		},
+
+		accept() {
+			this.error = ''
+			try {
+				const { provider, token } = this.parseInvite(this.invite)
+				this.$emit('accept', { provider, token })
+			} catch (e) {
+				this.error = this.t('contacts', 'This invite does not look valid. Check that you copied it completely or ask the sender to generate a new one.')
+			}
+		},
+
+		cancel() {
+			this.$emit('cancel')
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.ocm_manual_buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: calc(var(--default-grid-baseline) * 2);
+}
+
+.ocm_manual_form {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--default-grid-baseline) * 4);
+  margin: calc(var(--default-grid-baseline) * 4);
+  p {
+    margin-bottom: calc(var(--default-grid-baseline) * 4);
+  }
+  :deep(.input-field__helper-text-message) {
+	word-break: initial;
+  }
+  &__title {
+	margin-top: 0;
+  }
+}
+</style>

--- a/src/components/Ocm/OcmAcceptForm.vue
+++ b/src/components/Ocm/OcmAcceptForm.vue
@@ -1,0 +1,191 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="ocm_manual_form">
+		<div class="ocm_manual_form__heading">
+			<h3 class="ocm_manual_form__title">
+				{{ t('contacts', 'Accept invitation') }}
+			</h3>
+		</div>
+		<p>
+			{{ t('contacts', 'Accepting will add the inviter to your contacts list and in return, your contact info will be sent to the inviter. From there on you can start sharing data with each other.') }}
+		</p>
+
+		<NcTextField
+			v-model="invite"
+			:label="t('contacts', 'Invite link or code (required)')"
+			type="text"
+			:error="Boolean(error)"
+			:helper-text="error || t('contacts', 'Paste the invite link, or an invite code (token@provider), you received from the other person.')"
+			:required="true" />
+
+		<div class="ocm_manual_buttons">
+			<NcButton variant="tertiary" :disabled="loadingUpdate" @click="cancel">
+				{{ t('contacts', 'Cancel') }}
+			</NcButton>
+			<NcButton variant="primary" :disabled="loadingUpdate" @click="accept">
+				<template #icon>
+					<NcLoadingIcon v-if="loadingUpdate" :size="20" />
+					<IconCheck v-else :size="20" />
+				</template>
+				{{ t('contacts', 'Accept') }}
+			</NcButton>
+		</div>
+	</div>
+</template>
+
+<script>
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import NcTextField from '@nextcloud/vue/components/NcTextField'
+import IconCheck from 'vue-material-design-icons/Check.vue'
+
+export default {
+	name: 'OcmAcceptForm',
+	components: {
+		NcTextField,
+		NcButton,
+		NcLoadingIcon,
+		IconCheck,
+	},
+
+	props: {
+		loadingUpdate: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	emits: ['accept', 'cancel'],
+	data() {
+		return {
+			invite: '',
+			error: '',
+		}
+	},
+
+	methods: {
+		parseInvite(str) {
+			function looksLikeUrl(s) {
+				return /^[a-z][a-z0-9+.-]*:\/\//i.test(s)
+			}
+
+			// Try to parse token@provider format
+			function tryParseTokenProvider(s) {
+				const idx = s.lastIndexOf('@')
+				if (idx === -1) {
+					return null
+				}
+				const token = s.slice(0, idx).trim()
+				const provider = s.slice(idx + 1).trim()
+				if (!token || !provider) {
+					return null
+				}
+				return { provider, token }
+			}
+
+			// Try to parse as URL with token query parameter
+			function tryParseUrl(s) {
+				try {
+					const url = new URL(s)
+					const token = url.searchParams.get('token')
+					if (!token) {
+						return null
+					}
+					// Provider must come from the invite payload itself. Falling back
+					// to the current URL host silently turns incomplete links into the
+					// wrong remote target.
+					const provider = url.searchParams.get('providerDomain') || url.searchParams.get('provider')
+					if (!provider) {
+						return null
+					}
+					return { provider, token }
+				} catch (e) {
+					return null
+				}
+			}
+
+			const s = String(str || '').trim()
+			if (looksLikeUrl(s)) {
+				const result = tryParseUrl(s)
+				if (result) {
+					return result
+				}
+				throw new Error('Could not parse invite')
+			}
+
+			// 1. Try token@provider format first
+			let result = tryParseTokenProvider(s)
+			if (result) {
+				return result
+			}
+
+			// 2. Try base64 decoding then token@provider
+			try {
+				const decoded = atob(s)
+				if (looksLikeUrl(decoded)) {
+					result = tryParseUrl(decoded)
+					if (result) {
+						return result
+					}
+				}
+				result = tryParseTokenProvider(decoded)
+				if (result) {
+					return result
+				}
+			} catch (e) {
+				// Not base64, continue
+			}
+
+			// 3. Try as URL
+			result = tryParseUrl(s)
+			if (result) {
+				return result
+			}
+
+			throw new Error('Could not parse invite')
+		},
+
+		accept() {
+			this.error = ''
+			try {
+				const { provider, token } = this.parseInvite(this.invite)
+				this.$emit('accept', { provider, token })
+			} catch (e) {
+				this.error = this.t('contacts', 'This invite does not look valid. Check that you copied it completely or ask the sender to generate a new one.')
+			}
+		},
+
+		cancel() {
+			this.$emit('cancel')
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.ocm_manual_buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: calc(var(--default-grid-baseline) * 2);
+}
+
+.ocm_manual_form {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--default-grid-baseline) * 4);
+  margin: calc(var(--default-grid-baseline) * 4);
+  p {
+    margin-bottom: calc(var(--default-grid-baseline) * 4);
+  }
+  :deep(.input-field__helper-text-message) {
+	word-break: initial;
+  }
+  &__title {
+	margin-top: 0;
+  }
+}
+</style>

--- a/src/components/Ocm/OcmAttachEmailForm.vue
+++ b/src/components/Ocm/OcmAttachEmailForm.vue
@@ -1,0 +1,145 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="contact-header__infos" :aria-busy="loading">
+		<p>{{ t('contacts', 'The recipient will receive an email with the invite link. Their email address will be saved on the invite so you can resend later.') }}</p>
+
+		<div class="form-field">
+			<NcTextField
+				ref="emailField"
+				type="email"
+				:label="t('contacts', 'Recipient email (required)')"
+				:placeholder="t('contacts', 'email@example.com')"
+				:model-value="email"
+				:error="Boolean(error)"
+				:helper-text="error || ''"
+				:required="true"
+				inputmode="email"
+				autocomplete="email"
+				data-testid="ocm-invite-attach-email-input"
+				@input="onEmailInput" />
+		</div>
+
+		<div class="form-field">
+			<NcTextArea
+				v-model="message"
+				:label="t('contacts', 'Personal message (optional)')"
+				:placeholder="t('contacts', 'Message to include in the email')"
+				:rows="3"
+				data-testid="ocm-invite-attach-email-message-input" />
+		</div>
+
+		<div class="actions">
+			<NcButton
+				variant="tertiary"
+				:disabled="loading"
+				data-testid="ocm-invite-attach-email-cancel-btn"
+				@click="onCancel">
+				{{ t('contacts', 'Cancel') }}
+			</NcButton>
+			<NcButton
+				variant="primary"
+				:disabled="!canSubmit"
+				data-testid="ocm-invite-attach-email-submit-btn"
+				@click="onSubmit">
+				<template #icon>
+					<EmailFastOutlineIcon :size="20" />
+				</template>
+				{{ loading ? t('contacts', 'Sending…') : t('contacts', 'Send') }}
+			</NcButton>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcTextArea, NcTextField } from '@nextcloud/vue'
+import EmailFastOutlineIcon from 'vue-material-design-icons/EmailFastOutline.vue'
+
+export default {
+	name: 'OcmAttachEmailForm',
+	components: {
+		NcButton,
+		NcTextArea,
+		NcTextField,
+		EmailFastOutlineIcon,
+	},
+
+	props: {
+		loading: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	emits: ['submit', 'cancel'],
+	data() {
+		return {
+			email: '',
+			message: '',
+			error: '',
+		}
+	},
+
+	computed: {
+		canSubmit() {
+			return !this.loading && this.email.trim().length > 0
+		},
+	},
+
+	mounted() {
+		// NcModal activates its focus trap on nextTick, then yields to the
+		// browser. Two animation frames is enough to land focus inside the
+		// trap without a visible flicker. See @nextcloud/vue useFocusTrap.
+		requestAnimationFrame(() => {
+			requestAnimationFrame(() => {
+				this.$refs.emailField?.focus?.()
+			})
+		})
+	},
+
+	methods: {
+		onEmailInput(event) {
+			this.email = event.target.value
+			this.error = ''
+		},
+
+		onSubmit() {
+			const email = this.email.trim()
+			if (email.length === 0) {
+				this.error = this.t('contacts', 'Please enter an email address.')
+				return
+			}
+			this.$emit('submit', { email, message: this.message })
+		},
+
+		onCancel() {
+			this.$emit('cancel')
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.contact-header__infos {
+	margin: calc(var(--default-grid-baseline) * 4);
+
+	> p {
+		margin-bottom: calc(var(--default-grid-baseline) * 6);
+		color: var(--color-text-maxcontrast);
+	}
+
+	.form-field {
+		margin-bottom: calc(var(--default-grid-baseline) * 4);
+	}
+
+	.actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: calc(var(--default-grid-baseline) * 2);
+		margin-top: calc(var(--default-grid-baseline) * 4);
+	}
+}
+</style>

--- a/src/components/Ocm/OcmInviteAccept.vue
+++ b/src/components/Ocm/OcmInviteAccept.vue
@@ -1,0 +1,102 @@
+<!--
+  - SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="accept-invite-dialog">
+		<div class="accept-invite-dialog__heading">
+			<h3 class="accept-invite-dialog__title">
+				{{ t('contacts', 'Accept invitation') }}
+			</h3>
+		</div>
+		<p>{{ t('contacts', 'Accepting will add the inviter to your contacts list and in return, your contact info will be sent to the inviter. From there on you can start sharing data with each other.') }}</p>
+		<dl class="invitation-details">
+			<dt>{{ t('contacts', 'Invite code') }}</dt>
+			<dd>
+				<code class="ocm-invite-token" data-testid="ocm-invite-accept-token">{{ token }}</code>
+			</dd>
+			<dt>{{ t('contacts', 'Cloud provider') }}</dt>
+			<dd>
+				<bdi class="ocm-provider-host" data-testid="ocm-invite-accept-provider">{{ provider }}</bdi>
+			</dd>
+		</dl>
+		<div class="actions">
+			<slot name="accept-invite-actions" />
+		</div>
+	</div>
+</template>
+
+<script>
+
+export default {
+	name: 'OcmInviteAccept',
+	props: {
+		token: {
+			type: String,
+			required: true,
+		},
+
+		provider: {
+			type: String,
+			required: true,
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.accept-invite-dialog {
+	margin: calc(var(--default-grid-baseline) * 4);
+
+	> p {
+		margin-bottom: calc(var(--default-grid-baseline) * 6);
+		color: var(--color-text-maxcontrast);
+	}
+
+	&__title {
+		margin-top: 0;
+	}
+}
+
+.invitation-details {
+	margin: 0 0 calc(var(--default-grid-baseline) * 6) 0;
+	padding: calc(var(--default-grid-baseline) * 4);
+	background: var(--color-background-dark);
+	border-radius: var(--border-radius-large);
+	display: grid;
+	grid-template-columns: max-content minmax(0, 1fr);
+	column-gap: calc(var(--default-grid-baseline) * 4);
+	row-gap: calc(var(--default-grid-baseline) * 2);
+	align-items: baseline;
+
+	dt {
+		font-weight: 500;
+		color: var(--color-text-maxcontrast);
+		text-align: start;
+	}
+
+	dd {
+		margin: 0;
+		margin-inline-start: 0;
+		min-width: 0;
+		overflow-wrap: anywhere;
+		text-align: start;
+	}
+
+	.ocm-invite-token {
+		font-family: monospace;
+	}
+}
+
+@media (max-width: 480px) {
+	.invitation-details {
+		grid-template-columns: 1fr;
+		row-gap: var(--default-grid-baseline);
+
+		dd {
+			margin-bottom: calc(var(--default-grid-baseline) * 2);
+		}
+	}
+}
+</style>

--- a/src/components/Ocm/OcmInviteAccept.vue
+++ b/src/components/Ocm/OcmInviteAccept.vue
@@ -1,0 +1,102 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="accept-invite-dialog">
+		<div class="accept-invite-dialog__heading">
+			<h3 class="accept-invite-dialog__title">
+				{{ t('contacts', 'Accept invitation') }}
+			</h3>
+		</div>
+		<p>{{ t('contacts', 'Accepting will add the inviter to your contacts list and in return, your contact info will be sent to the inviter. From there on you can start sharing data with each other.') }}</p>
+		<dl class="invitation-details">
+			<dt>{{ t('contacts', 'Invite code') }}</dt>
+			<dd>
+				<code class="ocm-invite-token" data-testid="ocm-invite-accept-token">{{ token }}</code>
+			</dd>
+			<dt>{{ t('contacts', 'Cloud provider') }}</dt>
+			<dd>
+				<bdi class="ocm-provider-host" data-testid="ocm-invite-accept-provider">{{ provider }}</bdi>
+			</dd>
+		</dl>
+		<div class="actions">
+			<slot name="accept-invite-actions" />
+		</div>
+	</div>
+</template>
+
+<script>
+
+export default {
+	name: 'OcmInviteAccept',
+	props: {
+		token: {
+			type: String,
+			required: true,
+		},
+
+		provider: {
+			type: String,
+			required: true,
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.accept-invite-dialog {
+	margin: calc(var(--default-grid-baseline) * 4);
+
+	> p {
+		margin-bottom: calc(var(--default-grid-baseline) * 6);
+		color: var(--color-text-maxcontrast);
+	}
+
+	&__title {
+		margin-top: 0;
+	}
+}
+
+.invitation-details {
+	margin: 0 0 calc(var(--default-grid-baseline) * 6) 0;
+	padding: calc(var(--default-grid-baseline) * 4);
+	background: var(--color-background-dark);
+	border-radius: var(--border-radius-large);
+	display: grid;
+	grid-template-columns: max-content minmax(0, 1fr);
+	column-gap: calc(var(--default-grid-baseline) * 4);
+	row-gap: calc(var(--default-grid-baseline) * 2);
+	align-items: baseline;
+
+	dt {
+		font-weight: 500;
+		color: var(--color-text-maxcontrast);
+		text-align: start;
+	}
+
+	dd {
+		margin: 0;
+		margin-inline-start: 0;
+		min-width: 0;
+		overflow-wrap: anywhere;
+		text-align: start;
+	}
+
+	.ocm-invite-token {
+		font-family: monospace;
+	}
+}
+
+@media (max-width: 480px) {
+	.invitation-details {
+		grid-template-columns: 1fr;
+		row-gap: var(--default-grid-baseline);
+
+		dd {
+			margin-bottom: calc(var(--default-grid-baseline) * 2);
+		}
+	}
+}
+</style>

--- a/src/components/Ocm/OcmInviteDetails.vue
+++ b/src/components/Ocm/OcmInviteDetails.vue
@@ -1,0 +1,443 @@
+<!--
+  - SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcAppContentDetails>
+		<!-- nothing selected or invite not found -->
+		<NcEmptyContent
+			v-if="!invite"
+			class="empty-content"
+			:name="t('contacts', 'No invitation selected')"
+			:description="t('contacts', 'Select an invitation on the list to begin')">
+			<template #icon>
+				<IconAccountSwitchOutline :size="20" />
+			</template>
+		</NcEmptyContent>
+
+		<template v-else>
+			<div class="invite-details">
+				<h2>{{ t('contacts', 'External invitation') }}</h2>
+
+				<div class="invite-info">
+					<div v-if="invite.recipientName" class="info-row">
+						<span class="info-label">{{ t('contacts', 'Label') }}</span>
+						<span class="info-value" data-testid="ocm-invite-detail-label">{{ invite.recipientName }}</span>
+					</div>
+					<div v-if="invite.recipientEmail" class="info-row">
+						<span class="info-label">{{ t('contacts', 'Sent to') }}</span>
+						<span class="info-value" data-testid="ocm-invite-detail-email">{{ invite.recipientEmail }}</span>
+					</div>
+					<div class="info-row">
+						<span class="info-label">{{ t('contacts', 'Created') }}</span>
+						<span class="info-value">{{ formatDate(invite.createdAt) }}</span>
+					</div>
+					<div class="info-row">
+						<span class="info-label">{{ t('contacts', 'Expires') }}</span>
+						<span class="info-value">{{ formatDate(invite.expiredAt) }}</span>
+					</div>
+				</div>
+
+				<!-- More ways to share (collapsible) -->
+				<div class="more-ways" data-testid="ocm-invite-share-section">
+					<button
+						type="button"
+						class="more-ways__header"
+						:aria-expanded="showShare"
+						data-testid="ocm-invite-share-toggle"
+						@click="showShare = !showShare">
+						<span class="more-ways__title">{{ t('contacts', 'More ways to share') }}</span>
+						<IconChevronUp v-if="showShare" :size="20" />
+						<IconChevronDown v-else :size="20" />
+					</button>
+					<div v-if="showShare" class="more-ways__content">
+						<p class="more-ways__hint">
+							{{ t('contacts', 'Useful for sharing through a chat app or for manual acceptance.') }}
+						</p>
+						<OcmInviteShareActions
+							:invite-link="wayfLink"
+							:invite-code="inviteCode"
+							:encoded-invite="base64InviteString"
+							:clipboard-kinds="clipboardKinds"
+							:encoded-copy-button-enabled="encodedCopyButtonEnabled"
+							@copy="onCopyAction" />
+					</div>
+				</div>
+
+				<!-- Action buttons -->
+				<div class="action-buttons">
+					<NcButton
+						variant="error"
+						class="action-buttons__revoke"
+						data-testid="ocm-invite-revoke-btn"
+						@click="onRevoke">
+						{{ t('contacts', 'Revoke invitation') }}
+					</NcButton>
+					<NcButton
+						v-if="invite.recipientEmail"
+						variant="primary"
+						class="action-buttons__primary"
+						data-testid="ocm-invite-resend-btn"
+						@click="onResend">
+						<template #icon>
+							<EmailFastOutlineIcon :size="20" />
+						</template>
+						{{ t('contacts', 'Resend email') }}
+					</NcButton>
+					<NcButton
+						v-else
+						variant="primary"
+						class="action-buttons__primary"
+						data-testid="ocm-invite-attach-email-btn"
+						@click="openAttachEmailForm">
+						<template #icon>
+							<EmailFastOutlineIcon :size="20" />
+						</template>
+						{{ t('contacts', 'Send via email') }}
+					</NcButton>
+				</div>
+			</div>
+		</template>
+
+		<Modal
+			v-if="showAttachEmailForm"
+			v-model:show="showAttachEmailForm"
+			:name="t('contacts', 'Send invitation via email')"
+			:no-close="submittingAttachEmail">
+			<OcmAttachEmailForm
+				:loading="submittingAttachEmail"
+				@submit="onAttachEmailSubmit"
+				@cancel="closeAttachEmailForm" />
+		</Modal>
+	</NcAppContentDetails>
+</template>
+
+<script>
+
+import { showError, showSuccess } from '@nextcloud/dialogs'
+import { loadState } from '@nextcloud/initial-state'
+import moment from '@nextcloud/moment'
+import { generateUrl } from '@nextcloud/router'
+import {
+	NcModal as Modal,
+	NcAppContentDetails,
+	NcButton,
+	NcEmptyContent,
+} from '@nextcloud/vue'
+import { mapStores } from 'pinia'
+import IconAccountSwitchOutline from 'vue-material-design-icons/AccountSwitchOutline.vue'
+import IconChevronDown from 'vue-material-design-icons/ChevronDown.vue'
+import IconChevronUp from 'vue-material-design-icons/ChevronUp.vue'
+import EmailFastOutlineIcon from 'vue-material-design-icons/EmailFastOutline.vue'
+import OcmAttachEmailForm from './OcmAttachEmailForm.vue'
+import OcmInviteShareActions from './OcmInviteShareActions.vue'
+import useOcmInvitesStore from '../../store/ocminvites.ts'
+
+const dateFormat = 'lll'
+
+const CLIPBOARD_KIND_INVITE_LINK = 'invite-link'
+const CLIPBOARD_KIND_INVITE_CODE = 'invite-code'
+const CLIPBOARD_KIND_ENCODED_INVITE = 'encoded-invite'
+
+export default {
+	name: 'OcmInviteDetails',
+
+	components: {
+		EmailFastOutlineIcon,
+		IconAccountSwitchOutline,
+		IconChevronDown,
+		IconChevronUp,
+		Modal,
+		NcAppContentDetails,
+		NcButton,
+		NcEmptyContent,
+		OcmAttachEmailForm,
+		OcmInviteShareActions,
+	},
+
+	props: {
+		inviteKey: {
+			type: String,
+			default: undefined,
+		},
+	},
+
+	data() {
+		const config = loadState('contacts', 'ocmInvitesConfig', {
+			optionalMail: false,
+			encodedCopyButton: false,
+		})
+		return {
+			encodedCopyButtonEnabled: config.encodedCopyButton,
+			showAttachEmailForm: false,
+			submittingAttachEmail: false,
+			isComponentMounted: false,
+			showShare: false,
+		}
+	},
+
+	computed: {
+		clipboardKinds() {
+			return {
+				inviteLink: CLIPBOARD_KIND_INVITE_LINK,
+				inviteCode: CLIPBOARD_KIND_INVITE_CODE,
+				encodedInvite: CLIPBOARD_KIND_ENCODED_INVITE,
+			}
+		},
+
+		invite() {
+			return this.ocminvitesStore.getOcmInvite(this.inviteKey)
+		},
+
+		...mapStores(useOcmInvitesStore),
+
+		provider() {
+			return window.location.host
+		},
+
+		wayfLink() {
+			if (!this.invite) {
+				return ''
+			}
+			const wayfUrl = new URL(generateUrl('/apps/contacts/wayf'), window.location.origin)
+			wayfUrl.searchParams.set('token', this.invite.token)
+			wayfUrl.searchParams.set('providerDomain', this.provider)
+			return wayfUrl.toString()
+		},
+
+		inviteCode() {
+			if (!this.invite) {
+				return ''
+			}
+			return `${this.invite.token}@${this.provider}`
+		},
+
+		base64InviteString() {
+			if (!this.invite) {
+				return ''
+			}
+			return btoa(`${this.invite.token}@${this.provider}`)
+		},
+	},
+
+	mounted() {
+		this.isComponentMounted = true
+	},
+
+	beforeUnmount() {
+		this.isComponentMounted = false
+	},
+
+	methods: {
+		onCopyAction({ text, kind }) {
+			this.copyToClipboard(text, kind)
+		},
+
+		formatDate(date) {
+			// moment takes milliseconds
+			return moment(date * 1000).format(dateFormat)
+		},
+
+		async copyToClipboard(text, kind) {
+			try {
+				await navigator.clipboard.writeText(text)
+				let message
+				switch (kind) {
+					case CLIPBOARD_KIND_ENCODED_INVITE:
+						message = this.t('contacts', 'Encoded invite copied to clipboard')
+						break
+					case CLIPBOARD_KIND_INVITE_CODE:
+						message = this.t('contacts', 'Invite code copied to clipboard')
+						break
+					case CLIPBOARD_KIND_INVITE_LINK:
+						message = this.t('contacts', 'Invite link copied to clipboard')
+						break
+					default:
+						message = this.t('contacts', 'Copied to clipboard')
+				}
+				showSuccess(message)
+			} catch (error) {
+				showError(this.t('contacts', 'Failed to copy to clipboard'))
+			}
+		},
+
+		async onResend() {
+			try {
+				const response = await this.ocminvitesStore.resendOcmInvite(this.invite)
+				window.location.assign(response.data.invite)
+			} catch (error) {
+				const serverMessage = error?.response?.data?.message
+				showError(serverMessage || this.t('contacts', 'Could not resend invite'))
+			}
+		},
+
+		async onRevoke() {
+			if (!this.invite) {
+				return
+			}
+			try {
+				await this.ocminvitesStore.deleteOcmInvite(this.invite)
+				showSuccess(this.t('contacts', 'Invite revoked'))
+			} catch (error) {
+				const serverMessage = error?.response?.data?.message
+				showError(serverMessage || this.t('contacts', 'Could not revoke invite'))
+			}
+		},
+
+		openAttachEmailForm() {
+			this.showAttachEmailForm = true
+		},
+
+		closeAttachEmailForm() {
+			if (this.submittingAttachEmail) {
+				return
+			}
+			this.showAttachEmailForm = false
+		},
+
+		async onAttachEmailSubmit({ email, message }) {
+			if (!this.invite) {
+				return
+			}
+			this.submittingAttachEmail = true
+			try {
+				await this.ocminvitesStore.attachEmailAndSendOcmInvite({
+					token: this.invite.token,
+					email,
+					message,
+				})
+				if (!this.isComponentMounted) {
+					return
+				}
+				showSuccess(this.t('contacts', 'Invite sent to {email}', { email }))
+				this.showAttachEmailForm = false
+			} catch (error) {
+				if (!this.isComponentMounted) {
+					return
+				}
+				const serverMessage = error?.response?.data?.message
+				showError(serverMessage || this.t('contacts', 'Could not send invite'))
+			} finally {
+				if (this.isComponentMounted) {
+					this.submittingAttachEmail = false
+				}
+			}
+		},
+	},
+
+}
+</script>
+
+<style lang="scss" scoped>
+.empty-content {
+	margin-top: calc(var(--default-grid-baseline) * 20);
+}
+
+.invite-details {
+	padding: calc(var(--default-grid-baseline) * 6);
+	max-width: 600px;
+
+	h2 {
+		margin: 0 0 calc(var(--default-grid-baseline) * 6) 0;
+		font-size: 1.4em;
+		font-weight: 600;
+	}
+
+	h3 {
+		margin: 0 0 calc(var(--default-grid-baseline) * 3) 0;
+		font-size: 1em;
+		font-weight: 600;
+		color: var(--color-text-maxcontrast);
+	}
+}
+
+.invite-info {
+	margin-bottom: calc(var(--default-grid-baseline) * 8);
+
+	.info-row {
+		display: flex;
+		padding: calc(var(--default-grid-baseline) * 2) 0;
+		border-bottom: 1px solid var(--color-border);
+
+		&:last-child {
+			border-bottom: none;
+		}
+
+		.info-label {
+			flex: 0 0 calc(var(--default-grid-baseline) * 25);
+			font-weight: 500;
+			color: var(--color-text-maxcontrast);
+		}
+
+		.info-value {
+			flex: 1;
+			overflow-wrap: anywhere;
+		}
+	}
+}
+
+.more-ways {
+	margin-bottom: calc(var(--default-grid-baseline) * 6);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-large);
+	overflow: hidden;
+
+	&__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: calc(var(--default-grid-baseline) * 2);
+		width: 100%;
+		padding: calc(var(--default-grid-baseline) * 3);
+		border: none;
+		background-color: transparent;
+		color: var(--color-main-text);
+		font-weight: 500;
+		cursor: pointer;
+
+		&:hover {
+			background-color: var(--color-background-hover);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--color-primary-element);
+			outline-offset: -2px;
+			background-color: var(--color-background-hover);
+		}
+	}
+
+	&__title {
+		text-align: start;
+	}
+
+	&__content {
+		padding: 0 calc(var(--default-grid-baseline) * 3) calc(var(--default-grid-baseline) * 3);
+	}
+
+	&__hint {
+		font-size: 0.85em;
+		color: var(--color-text-maxcontrast);
+		margin: 0 0 calc(var(--default-grid-baseline) * 3) 0;
+	}
+}
+
+.action-buttons {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: calc(var(--default-grid-baseline) * 3);
+
+	@media (max-width: 480px) {
+		flex-direction: column;
+		align-items: stretch;
+
+		.action-buttons__primary,
+		.action-buttons__revoke {
+			margin-inline-start: 0;
+			width: 100%;
+		}
+	}
+}
+</style>

--- a/src/components/Ocm/OcmInviteDetails.vue
+++ b/src/components/Ocm/OcmInviteDetails.vue
@@ -1,0 +1,443 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcAppContentDetails>
+		<!-- nothing selected or invite not found -->
+		<NcEmptyContent
+			v-if="!invite"
+			class="empty-content"
+			:name="t('contacts', 'No invitation selected')"
+			:description="t('contacts', 'Select an invitation on the list to begin')">
+			<template #icon>
+				<IconAccountSwitchOutline :size="20" />
+			</template>
+		</NcEmptyContent>
+
+		<template v-else>
+			<div class="invite-details">
+				<h2>{{ t('contacts', 'External invitation') }}</h2>
+
+				<div class="invite-info">
+					<div v-if="invite.recipientName" class="info-row">
+						<span class="info-label">{{ t('contacts', 'Label') }}</span>
+						<span class="info-value" data-testid="ocm-invite-detail-label">{{ invite.recipientName }}</span>
+					</div>
+					<div v-if="invite.recipientEmail" class="info-row">
+						<span class="info-label">{{ t('contacts', 'Sent to') }}</span>
+						<span class="info-value" data-testid="ocm-invite-detail-email">{{ invite.recipientEmail }}</span>
+					</div>
+					<div class="info-row">
+						<span class="info-label">{{ t('contacts', 'Created') }}</span>
+						<span class="info-value">{{ formatDate(invite.createdAt) }}</span>
+					</div>
+					<div class="info-row">
+						<span class="info-label">{{ t('contacts', 'Expires') }}</span>
+						<span class="info-value">{{ formatDate(invite.expiredAt) }}</span>
+					</div>
+				</div>
+
+				<!-- More ways to share (collapsible) -->
+				<div class="more-ways" data-testid="ocm-invite-share-section">
+					<button
+						type="button"
+						class="more-ways__header"
+						:aria-expanded="showShare"
+						data-testid="ocm-invite-share-toggle"
+						@click="showShare = !showShare">
+						<span class="more-ways__title">{{ t('contacts', 'More ways to share') }}</span>
+						<IconChevronUp v-if="showShare" :size="20" />
+						<IconChevronDown v-else :size="20" />
+					</button>
+					<div v-if="showShare" class="more-ways__content">
+						<p class="more-ways__hint">
+							{{ t('contacts', 'Useful for sharing through a chat app or for manual acceptance.') }}
+						</p>
+						<OcmInviteShareActions
+							:invite-link="wayfLink"
+							:invite-code="inviteCode"
+							:encoded-invite="base64InviteString"
+							:clipboard-kinds="clipboardKinds"
+							:encoded-copy-button-enabled="encodedCopyButtonEnabled"
+							@copy="onCopyAction" />
+					</div>
+				</div>
+
+				<!-- Action buttons -->
+				<div class="action-buttons">
+					<NcButton
+						variant="error"
+						class="action-buttons__revoke"
+						data-testid="ocm-invite-revoke-btn"
+						@click="onRevoke">
+						{{ t('contacts', 'Revoke invitation') }}
+					</NcButton>
+					<NcButton
+						v-if="invite.recipientEmail"
+						variant="primary"
+						class="action-buttons__primary"
+						data-testid="ocm-invite-resend-btn"
+						@click="onResend">
+						<template #icon>
+							<EmailFastOutlineIcon :size="20" />
+						</template>
+						{{ t('contacts', 'Resend email') }}
+					</NcButton>
+					<NcButton
+						v-else
+						variant="primary"
+						class="action-buttons__primary"
+						data-testid="ocm-invite-attach-email-btn"
+						@click="openAttachEmailForm">
+						<template #icon>
+							<EmailFastOutlineIcon :size="20" />
+						</template>
+						{{ t('contacts', 'Send via email') }}
+					</NcButton>
+				</div>
+			</div>
+		</template>
+
+		<Modal
+			v-if="showAttachEmailForm"
+			v-model:show="showAttachEmailForm"
+			:name="t('contacts', 'Send invitation via email')"
+			:no-close="submittingAttachEmail">
+			<OcmAttachEmailForm
+				:loading="submittingAttachEmail"
+				@submit="onAttachEmailSubmit"
+				@cancel="closeAttachEmailForm" />
+		</Modal>
+	</NcAppContentDetails>
+</template>
+
+<script>
+
+import { showError, showSuccess } from '@nextcloud/dialogs'
+import { loadState } from '@nextcloud/initial-state'
+import moment from '@nextcloud/moment'
+import { generateUrl } from '@nextcloud/router'
+import {
+	NcModal as Modal,
+	NcAppContentDetails,
+	NcButton,
+	NcEmptyContent,
+} from '@nextcloud/vue'
+import { mapStores } from 'pinia'
+import IconAccountSwitchOutline from 'vue-material-design-icons/AccountSwitchOutline.vue'
+import IconChevronDown from 'vue-material-design-icons/ChevronDown.vue'
+import IconChevronUp from 'vue-material-design-icons/ChevronUp.vue'
+import EmailFastOutlineIcon from 'vue-material-design-icons/EmailFastOutline.vue'
+import OcmAttachEmailForm from './OcmAttachEmailForm.vue'
+import OcmInviteShareActions from './OcmInviteShareActions.vue'
+import useOcmInvitesStore from '../../store/ocminvites.ts'
+
+const dateFormat = 'lll'
+
+const CLIPBOARD_KIND_INVITE_LINK = 'invite-link'
+const CLIPBOARD_KIND_INVITE_CODE = 'invite-code'
+const CLIPBOARD_KIND_ENCODED_INVITE = 'encoded-invite'
+
+export default {
+	name: 'OcmInviteDetails',
+
+	components: {
+		EmailFastOutlineIcon,
+		IconAccountSwitchOutline,
+		IconChevronDown,
+		IconChevronUp,
+		Modal,
+		NcAppContentDetails,
+		NcButton,
+		NcEmptyContent,
+		OcmAttachEmailForm,
+		OcmInviteShareActions,
+	},
+
+	props: {
+		inviteKey: {
+			type: String,
+			default: undefined,
+		},
+	},
+
+	data() {
+		const config = loadState('contacts', 'ocmInvitesConfig', {
+			optionalMail: false,
+			encodedCopyButton: false,
+		})
+		return {
+			encodedCopyButtonEnabled: config.encodedCopyButton,
+			showAttachEmailForm: false,
+			submittingAttachEmail: false,
+			isComponentMounted: false,
+			showShare: false,
+		}
+	},
+
+	computed: {
+		clipboardKinds() {
+			return {
+				inviteLink: CLIPBOARD_KIND_INVITE_LINK,
+				inviteCode: CLIPBOARD_KIND_INVITE_CODE,
+				encodedInvite: CLIPBOARD_KIND_ENCODED_INVITE,
+			}
+		},
+
+		invite() {
+			return this.ocminvitesStore.getOcmInvite(this.inviteKey)
+		},
+
+		...mapStores(useOcmInvitesStore),
+
+		provider() {
+			return window.location.host
+		},
+
+		wayfLink() {
+			if (!this.invite) {
+				return ''
+			}
+			const wayfUrl = new URL(generateUrl('/apps/contacts/wayf'), window.location.origin)
+			wayfUrl.searchParams.set('token', this.invite.token)
+			wayfUrl.searchParams.set('providerDomain', this.provider)
+			return wayfUrl.toString()
+		},
+
+		inviteCode() {
+			if (!this.invite) {
+				return ''
+			}
+			return `${this.invite.token}@${this.provider}`
+		},
+
+		base64InviteString() {
+			if (!this.invite) {
+				return ''
+			}
+			return btoa(`${this.invite.token}@${this.provider}`)
+		},
+	},
+
+	mounted() {
+		this.isComponentMounted = true
+	},
+
+	beforeUnmount() {
+		this.isComponentMounted = false
+	},
+
+	methods: {
+		onCopyAction({ text, kind }) {
+			this.copyToClipboard(text, kind)
+		},
+
+		formatDate(date) {
+			// moment takes milliseconds
+			return moment(date * 1000).format(dateFormat)
+		},
+
+		async copyToClipboard(text, kind) {
+			try {
+				await navigator.clipboard.writeText(text)
+				let message
+				switch (kind) {
+					case CLIPBOARD_KIND_ENCODED_INVITE:
+						message = this.t('contacts', 'Encoded invite copied to clipboard')
+						break
+					case CLIPBOARD_KIND_INVITE_CODE:
+						message = this.t('contacts', 'Invite code copied to clipboard')
+						break
+					case CLIPBOARD_KIND_INVITE_LINK:
+						message = this.t('contacts', 'Invite link copied to clipboard')
+						break
+					default:
+						message = this.t('contacts', 'Copied to clipboard')
+				}
+				showSuccess(message)
+			} catch (error) {
+				showError(this.t('contacts', 'Failed to copy to clipboard'))
+			}
+		},
+
+		async onResend() {
+			try {
+				const response = await this.ocminvitesStore.resendOcmInvite(this.invite)
+				window.location.assign(response.data.invite)
+			} catch (error) {
+				const serverMessage = error?.response?.data?.message
+				showError(serverMessage || this.t('contacts', 'Could not resend invite'))
+			}
+		},
+
+		async onRevoke() {
+			if (!this.invite) {
+				return
+			}
+			try {
+				await this.ocminvitesStore.deleteOcmInvite(this.invite)
+				showSuccess(this.t('contacts', 'Invite revoked'))
+			} catch (error) {
+				const serverMessage = error?.response?.data?.message
+				showError(serverMessage || this.t('contacts', 'Could not revoke invite'))
+			}
+		},
+
+		openAttachEmailForm() {
+			this.showAttachEmailForm = true
+		},
+
+		closeAttachEmailForm() {
+			if (this.submittingAttachEmail) {
+				return
+			}
+			this.showAttachEmailForm = false
+		},
+
+		async onAttachEmailSubmit({ email, message }) {
+			if (!this.invite) {
+				return
+			}
+			this.submittingAttachEmail = true
+			try {
+				await this.ocminvitesStore.attachEmailAndSendOcmInvite({
+					token: this.invite.token,
+					email,
+					message,
+				})
+				if (!this.isComponentMounted) {
+					return
+				}
+				showSuccess(this.t('contacts', 'Invite sent to {email}', { email }))
+				this.showAttachEmailForm = false
+			} catch (error) {
+				if (!this.isComponentMounted) {
+					return
+				}
+				const serverMessage = error?.response?.data?.message
+				showError(serverMessage || this.t('contacts', 'Could not send invite'))
+			} finally {
+				if (this.isComponentMounted) {
+					this.submittingAttachEmail = false
+				}
+			}
+		},
+	},
+
+}
+</script>
+
+<style lang="scss" scoped>
+.empty-content {
+	margin-top: calc(var(--default-grid-baseline) * 20);
+}
+
+.invite-details {
+	padding: calc(var(--default-grid-baseline) * 6);
+	max-width: 600px;
+
+	h2 {
+		margin: 0 0 calc(var(--default-grid-baseline) * 6) 0;
+		font-size: 1.4em;
+		font-weight: 600;
+	}
+
+	h3 {
+		margin: 0 0 calc(var(--default-grid-baseline) * 3) 0;
+		font-size: 1em;
+		font-weight: 600;
+		color: var(--color-text-maxcontrast);
+	}
+}
+
+.invite-info {
+	margin-bottom: calc(var(--default-grid-baseline) * 8);
+
+	.info-row {
+		display: flex;
+		padding: calc(var(--default-grid-baseline) * 2) 0;
+		border-bottom: 1px solid var(--color-border);
+
+		&:last-child {
+			border-bottom: none;
+		}
+
+		.info-label {
+			flex: 0 0 calc(var(--default-grid-baseline) * 25);
+			font-weight: 500;
+			color: var(--color-text-maxcontrast);
+		}
+
+		.info-value {
+			flex: 1;
+			overflow-wrap: anywhere;
+		}
+	}
+}
+
+.more-ways {
+	margin-bottom: calc(var(--default-grid-baseline) * 6);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-large);
+	overflow: hidden;
+
+	&__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: calc(var(--default-grid-baseline) * 2);
+		width: 100%;
+		padding: calc(var(--default-grid-baseline) * 3);
+		border: none;
+		background-color: transparent;
+		color: var(--color-main-text);
+		font-weight: 500;
+		cursor: pointer;
+
+		&:hover {
+			background-color: var(--color-background-hover);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--color-primary-element);
+			outline-offset: -2px;
+			background-color: var(--color-background-hover);
+		}
+	}
+
+	&__title {
+		text-align: start;
+	}
+
+	&__content {
+		padding: 0 calc(var(--default-grid-baseline) * 3) calc(var(--default-grid-baseline) * 3);
+	}
+
+	&__hint {
+		font-size: 0.85em;
+		color: var(--color-text-maxcontrast);
+		margin: 0 0 calc(var(--default-grid-baseline) * 3) 0;
+	}
+}
+
+.action-buttons {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: calc(var(--default-grid-baseline) * 3);
+
+	@media (max-width: 480px) {
+		flex-direction: column;
+		align-items: stretch;
+
+		.action-buttons__primary,
+		.action-buttons__revoke {
+			margin-inline-start: 0;
+			width: 100%;
+		}
+	}
+}
+</style>

--- a/src/components/Ocm/OcmInviteForm.vue
+++ b/src/components/Ocm/OcmInviteForm.vue
@@ -1,0 +1,271 @@
+<!--
+  - SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="ocm-invite-form">
+		<div class="ocm-invite-form__heading">
+			<h3 class="ocm-invite-form__title">
+				{{ t('contacts', 'Invite someone outside your organization to collaborate') }}
+			</h3>
+		</div>
+		<p class="ocm-invite-form__intro">
+			{{ t('contacts', 'After the invitee accepts the invite, both of you will appear in each other\'s contacts list and you can start sharing data with each other.') }}
+		</p>
+
+		<!-- Only show toggle if optional mail is enabled -->
+		<NcCheckboxRadioSwitch
+			v-if="optionalMailEnabled"
+			:model-value="sendEmail"
+			:disabled="loadingUpdate"
+			data-testid="ocm-invite-send-email-checkbox"
+			@update:model-value="sendEmail = $event">
+			{{ t('contacts', 'Send invite via email') }}
+		</NcCheckboxRadioSwitch>
+		<div v-if="showEmailFields" class="ocm-invite-form__fields">
+			<NcTextField
+				type="email"
+				:label="emailLabel"
+				:placeholder="t('contacts', 'email@example.com')"
+				:model-value="ocmInvite.email"
+				:required="emailRequired"
+				:disabled="loadingUpdate"
+				inputmode="email"
+				data-testid="ocm-invite-email-input"
+				@input="setEmail" />
+			<NcTextArea
+				v-model="messageModel"
+				:label="t('contacts', 'Personal message (optional)')"
+				:placeholder="t('contacts', 'Message to include in the email')"
+				:rows="3"
+				:disabled="loadingUpdate"
+				data-testid="ocm-invite-message-input" />
+			<!-- Collapsible preview of the email the recipient will receive -->
+			<div class="ocm-invite-form__preview">
+				<NcButton
+					variant="tertiary"
+					class="ocm-invite-form__preview-toggle"
+					:aria-expanded="showPreview"
+					data-testid="ocm-invite-preview-toggle"
+					@click="showPreview = !showPreview">
+					<template #icon>
+						<IconChevronUp v-if="showPreview" :size="20" />
+						<IconChevronDown v-else :size="20" />
+					</template>
+					{{ showPreview ? t('contacts', 'Hide email preview') : t('contacts', 'Show email preview') }}
+				</NcButton>
+				<div v-if="showPreview" class="ocm-invite-form__preview-panel" data-testid="ocm-invite-preview-panel">
+					<p v-if="previewRecipient" class="ocm-invite-form__preview-caption">
+						{{ t('contacts', 'This is what {recipient} will receive:', { recipient: previewRecipient }) }}
+					</p>
+					<div class="ocm-invite-form__preview-body" v-text="emailPreview" />
+				</div>
+			</div>
+			<p v-if="optionalMailEnabled && !sendEmail" class="hint">
+				{{ t('contacts', 'If you do not send an email, you will need to share the invite link yourself.') }}
+			</p>
+		</div>
+
+		<div class="actions">
+			<slot name="new-invite-actions" />
+		</div>
+	</div>
+</template>
+
+<script>
+import { getCurrentUser } from '@nextcloud/auth'
+import { loadState } from '@nextcloud/initial-state'
+import { NcButton, NcCheckboxRadioSwitch, NcTextArea, NcTextField } from '@nextcloud/vue'
+import IconChevronDown from 'vue-material-design-icons/ChevronDown.vue'
+import IconChevronUp from 'vue-material-design-icons/ChevronUp.vue'
+
+export default {
+	name: 'OcmInviteForm',
+	components: {
+		IconChevronDown,
+		IconChevronUp,
+		NcButton,
+		NcCheckboxRadioSwitch,
+		NcTextField,
+		NcTextArea,
+	},
+
+	props: {
+		ocmInvite: {
+			type: Object,
+			required: true,
+		},
+
+		loadingUpdate: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	emits: ['update:ocmInvite'],
+	data() {
+		const config = loadState('contacts', 'ocmInvitesConfig', {
+			optionalMail: false,
+		})
+		const currentUser = getCurrentUser()
+		return {
+			sendEmail: !config.optionalMail,
+			optionalMailEnabled: config.optionalMail,
+			showPreview: false,
+			senderName: currentUser?.displayName || currentUser?.uid || '',
+		}
+	},
+
+	computed: {
+		showEmailFields() {
+			// Always show if optional mail is disabled (email required)
+			// Otherwise show based on sendEmail toggle
+			return !this.optionalMailEnabled || this.sendEmail
+		},
+
+		previewRecipient() {
+			return (this.ocmInvite.email ?? '').trim()
+		},
+
+		/**
+		 * Plain-text reconstruction of the invitation email body so the sender
+		 * can preview how their personal message reads in context. Mirrors the
+		 * body assembled server-side in FederatedInvitesController; the actual
+		 * invite link and code are added when the invitation is sent.
+		 *
+		 * @return {string}
+		 */
+		emailPreview() {
+			const message = (this.ocmInvite.message ?? '').trim()
+			const lines = [
+				this.t('contacts', 'Hi there,'),
+				'',
+				this.t('contacts', '{name} invites you to exchange cloud accounts and contact information.', { name: this.senderName }),
+				this.t('contacts', 'This will allow you to share data with each other.'),
+			]
+			if (message !== '') {
+				lines.push('---', message, '---')
+			}
+			lines.push(
+				'',
+				this.t('contacts', 'To accept this invite, click the link below and sign in with your cloud provider:'),
+				this.t('contacts', 'The invite link and code are added automatically when you send the invitation.'),
+			)
+			return lines.join('\n')
+		},
+
+		emailRequired() {
+			return !this.optionalMailEnabled || this.sendEmail
+		},
+
+		emailLabel() {
+			return this.emailRequired
+				? this.t('contacts', 'Recipient email (required)')
+				: this.t('contacts', 'Recipient email')
+		},
+
+		messageModel: {
+			get() {
+				return this.ocmInvite.message ?? ''
+			},
+
+			set(value) {
+				this.updateInvite({ message: value })
+			},
+		},
+	},
+
+	watch: {
+		sendEmail: {
+			immediate: true,
+			handler(newVal, oldVal) {
+				const patch = { sendEmail: newVal }
+				// Clear pre-filled fields only when the user explicitly toggles the
+				// switch off (oldVal is defined). On the first immediate fire
+				// (oldVal === undefined) we must preserve any prefill the parent
+				// passed in via v-model:ocm-invite.
+				if (!newVal && oldVal !== undefined) {
+					patch.email = ''
+					patch.message = ''
+				}
+				this.updateInvite(patch)
+			},
+		},
+	},
+
+	methods: {
+		updateInvite(patch) {
+			this.$emit('update:ocmInvite', { ...this.ocmInvite, ...patch })
+		},
+
+		setEmail(e) {
+			this.updateInvite({ email: e.target.value })
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.ocm-invite-form {
+	margin: calc(var(--default-grid-baseline) * 4);
+
+	&__intro {
+		margin-bottom: calc(var(--default-grid-baseline) * 6);
+		color: var(--color-text-maxcontrast);
+	}
+
+	.hint {
+		font-size: 0.85em;
+		color: var(--color-text-maxcontrast);
+		margin-top: calc(var(--default-grid-baseline) * 2);
+		margin-bottom: 0;
+	}
+
+	.form-field {
+		margin-bottom: calc(var(--default-grid-baseline) * 6);
+	}
+
+	&__fields {
+		display: flex;
+		flex-direction: column;
+		gap: calc(var(--default-grid-baseline) * 3);
+	}
+
+	&__title {
+		margin-top: 0;
+	}
+
+	&__preview {
+		display: flex;
+		flex-direction: column;
+		gap: calc(var(--default-grid-baseline) * 2);
+	}
+
+	&__preview-toggle {
+		margin-inline-start: 0;
+	}
+
+	&__preview-caption {
+		font-size: 0.85em;
+		color: var(--color-text-maxcontrast);
+		margin: 0 0 calc(var(--default-grid-baseline) * 2) 0;
+	}
+
+	&__preview-body {
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+		font-size: 0.9em;
+		line-height: 1.5;
+		padding: calc(var(--default-grid-baseline) * 3);
+		border: 1px solid var(--color-border);
+		border-radius: var(--border-radius-large);
+		background-color: var(--color-background-hover);
+		color: var(--color-main-text);
+	}
+
+	.actions {
+		margin-top: calc(var(--default-grid-baseline) * 4);
+	}
+}
+</style>

--- a/src/components/Ocm/OcmInviteForm.vue
+++ b/src/components/Ocm/OcmInviteForm.vue
@@ -1,0 +1,271 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="ocm-invite-form">
+		<div class="ocm-invite-form__heading">
+			<h3 class="ocm-invite-form__title">
+				{{ t('contacts', 'Invite someone outside your organization to collaborate') }}
+			</h3>
+		</div>
+		<p class="ocm-invite-form__intro">
+			{{ t('contacts', 'After the invitee accepts the invite, both of you will appear in each other\'s contacts list and you can start sharing data with each other.') }}
+		</p>
+
+		<!-- Only show toggle if optional mail is enabled -->
+		<NcCheckboxRadioSwitch
+			v-if="optionalMailEnabled"
+			:model-value="sendEmail"
+			:disabled="loadingUpdate"
+			data-testid="ocm-invite-send-email-checkbox"
+			@update:model-value="sendEmail = $event">
+			{{ t('contacts', 'Send invite via email') }}
+		</NcCheckboxRadioSwitch>
+		<div v-if="showEmailFields" class="ocm-invite-form__fields">
+			<NcTextField
+				type="email"
+				:label="emailLabel"
+				:placeholder="t('contacts', 'email@example.com')"
+				:model-value="ocmInvite.email"
+				:required="emailRequired"
+				:disabled="loadingUpdate"
+				inputmode="email"
+				data-testid="ocm-invite-email-input"
+				@input="setEmail" />
+			<NcTextArea
+				v-model="messageModel"
+				:label="t('contacts', 'Personal message (optional)')"
+				:placeholder="t('contacts', 'Message to include in the email')"
+				:rows="3"
+				:disabled="loadingUpdate"
+				data-testid="ocm-invite-message-input" />
+			<!-- Collapsible preview of the email the recipient will receive -->
+			<div class="ocm-invite-form__preview">
+				<NcButton
+					variant="tertiary"
+					class="ocm-invite-form__preview-toggle"
+					:aria-expanded="showPreview"
+					data-testid="ocm-invite-preview-toggle"
+					@click="showPreview = !showPreview">
+					<template #icon>
+						<IconChevronUp v-if="showPreview" :size="20" />
+						<IconChevronDown v-else :size="20" />
+					</template>
+					{{ showPreview ? t('contacts', 'Hide email preview') : t('contacts', 'Show email preview') }}
+				</NcButton>
+				<div v-if="showPreview" class="ocm-invite-form__preview-panel" data-testid="ocm-invite-preview-panel">
+					<p v-if="previewRecipient" class="ocm-invite-form__preview-caption">
+						{{ t('contacts', 'This is what {recipient} will receive:', { recipient: previewRecipient }) }}
+					</p>
+					<div class="ocm-invite-form__preview-body" v-text="emailPreview" />
+				</div>
+			</div>
+			<p v-if="optionalMailEnabled && !sendEmail" class="hint">
+				{{ t('contacts', 'If you do not send an email, you will need to share the invite link yourself.') }}
+			</p>
+		</div>
+
+		<div class="actions">
+			<slot name="new-invite-actions" />
+		</div>
+	</div>
+</template>
+
+<script>
+import { getCurrentUser } from '@nextcloud/auth'
+import { loadState } from '@nextcloud/initial-state'
+import { NcButton, NcCheckboxRadioSwitch, NcTextArea, NcTextField } from '@nextcloud/vue'
+import IconChevronDown from 'vue-material-design-icons/ChevronDown.vue'
+import IconChevronUp from 'vue-material-design-icons/ChevronUp.vue'
+
+export default {
+	name: 'OcmInviteForm',
+	components: {
+		IconChevronDown,
+		IconChevronUp,
+		NcButton,
+		NcCheckboxRadioSwitch,
+		NcTextField,
+		NcTextArea,
+	},
+
+	props: {
+		ocmInvite: {
+			type: Object,
+			required: true,
+		},
+
+		loadingUpdate: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	emits: ['update:ocmInvite'],
+	data() {
+		const config = loadState('contacts', 'ocmInvitesConfig', {
+			optionalMail: false,
+		})
+		const currentUser = getCurrentUser()
+		return {
+			sendEmail: !config.optionalMail,
+			optionalMailEnabled: config.optionalMail,
+			showPreview: false,
+			senderName: currentUser?.displayName || currentUser?.uid || '',
+		}
+	},
+
+	computed: {
+		showEmailFields() {
+			// Always show if optional mail is disabled (email required)
+			// Otherwise show based on sendEmail toggle
+			return !this.optionalMailEnabled || this.sendEmail
+		},
+
+		previewRecipient() {
+			return (this.ocmInvite.email ?? '').trim()
+		},
+
+		/**
+		 * Plain-text reconstruction of the invitation email body so the sender
+		 * can preview how their personal message reads in context. Mirrors the
+		 * body assembled server-side in FederatedInvitesController; the actual
+		 * invite link and code are added when the invitation is sent.
+		 *
+		 * @return {string}
+		 */
+		emailPreview() {
+			const message = (this.ocmInvite.message ?? '').trim()
+			const lines = [
+				this.t('contacts', 'Hi there,'),
+				'',
+				this.t('contacts', '{name} invites you to exchange cloud accounts and contact information.', { name: this.senderName }),
+				this.t('contacts', 'This will allow you to share data with each other.'),
+			]
+			if (message !== '') {
+				lines.push('---', message, '---')
+			}
+			lines.push(
+				'',
+				this.t('contacts', 'To accept this invite, click the link below and sign in with your cloud provider:'),
+				this.t('contacts', 'The invite link and code are added automatically when you send the invitation.'),
+			)
+			return lines.join('\n')
+		},
+
+		emailRequired() {
+			return !this.optionalMailEnabled || this.sendEmail
+		},
+
+		emailLabel() {
+			return this.emailRequired
+				? this.t('contacts', 'Recipient email (required)')
+				: this.t('contacts', 'Recipient email')
+		},
+
+		messageModel: {
+			get() {
+				return this.ocmInvite.message ?? ''
+			},
+
+			set(value) {
+				this.updateInvite({ message: value })
+			},
+		},
+	},
+
+	watch: {
+		sendEmail: {
+			immediate: true,
+			handler(newVal, oldVal) {
+				const patch = { sendEmail: newVal }
+				// Clear pre-filled fields only when the user explicitly toggles the
+				// switch off (oldVal is defined). On the first immediate fire
+				// (oldVal === undefined) we must preserve any prefill the parent
+				// passed in via v-model:ocm-invite.
+				if (!newVal && oldVal !== undefined) {
+					patch.email = ''
+					patch.message = ''
+				}
+				this.updateInvite(patch)
+			},
+		},
+	},
+
+	methods: {
+		updateInvite(patch) {
+			this.$emit('update:ocmInvite', { ...this.ocmInvite, ...patch })
+		},
+
+		setEmail(e) {
+			this.updateInvite({ email: e.target.value })
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.ocm-invite-form {
+	margin: calc(var(--default-grid-baseline) * 4);
+
+	&__intro {
+		margin-bottom: calc(var(--default-grid-baseline) * 6);
+		color: var(--color-text-maxcontrast);
+	}
+
+	.hint {
+		font-size: 0.85em;
+		color: var(--color-text-maxcontrast);
+		margin-top: calc(var(--default-grid-baseline) * 2);
+		margin-bottom: 0;
+	}
+
+	.form-field {
+		margin-bottom: calc(var(--default-grid-baseline) * 6);
+	}
+
+	&__fields {
+		display: flex;
+		flex-direction: column;
+		gap: calc(var(--default-grid-baseline) * 3);
+	}
+
+	&__title {
+		margin-top: 0;
+	}
+
+	&__preview {
+		display: flex;
+		flex-direction: column;
+		gap: calc(var(--default-grid-baseline) * 2);
+	}
+
+	&__preview-toggle {
+		margin-inline-start: 0;
+	}
+
+	&__preview-caption {
+		font-size: 0.85em;
+		color: var(--color-text-maxcontrast);
+		margin: 0 0 calc(var(--default-grid-baseline) * 2) 0;
+	}
+
+	&__preview-body {
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+		font-size: 0.9em;
+		line-height: 1.5;
+		padding: calc(var(--default-grid-baseline) * 3);
+		border: 1px solid var(--color-border);
+		border-radius: var(--border-radius-large);
+		background-color: var(--color-background-hover);
+		color: var(--color-main-text);
+	}
+
+	.actions {
+		margin-top: calc(var(--default-grid-baseline) * 4);
+	}
+}
+</style>

--- a/src/components/Ocm/OcmInviteShareActions.vue
+++ b/src/components/Ocm/OcmInviteShareActions.vue
@@ -1,0 +1,137 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="share-rows">
+		<div class="share-row">
+			<span class="share-row__label">{{ t('contacts', 'Invite link') }}</span>
+			<span class="share-row__value" :title="inviteLink">{{ inviteLink }}</span>
+			<NcButton
+				variant="tertiary-no-background"
+				:aria-label="t('contacts', 'Copy invite link to clipboard')"
+				:title="t('contacts', 'Copy invite link to clipboard')"
+				data-testid="ocm-invite-link-copy-btn"
+				@click="emitCopy(inviteLink, clipboardKinds.inviteLink)">
+				<template #icon>
+					<ContentCopyIcon :size="20" />
+				</template>
+			</NcButton>
+		</div>
+
+		<div class="share-row">
+			<span class="share-row__label">{{ t('contacts', 'Invite code') }}</span>
+			<span class="share-row__value" :title="inviteCode">{{ inviteCode }}</span>
+			<NcButton
+				variant="tertiary-no-background"
+				:aria-label="t('contacts', 'Copy invite code to clipboard')"
+				:title="t('contacts', 'Copy invite code to clipboard')"
+				data-testid="ocm-invite-code-copy-btn"
+				@click="emitCopy(inviteCode, clipboardKinds.inviteCode)">
+				<template #icon>
+					<ContentCopyIcon :size="20" />
+				</template>
+			</NcButton>
+		</div>
+
+		<div v-if="encodedCopyButtonEnabled" class="share-row">
+			<span class="share-row__label">{{ t('contacts', 'Encoded invite') }}</span>
+			<span class="share-row__value" :title="encodedInvite">{{ encodedInvite }}</span>
+			<NcButton
+				variant="tertiary-no-background"
+				:aria-label="t('contacts', 'Copy encoded invite to clipboard')"
+				:title="t('contacts', 'Copy encoded invite to clipboard')"
+				data-testid="ocm-invite-base64-copy-btn"
+				@click="emitCopy(encodedInvite, clipboardKinds.encodedInvite)">
+				<template #icon>
+					<ContentCopyIcon :size="20" />
+				</template>
+			</NcButton>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcButton } from '@nextcloud/vue'
+import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
+
+export default {
+	name: 'OcmInviteShareActions',
+	components: {
+		ContentCopyIcon,
+		NcButton,
+	},
+
+	props: {
+		encodedCopyButtonEnabled: {
+			type: Boolean,
+			default: false,
+		},
+
+		inviteLink: {
+			type: String,
+			required: true,
+		},
+
+		inviteCode: {
+			type: String,
+			default: '',
+		},
+
+		encodedInvite: {
+			type: String,
+			default: '',
+		},
+
+		clipboardKinds: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	emits: ['copy'],
+
+	methods: {
+		emitCopy(text, kind) {
+			this.$emit('copy', { text, kind })
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.share-rows {
+	display: flex;
+	flex-direction: column;
+}
+
+.share-row {
+	display: flex;
+	align-items: center;
+	gap: calc(var(--default-grid-baseline) * 2);
+	padding: calc(var(--default-grid-baseline) * 2) 0;
+	border-bottom: 1px solid var(--color-border);
+
+	&:last-child {
+		border-bottom: none;
+	}
+
+	&__label {
+		flex: 0 0 calc(var(--default-grid-baseline) * 28);
+		color: var(--color-text-maxcontrast);
+		font-size: 0.9em;
+	}
+
+	&__value {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+		font-size: 0.85em;
+		color: var(--color-main-text);
+	}
+}
+</style>

--- a/src/components/Ocm/OcmInvitesList.vue
+++ b/src/components/Ocm/OcmInvitesList.vue
@@ -1,0 +1,169 @@
+<!--
+  - SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<AppContentList class="content-list">
+		<div class="contacts-list__header">
+			<div class="search-contacts-field">
+				<input v-model="query" type="text" :placeholder="t('contacts', 'Search invites…')">
+			</div>
+		</div>
+		<VList
+			v-slot="{ item }"
+			ref="scroller"
+			class="contacts-list"
+			:data="filteredList">
+			<OcmInvitesListItem
+				:source="item" />
+		</VList>
+	</AppContentList>
+</template>
+
+<script>
+import { NcAppContentList as AppContentList } from '@nextcloud/vue'
+import { VList } from 'virtua/vue'
+import OcmInvitesListItem from './OcmInvitesListItem.vue'
+import { getOcmInviteSearchData } from '../../models/ocminvite.ts'
+
+const _default = {
+	name: 'OcmInvitesList',
+
+	components: {
+		AppContentList,
+		OcmInvitesListItem,
+		VList,
+	},
+
+	props: {
+		list: {
+			type: Array,
+			required: true,
+		},
+		invites: {
+			type: Object,
+			required: true,
+		},
+		searchQuery: {
+			type: String,
+			default: '',
+		},
+	},
+
+	data() {
+		return {
+			query: '',
+		}
+	},
+
+	computed: {
+		selectedInvite() {
+			return this.$route.params.selectedInvite
+		},
+		selectedGroup() {
+			return this.$route.params.selectedGroup
+		},
+		filteredList() {
+			let invitesList = this.list
+				.filter((item) => this.matchSearch(this.invites[item.key]))
+				.map((item) => this.invites[item.key])
+
+			invitesList = invitesList.filter((item) => item !== undefined)
+			return invitesList
+		},
+	},
+
+	watch: {
+		selectedInvite(key) {
+			this.$nextTick(() => {
+				this.scrollToInvite(key)
+			})
+		},
+		list(val, old) {
+			// we just loaded the list and the url already have a selected contact
+			// if not, the selectedInvite watcher will take over
+			// to select the first entry
+			if (val.length !== 0 && old.length === 0 && this.selectedInvite) {
+				this.$nextTick(() => {
+					this.scrollToInvite(this.selectedInvite)
+				})
+			}
+		},
+	},
+
+	mounted() {
+		this.query = this.searchQuery
+	},
+
+	methods: {
+		/**
+		 * Scroll to the desired contact if in the list and not visible
+		 *
+		 * @param {string} key the contact unique key
+		 */
+		scrollToInvite(key) {
+			const index = this.filteredList.findIndex((invite) => invite.key === key)
+			if (index < 0) {
+				return
+			}
+
+			const item = this.$el.querySelector(`#invite-${key}`)
+			if (!item) {
+				this.$refs.scroller?.scrollToIndex(index)
+				return
+			}
+
+			const itemRect = item.getBoundingClientRect()
+			const listRect = this.$el.getBoundingClientRect()
+			const isAbove = itemRect.top < listRect.top + 50 // account for list header
+			const isBelow = itemRect.bottom > listRect.bottom
+			if (isAbove || isBelow) {
+				this.$refs.scroller?.scrollToIndex(index)
+			}
+		},
+
+		/**
+		 * Is this matching the current search ?
+		 *
+		 * @param {OcmInvite} invite the invite to search
+		 * @return {boolean}
+		 */
+		matchSearch(invite) {
+			if (this.query.trim() !== '') {
+				return getOcmInviteSearchData(invite).toLowerCase().includes(this.query.trim().toLowerCase())
+			}
+			return true
+		},
+	},
+}
+export default _default
+
+</script>
+
+<style lang="scss" scoped>
+// Make virtual scroller scrollable
+.contacts-list {
+	flex: 1 auto;
+}
+
+// Add empty header to contacts-list that solves overlapping of contacts with app-navigation-toogle
+.contacts-list__header {
+	min-height: calc(var(--default-grid-baseline) * 12)
+}
+
+// Search field
+.search-contacts-field {
+	padding: var(--default-grid-baseline) calc(var(--default-grid-baseline) * 2) var(--default-grid-baseline) calc(var(--default-grid-baseline) * 12);
+
+	> input {
+		width: 100%;
+	}
+}
+
+.content-list {
+	overflow-y: auto;
+	padding: 0 var(--default-grid-baseline);
+}
+
+</style>

--- a/src/components/Ocm/OcmInvitesList.vue
+++ b/src/components/Ocm/OcmInvitesList.vue
@@ -1,0 +1,169 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<AppContentList class="content-list">
+		<div class="contacts-list__header">
+			<div class="search-contacts-field">
+				<input v-model="query" type="text" :placeholder="t('contacts', 'Search invites…')">
+			</div>
+		</div>
+		<VList
+			v-slot="{ item }"
+			ref="scroller"
+			class="contacts-list"
+			:data="filteredList">
+			<OcmInvitesListItem
+				:source="item" />
+		</VList>
+	</AppContentList>
+</template>
+
+<script>
+import { NcAppContentList as AppContentList } from '@nextcloud/vue'
+import { VList } from 'virtua/vue'
+import OcmInvitesListItem from './OcmInvitesListItem.vue'
+import { getOcmInviteSearchData } from '../../models/ocminvite.ts'
+
+const _default = {
+	name: 'OcmInvitesList',
+
+	components: {
+		AppContentList,
+		OcmInvitesListItem,
+		VList,
+	},
+
+	props: {
+		list: {
+			type: Array,
+			required: true,
+		},
+		invites: {
+			type: Object,
+			required: true,
+		},
+		searchQuery: {
+			type: String,
+			default: '',
+		},
+	},
+
+	data() {
+		return {
+			query: '',
+		}
+	},
+
+	computed: {
+		selectedInvite() {
+			return this.$route.params.selectedInvite
+		},
+		selectedGroup() {
+			return this.$route.params.selectedGroup
+		},
+		filteredList() {
+			let invitesList = this.list
+				.filter((item) => this.matchSearch(this.invites[item.key]))
+				.map((item) => this.invites[item.key])
+
+			invitesList = invitesList.filter((item) => item !== undefined)
+			return invitesList
+		},
+	},
+
+	watch: {
+		selectedInvite(key) {
+			this.$nextTick(() => {
+				this.scrollToInvite(key)
+			})
+		},
+		list(val, old) {
+			// we just loaded the list and the url already have a selected contact
+			// if not, the selectedInvite watcher will take over
+			// to select the first entry
+			if (val.length !== 0 && old.length === 0 && this.selectedInvite) {
+				this.$nextTick(() => {
+					this.scrollToInvite(this.selectedInvite)
+				})
+			}
+		},
+	},
+
+	mounted() {
+		this.query = this.searchQuery
+	},
+
+	methods: {
+		/**
+		 * Scroll to the desired contact if in the list and not visible
+		 *
+		 * @param {string} key the contact unique key
+		 */
+		scrollToInvite(key) {
+			const index = this.filteredList.findIndex((invite) => invite.key === key)
+			if (index < 0) {
+				return
+			}
+
+			const item = this.$el.querySelector(`#invite-${key}`)
+			if (!item) {
+				this.$refs.scroller?.scrollToIndex(index)
+				return
+			}
+
+			const itemRect = item.getBoundingClientRect()
+			const listRect = this.$el.getBoundingClientRect()
+			const isAbove = itemRect.top < listRect.top + 50 // account for list header
+			const isBelow = itemRect.bottom > listRect.bottom
+			if (isAbove || isBelow) {
+				this.$refs.scroller?.scrollToIndex(index)
+			}
+		},
+
+		/**
+		 * Is this matching the current search ?
+		 *
+		 * @param {OcmInvite} invite the invite to search
+		 * @return {boolean}
+		 */
+		matchSearch(invite) {
+			if (this.query.trim() !== '') {
+				return getOcmInviteSearchData(invite).toLowerCase().includes(this.query.trim().toLowerCase())
+			}
+			return true
+		},
+	},
+}
+export default _default
+
+</script>
+
+<style lang="scss" scoped>
+// Make virtual scroller scrollable
+.contacts-list {
+	flex: 1 auto;
+}
+
+// Add empty header to contacts-list that solves overlapping of contacts with app-navigation-toogle
+.contacts-list__header {
+	min-height: calc(var(--default-grid-baseline) * 12)
+}
+
+// Search field
+.search-contacts-field {
+	padding: var(--default-grid-baseline) calc(var(--default-grid-baseline) * 2) var(--default-grid-baseline) calc(var(--default-grid-baseline) * 12);
+
+	> input {
+		width: 100%;
+	}
+}
+
+.content-list {
+	overflow-y: auto;
+	padding: 0 var(--default-grid-baseline);
+}
+
+</style>

--- a/src/components/Ocm/OcmInvitesListItem.vue
+++ b/src/components/Ocm/OcmInvitesListItem.vue
@@ -1,0 +1,95 @@
+<!--
+  - SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="contacts-list__item-wrapper">
+		<ListItem
+			:id="id"
+			:key="source.key"
+			class="list-item-style envelope"
+			:name="displayName"
+			:to="{ name: ROUTE_NAME_OCM_INVITE, params: { selectedInvite: source.key } }"
+			:data-testid="`ocm-invite-item-${source.token}`" />
+	</div>
+</template>
+
+<script>
+import {
+	NcListItem as ListItem,
+} from '@nextcloud/vue'
+import { ROUTE_NAME_OCM_INVITE } from '../../models/constants.ts'
+import { getOcmInviteDisplayName } from '../../models/ocminvite.ts'
+
+export default {
+	name: 'OcmInvitesListItem',
+
+	components: {
+		ListItem,
+	},
+
+	props: {
+		source: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			ROUTE_NAME_OCM_INVITE,
+		}
+	},
+
+	computed: {
+		// usable and valid html id for scrollTo
+		id() {
+			// Token is UUID format, use with prefix for valid HTML ID
+			return `invite-${this.source.key}`
+		},
+
+		displayName() {
+			return getOcmInviteDisplayName(this.source)
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+
+.envelope {
+	.app-content-list-item-icon {
+		height: calc(var(--default-grid-baseline) * 10); // To prevent some unexpected spacing below the avatar
+	}
+
+	&__subtitle {
+		display: flex;
+		gap: var(--default-grid-baseline);
+
+		&__subject {
+			line-height: 130%;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+	}
+}
+
+:deep(.list-item) {
+	list-style: none;
+	padding-inline: calc(var(--default-grid-baseline) * 3);
+	padding-block: calc(var(--default-grid-baseline) * 2);
+}
+
+</style>
+
+<style lang="scss">
+.contacts-list__item-wrapper {
+	&[draggable='true'] .avatardiv * {
+		cursor: move !important;
+	}
+
+	&[draggable='false'] .avatardiv * {
+		cursor: not-allowed !important;
+	}
+}
+</style>

--- a/src/components/Ocm/OcmInvitesListItem.vue
+++ b/src/components/Ocm/OcmInvitesListItem.vue
@@ -1,0 +1,95 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="contacts-list__item-wrapper">
+		<ListItem
+			:id="id"
+			:key="source.key"
+			class="list-item-style envelope"
+			:name="displayName"
+			:to="{ name: ROUTE_NAME_OCM_INVITE, params: { selectedInvite: source.key } }"
+			:data-testid="`ocm-invite-item-${source.token}`" />
+	</div>
+</template>
+
+<script>
+import {
+	NcListItem as ListItem,
+} from '@nextcloud/vue'
+import { ROUTE_NAME_OCM_INVITE } from '../../models/constants.ts'
+import { getOcmInviteDisplayName } from '../../models/ocminvite.ts'
+
+export default {
+	name: 'OcmInvitesListItem',
+
+	components: {
+		ListItem,
+	},
+
+	props: {
+		source: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			ROUTE_NAME_OCM_INVITE,
+		}
+	},
+
+	computed: {
+		// usable and valid html id for scrollTo
+		id() {
+			// Token is UUID format, use with prefix for valid HTML ID
+			return `invite-${this.source.key}`
+		},
+
+		displayName() {
+			return getOcmInviteDisplayName(this.source)
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+
+.envelope {
+	.app-content-list-item-icon {
+		height: calc(var(--default-grid-baseline) * 10); // To prevent some unexpected spacing below the avatar
+	}
+
+	&__subtitle {
+		display: flex;
+		gap: var(--default-grid-baseline);
+
+		&__subject {
+			line-height: 130%;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+	}
+}
+
+:deep(.list-item) {
+	list-style: none;
+	padding-inline: calc(var(--default-grid-baseline) * 3);
+	padding-block: calc(var(--default-grid-baseline) * 2);
+}
+
+</style>
+
+<style lang="scss">
+.contacts-list__item-wrapper {
+	&[draggable='true'] .avatardiv * {
+		cursor: move !important;
+	}
+
+	&[draggable='false'] .avatardiv * {
+		cursor: not-allowed !important;
+	}
+}
+</style>

--- a/src/components/Ocm/Wayf.vue
+++ b/src/components/Ocm/Wayf.vue
@@ -1,0 +1,273 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcGuestContent app-name="contacts" class="wayf">
+		<template #default>
+			<div class="wayf-body">
+				<div v-if="token !== ''">
+					<h2>{{ t('contacts', 'Select your server') }}</h2>
+					<NcFormBox class="wayf-form">
+						<div v-if="hasFederationData" class="wayf-search">
+							<NcTextField
+								id="wayf-search"
+								v-model="query"
+								:label="t('contacts', 'Type to search')"
+								type="search"
+								name="search">
+								<template #icon>
+									<Magnify :size="20" />
+								</template>
+							</NcTextField>
+							<div v-if="hasVisibleProviders">
+								<div
+									v-for="group in visibleFederations"
+									:key="group.federation">
+									<h3>{{ group.federation }}</h3>
+									<ul class="wayf-list">
+										<NcListItem
+											v-for="p in group.providers"
+											:key="p.fqdn"
+											:href="p.inviteUrl"
+											:name="p.name"
+											one-line>
+											<template #icon>
+												<NcListItemIcon :name="p.name" :subname="p.fqdn">
+													<WeatherCloudyArrowRight :size="20" />
+												</NcListItemIcon>
+											</template>
+										</NcListItem>
+									</ul>
+								</div>
+							</div>
+							<p v-else class="wayf-empty">
+								{{ t('contacts', 'No servers match your search.') }}
+							</p>
+						</div>
+						<p v-else class="wayf-empty">
+							{{ t('contacts', 'No servers are currently available.') }}
+						</p>
+						<div class="wayf-manual">
+							<NcTextField
+								id="wayf-manual"
+								v-model="manualProvider"
+								:label="t('contacts', 'Your server not listed? Enter one manually.')"
+								type="text"
+								name="manual"
+								@keydown.enter.prevent="goToManualProvider">
+								<template #icon>
+									<WeatherCloudyArrowRight :size="20" />
+								</template>
+							</NcTextField>
+							<div class="wayf-manual-actions">
+								<NcButton variant="primary" @click="goToManualProvider">
+									{{ t('contacts', 'Continue') }}
+								</NcButton>
+							</div>
+						</div>
+					</NcFormBox>
+				</div>
+				<div v-else>
+					<p>{{ t('contacts', 'You need an invite link for this feature to work.') }}</p>
+				</div>
+			</div>
+		</template>
+	</NcGuestContent>
+</template>
+
+<script>
+import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+import { generateUrl } from '@nextcloud/router'
+import {
+	NcButton,
+	NcGuestContent,
+	NcListItem,
+	NcListItemIcon,
+	NcTextField,
+} from '@nextcloud/vue'
+import NcFormBox from '@nextcloud/vue/components/NcFormBox'
+import Magnify from 'vue-material-design-icons/Magnify.vue'
+import WeatherCloudyArrowRight from 'vue-material-design-icons/WeatherCloudyArrowRight.vue'
+
+export default {
+	name: 'Wayf',
+	components: {
+		Magnify,
+		NcButton,
+		NcFormBox,
+		NcGuestContent,
+		NcListItem,
+		NcListItemIcon,
+		NcTextField,
+		WeatherCloudyArrowRight,
+	},
+
+	props: {
+		federations: { type: Object, default: () => ({}) },
+		providerDomain: { type: String, default: '' },
+		token: { type: String, default: '' },
+	},
+
+	data: () => ({ query: '', manualProvider: '' }),
+
+	computed: {
+		hasFederationData() {
+			return Object.keys(this.federations || {}).length > 0
+		},
+
+		visibleFederations() {
+			return Object.entries(this.federations || {}).reduce((groups, [federation, providers]) => {
+				const visibleProviders = this.filteredBy(providers)
+				if (visibleProviders.length > 0) {
+					groups.push({
+						federation,
+						providers: visibleProviders,
+					})
+				}
+				return groups
+			}, [])
+		},
+
+		hasVisibleProviders() {
+			return this.visibleFederations.length > 0
+		},
+	},
+
+	methods: {
+		async discoverProvider(base) {
+			const resp = await axios.get(generateUrl('/apps/contacts/discover'), {
+				params: { base },
+				timeout: 8000,
+			})
+			if (!resp.data?.inviteAcceptDialogAbsolute) {
+				throw new Error('Discovery failed')
+			}
+
+			// append provider & token safely
+			const u = new URL(resp.data.inviteAcceptDialogAbsolute)
+			if (this.providerDomain) {
+				u.searchParams.set('providerDomain', this.providerDomain)
+			}
+			if (this.token) {
+				u.searchParams.set('token', this.token)
+			}
+			return u.toString()
+		},
+
+		providerInviteUrl(providerEntry) {
+			const source = providerEntry?.inviteAcceptDialog || ''
+			if (!source) {
+				return ''
+			}
+			try {
+				const url = new URL(source, window.location.origin)
+				if (this.providerDomain) {
+					url.searchParams.set('providerDomain', this.providerDomain)
+				}
+				if (this.token) {
+					url.searchParams.set('token', this.token)
+				}
+				return url.toString()
+			} catch (error) {
+				return ''
+			}
+		},
+
+		filteredBy(providers) {
+			const s = (this.query || '').toLowerCase()
+			if (!Array.isArray(providers)) {
+				return []
+			}
+			return providers.reduce((list, providerEntry) => {
+				const name = String(providerEntry?.name || '')
+				const fqdn = String(providerEntry?.fqdn || '')
+				const inviteUrl = this.providerInviteUrl(providerEntry)
+				if (inviteUrl === '') {
+					return list
+				}
+				if (!name.toLowerCase().includes(s) && !fqdn.toLowerCase().includes(s)) {
+					return list
+				}
+				list.push({
+					...providerEntry,
+					name: name || fqdn,
+					fqdn,
+					inviteUrl,
+				})
+				return list
+			}, [])
+		},
+
+		async goToManualProvider() {
+			const input = (this.manualProvider || '').trim()
+			if (!input) {
+				return
+			}
+			try {
+				const target = await this.discoverProvider(input)
+				window.location.href = target
+			} catch (error) {
+				showError(this.t('contacts', 'Could not discover that provider. Check the address and try again.'))
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss">
+#contacts-wayf {
+  background: var(--color-background-plain);
+  color: var(--color-background-plain-text);
+  border-radius: var(--border-radius-large);
+}
+
+.wayf-list {
+  text-align: start;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.wayf-list > li {
+  align-items: center;
+  justify-content: space-between;
+  gap: calc(var(--default-grid-baseline) * 2);
+
+  padding: calc(var(--default-grid-baseline) * 3) calc(var(--default-grid-baseline) * 4);
+  margin: var(--default-grid-baseline) 0;
+
+  background-color: var(--color-background-dark);
+  color: var(--color-main-text);
+
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color 0.15s;
+}
+
+.wayf-list > li:hover {
+  background-color: var(--color-background-darker);
+}
+
+.wayf-list > li:active {
+  background-color: var(--color-primary);
+  color: var(--color-primary-text);
+}
+
+.wayf-empty {
+  margin-block: calc(var(--default-grid-baseline) * 3) calc(var(--default-grid-baseline) * 4);
+  color: var(--color-text-maxcontrast);
+}
+
+.wayf-manual {
+  margin-top: calc(var(--default-grid-baseline) * 4);
+}
+
+.wayf-manual-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: calc(var(--default-grid-baseline) * 2);
+}
+</style>

--- a/src/components/Ocm/Wayf.vue
+++ b/src/components/Ocm/Wayf.vue
@@ -1,0 +1,273 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcGuestContent app-name="contacts" class="wayf">
+		<template #default>
+			<div class="wayf-body">
+				<div v-if="token !== ''">
+					<h2>{{ t('contacts', 'Select your server') }}</h2>
+					<NcFormBox class="wayf-form">
+						<div v-if="hasFederationData" class="wayf-search">
+							<NcTextField
+								id="wayf-search"
+								v-model="query"
+								:label="t('contacts', 'Type to search')"
+								type="search"
+								name="search">
+								<template #icon>
+									<Magnify :size="20" />
+								</template>
+							</NcTextField>
+							<div v-if="hasVisibleProviders">
+								<div
+									v-for="group in visibleFederations"
+									:key="group.federation">
+									<h3>{{ group.federation }}</h3>
+									<ul class="wayf-list">
+										<NcListItem
+											v-for="p in group.providers"
+											:key="p.fqdn"
+											:href="p.inviteUrl"
+											:name="p.name"
+											one-line>
+											<template #icon>
+												<NcListItemIcon :name="p.name" :subname="p.fqdn">
+													<WeatherCloudyArrowRight :size="20" />
+												</NcListItemIcon>
+											</template>
+										</NcListItem>
+									</ul>
+								</div>
+							</div>
+							<p v-else class="wayf-empty">
+								{{ t('contacts', 'No servers match your search.') }}
+							</p>
+						</div>
+						<p v-else class="wayf-empty">
+							{{ t('contacts', 'No servers are currently available.') }}
+						</p>
+						<div class="wayf-manual">
+							<NcTextField
+								id="wayf-manual"
+								v-model="manualProvider"
+								:label="t('contacts', 'Your server not listed? Enter one manually.')"
+								type="text"
+								name="manual"
+								@keydown.enter.prevent="goToManualProvider">
+								<template #icon>
+									<WeatherCloudyArrowRight :size="20" />
+								</template>
+							</NcTextField>
+							<div class="wayf-manual-actions">
+								<NcButton variant="primary" @click="goToManualProvider">
+									{{ t('contacts', 'Continue') }}
+								</NcButton>
+							</div>
+						</div>
+					</NcFormBox>
+				</div>
+				<div v-else>
+					<p>{{ t('contacts', 'You need an invite link for this feature to work.') }}</p>
+				</div>
+			</div>
+		</template>
+	</NcGuestContent>
+</template>
+
+<script>
+import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+import { generateUrl } from '@nextcloud/router'
+import {
+	NcButton,
+	NcGuestContent,
+	NcListItem,
+	NcListItemIcon,
+	NcTextField,
+} from '@nextcloud/vue'
+import NcFormBox from '@nextcloud/vue/components/NcFormBox'
+import Magnify from 'vue-material-design-icons/Magnify.vue'
+import WeatherCloudyArrowRight from 'vue-material-design-icons/WeatherCloudyArrowRight.vue'
+
+export default {
+	name: 'Wayf',
+	components: {
+		Magnify,
+		NcButton,
+		NcFormBox,
+		NcGuestContent,
+		NcListItem,
+		NcListItemIcon,
+		NcTextField,
+		WeatherCloudyArrowRight,
+	},
+
+	props: {
+		federations: { type: Object, default: () => ({}) },
+		providerDomain: { type: String, default: '' },
+		token: { type: String, default: '' },
+	},
+
+	data: () => ({ query: '', manualProvider: '' }),
+
+	computed: {
+		hasFederationData() {
+			return Object.keys(this.federations || {}).length > 0
+		},
+
+		visibleFederations() {
+			return Object.entries(this.federations || {}).reduce((groups, [federation, providers]) => {
+				const visibleProviders = this.filteredBy(providers)
+				if (visibleProviders.length > 0) {
+					groups.push({
+						federation,
+						providers: visibleProviders,
+					})
+				}
+				return groups
+			}, [])
+		},
+
+		hasVisibleProviders() {
+			return this.visibleFederations.length > 0
+		},
+	},
+
+	methods: {
+		async discoverProvider(base) {
+			const resp = await axios.get(generateUrl('/apps/contacts/discover'), {
+				params: { base },
+				timeout: 8000,
+			})
+			if (!resp.data?.inviteAcceptDialogAbsolute) {
+				throw new Error('Discovery failed')
+			}
+
+			// append provider & token safely
+			const u = new URL(resp.data.inviteAcceptDialogAbsolute)
+			if (this.providerDomain) {
+				u.searchParams.set('providerDomain', this.providerDomain)
+			}
+			if (this.token) {
+				u.searchParams.set('token', this.token)
+			}
+			return u.toString()
+		},
+
+		providerInviteUrl(providerEntry) {
+			const source = providerEntry?.inviteAcceptDialog || ''
+			if (!source) {
+				return ''
+			}
+			try {
+				const url = new URL(source, window.location.origin)
+				if (this.providerDomain) {
+					url.searchParams.set('providerDomain', this.providerDomain)
+				}
+				if (this.token) {
+					url.searchParams.set('token', this.token)
+				}
+				return url.toString()
+			} catch (error) {
+				return ''
+			}
+		},
+
+		filteredBy(providers) {
+			const s = (this.query || '').toLowerCase()
+			if (!Array.isArray(providers)) {
+				return []
+			}
+			return providers.reduce((list, providerEntry) => {
+				const name = String(providerEntry?.name || '')
+				const fqdn = String(providerEntry?.fqdn || '')
+				const inviteUrl = this.providerInviteUrl(providerEntry)
+				if (inviteUrl === '') {
+					return list
+				}
+				if (!name.toLowerCase().includes(s) && !fqdn.toLowerCase().includes(s)) {
+					return list
+				}
+				list.push({
+					...providerEntry,
+					name: name || fqdn,
+					fqdn,
+					inviteUrl,
+				})
+				return list
+			}, [])
+		},
+
+		async goToManualProvider() {
+			const input = (this.manualProvider || '').trim()
+			if (!input) {
+				return
+			}
+			try {
+				const target = await this.discoverProvider(input)
+				window.location.href = target
+			} catch (error) {
+				showError(this.t('contacts', 'Could not discover that provider. Check the address and try again.'))
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss">
+#contacts-wayf {
+  background: var(--color-background-plain);
+  color: var(--color-background-plain-text);
+  border-radius: var(--border-radius-large);
+}
+
+.wayf-list {
+  text-align: start;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.wayf-list > li {
+  align-items: center;
+  justify-content: space-between;
+  gap: calc(var(--default-grid-baseline) * 2);
+
+  padding: calc(var(--default-grid-baseline) * 3) calc(var(--default-grid-baseline) * 4);
+  margin: var(--default-grid-baseline) 0;
+
+  background-color: var(--color-background-dark);
+  color: var(--color-main-text);
+
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color 0.15s;
+}
+
+.wayf-list > li:hover {
+  background-color: var(--color-background-darker);
+}
+
+.wayf-list > li:active {
+  background-color: var(--color-primary);
+  color: var(--color-primary-text);
+}
+
+.wayf-empty {
+  margin-block: calc(var(--default-grid-baseline) * 3) calc(var(--default-grid-baseline) * 4);
+  color: var(--color-text-maxcontrast);
+}
+
+.wayf-manual {
+  margin-top: calc(var(--default-grid-baseline) * 4);
+}
+
+.wayf-manual-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: calc(var(--default-grid-baseline) * 2);
+}
+</style>

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -4,6 +4,7 @@
  */
 /// <reference types="@nextcloud/typings" />
 
+import { loadState } from '@nextcloud/initial-state'
 import { translate as t } from '@nextcloud/l10n'
 import { ShareType } from '@nextcloud/sharing'
 
@@ -28,6 +29,18 @@ export const CHART_ALL_CONTACTS: DefaultChart = t('contacts', 'Organization char
 export const ROUTE_CIRCLE = 'circle'
 export const ROUTE_CHART = 'chart'
 export const ROUTE_USER_GROUP = 'user_group'
+
+const acceptInviteDialogUrl = loadState('contacts', 'acceptInviteDialogUrl', '/ocm/invite-accept-dialog')
+export const ROUTE_INVITE_ACCEPT_DIALOG = acceptInviteDialogUrl
+export const ROUTE_NAME_INVITE_ACCEPT_DIALOG = 'invite_accept_dialog'
+export const ROUTE_ALL_OCM_INVITES = 'ocm-invites'
+export const ROUTE_NAME_ALL_OCM_INVITES = 'all_ocm_invites'
+export const ROUTE_NAME_OCM_INVITE = 'ocm_invite'
+export const GROUP_ALL_OCM_INVITES = t('contacts', 'External invitations')
+export const OCM_INVITES_CONFIG_KEYS = {
+	optionalMail: 'ocm_invites_optional_mail',
+	encodedCopyButton: 'ocm_invites_encoded_copy_button',
+} as const
 
 // Contact settings
 export const CONTACTS_SETTINGS: DefaultGroup = t('contacts', 'Contacts settings')

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -4,6 +4,7 @@
  */
 /// <reference types="@nextcloud/typings" />
 
+import { loadState } from '@nextcloud/initial-state'
 import { translate as t } from '@nextcloud/l10n'
 import { ShareType } from '@nextcloud/sharing'
 
@@ -29,6 +30,18 @@ export const ROUTE_CIRCLE = 'circle'
 export const ROUTE_CHART = 'chart'
 export const ROUTE_USER_GROUP = 'user_group'
 export const ROUTE_ADDRESSBOOK = 'addressbook'
+
+const acceptInviteDialogUrl = loadState('contacts', 'acceptInviteDialogUrl', '/ocm/invite-accept-dialog')
+export const ROUTE_INVITE_ACCEPT_DIALOG = acceptInviteDialogUrl
+export const ROUTE_NAME_INVITE_ACCEPT_DIALOG = 'invite_accept_dialog'
+export const ROUTE_ALL_OCM_INVITES = 'ocm-invites'
+export const ROUTE_NAME_ALL_OCM_INVITES = 'all_ocm_invites'
+export const ROUTE_NAME_OCM_INVITE = 'ocm_invite'
+export const GROUP_ALL_OCM_INVITES = t('contacts', 'External invitations')
+export const OCM_INVITES_CONFIG_KEYS = {
+	optionalMail: 'ocm_invites_optional_mail',
+	encodedCopyButton: 'ocm_invites_encoded_copy_button',
+} as const
 
 // Contact settings
 export const CONTACTS_SETTINGS: DefaultGroup = t('contacts', 'Contacts settings')

--- a/src/models/ocminvite.ts
+++ b/src/models/ocminvite.ts
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { t } from '@nextcloud/l10n'
+
+/**
+ * Raw invite payload as returned by the federated_invites endpoint.
+ */
+export interface OcmInviteData {
+	token: string
+	accepted?: boolean
+	recipientName?: string
+	recipientEmail?: string
+	recipientUserId?: string
+	recipientProvider?: string
+	createdAt?: number
+	expiredAt?: number
+	acceptedAt?: number
+}
+
+/**
+ * Store-side shape: same data as OcmInviteData plus a derived `key` used
+ * for keyed lookups and stable list rendering.
+ */
+export interface OcmInviteEntry extends OcmInviteData {
+	key: string
+}
+
+/**
+ * Build a store-friendly entry from a raw invite payload. Returns null
+ * when the payload is missing the token, since the token is the only
+ * field we can use as a stable key.
+ */
+export function toOcmInviteEntry(data: OcmInviteData | null | undefined): OcmInviteEntry | null {
+	if (!data || typeof data !== 'object' || !data.token) {
+		return null
+	}
+	return { ...data, key: data.token }
+}
+
+/**
+ * Label used in lists and headings. Falls back to the recipient email,
+ * then to a neutral "link-only invite" string when no email was given.
+ */
+export function getOcmInviteDisplayName(invite: OcmInviteData): string {
+	return invite.recipientName || invite.recipientEmail || t('contacts', 'Link-only invite')
+}
+
+/**
+ * Searchable text for an invite. Joins the recipient name and email
+ * when present, otherwise falls back to the same neutral label so
+ * link-only invites still match a search for that phrase.
+ */
+export function getOcmInviteSearchData(invite: OcmInviteData): string {
+	const parts = [invite.recipientName, invite.recipientEmail].filter(Boolean) as string[]
+	return parts.length > 0 ? parts.join(' ') : t('contacts', 'Link-only invite')
+}

--- a/src/models/ocminvite.ts
+++ b/src/models/ocminvite.ts
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { t } from '@nextcloud/l10n'
+
+/**
+ * Raw invite payload as returned by the federated_invites endpoint.
+ */
+export interface OcmInviteData {
+	token: string
+	accepted?: boolean
+	recipientName?: string
+	recipientEmail?: string
+	recipientUserId?: string
+	recipientProvider?: string
+	createdAt?: number
+	expiredAt?: number
+	acceptedAt?: number
+}
+
+/**
+ * Store-side shape: same data as OcmInviteData plus a derived `key` used
+ * for keyed lookups and stable list rendering.
+ */
+export interface OcmInviteEntry extends OcmInviteData {
+	key: string
+}
+
+/**
+ * Build a store-friendly entry from a raw invite payload. Returns null
+ * when the payload is missing the token, since the token is the only
+ * field we can use as a stable key.
+ */
+export function toOcmInviteEntry(data: OcmInviteData | null | undefined): OcmInviteEntry | null {
+	if (!data || typeof data !== 'object' || !data.token) {
+		return null
+	}
+	return { ...data, key: data.token }
+}
+
+/**
+ * Label used in lists and headings. Falls back to the recipient email,
+ * then to a neutral "link-only invite" string when no email was given.
+ */
+export function getOcmInviteDisplayName(invite: OcmInviteData): string {
+	return invite.recipientName || invite.recipientEmail || t('contacts', 'Link-only invite')
+}
+
+/**
+ * Searchable text for an invite. Joins the recipient name and email
+ * when present, otherwise falls back to the same neutral label so
+ * link-only invites still match a search for that phrase.
+ */
+export function getOcmInviteSearchData(invite: OcmInviteData): string {
+	const parts = [invite.recipientName, invite.recipientEmail].filter(Boolean) as string[]
+	return parts.length > 0 ? parts.join(' ') : t('contacts', 'Link-only invite')
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,7 +6,7 @@
 import { generateUrl } from '@nextcloud/router'
 import { createRouter, createWebHistory } from 'vue-router'
 import Contacts from '../views/Contacts.vue'
-import { GROUP_ALL_CONTACTS, ROUTE_CHART, ROUTE_CIRCLE, ROUTE_USER_GROUP } from '../models/constants.ts'
+import { GROUP_ALL_CONTACTS, GROUP_ALL_OCM_INVITES, ROUTE_ALL_OCM_INVITES, ROUTE_CHART, ROUTE_CIRCLE, ROUTE_INVITE_ACCEPT_DIALOG, ROUTE_NAME_ALL_OCM_INVITES, ROUTE_NAME_INVITE_ACCEPT_DIALOG, ROUTE_NAME_OCM_INVITE, ROUTE_USER_GROUP } from '../models/constants.ts'
 import { generateContactKey } from '../models/contact.js'
 
 // if index.php is in the url AND we got this far, then it's working:
@@ -28,6 +28,23 @@ export default createRouter({
 				params: { selectedGroup: t('contacts', 'All contacts') },
 			},
 			children: [
+				{
+					path: `/${ROUTE_ALL_OCM_INVITES}`,
+					name: ROUTE_NAME_ALL_OCM_INVITES,
+					component: Contacts,
+					meta: { selectedGroup: GROUP_ALL_OCM_INVITES },
+				},
+				{
+					path: `/${ROUTE_ALL_OCM_INVITES}/:selectedInvite`,
+					name: ROUTE_NAME_OCM_INVITE,
+					component: Contacts,
+					meta: { selectedGroup: GROUP_ALL_OCM_INVITES },
+				},
+				{
+					path: ROUTE_INVITE_ACCEPT_DIALOG,
+					name: ROUTE_NAME_INVITE_ACCEPT_DIALOG,
+					component: Contacts,
+				},
 				{
 					path: `/${ROUTE_CHART}/:selectedChart`,
 					name: 'chart',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,7 +6,7 @@
 import { generateUrl } from '@nextcloud/router'
 import { createRouter, createWebHistory } from 'vue-router'
 import Contacts from '../views/Contacts.vue'
-import { GROUP_ALL_CONTACTS, ROUTE_ADDRESSBOOK, ROUTE_CHART, ROUTE_CIRCLE, ROUTE_USER_GROUP } from '../models/constants.ts'
+import { GROUP_ALL_CONTACTS, GROUP_ALL_OCM_INVITES, ROUTE_ADDRESSBOOK, ROUTE_ALL_OCM_INVITES, ROUTE_CHART, ROUTE_CIRCLE, ROUTE_INVITE_ACCEPT_DIALOG, ROUTE_NAME_ALL_OCM_INVITES, ROUTE_NAME_INVITE_ACCEPT_DIALOG, ROUTE_NAME_OCM_INVITE, ROUTE_USER_GROUP } from '../models/constants.ts'
 import { generateContactKey } from '../models/contact.js'
 import isTeamManagementEnabled from '../services/isTeamManagementEnabled.js'
 
@@ -29,6 +29,23 @@ export default createRouter({
 				params: { selectedGroup: t('contacts', 'All contacts') },
 			},
 			children: [
+				{
+					path: `/${ROUTE_ALL_OCM_INVITES}`,
+					name: ROUTE_NAME_ALL_OCM_INVITES,
+					component: Contacts,
+					meta: { selectedGroup: GROUP_ALL_OCM_INVITES },
+				},
+				{
+					path: `/${ROUTE_ALL_OCM_INVITES}/:selectedInvite`,
+					name: ROUTE_NAME_OCM_INVITE,
+					component: Contacts,
+					meta: { selectedGroup: GROUP_ALL_OCM_INVITES },
+				},
+				{
+					path: ROUTE_INVITE_ACCEPT_DIALOG,
+					name: ROUTE_NAME_INVITE_ACCEPT_DIALOG,
+					component: Contacts,
+				},
 				{
 					path: `/${ROUTE_CHART}/:selectedChart`,
 					name: 'chart',

--- a/src/services/isOcmInvitesEnabled.js
+++ b/src/services/isOcmInvitesEnabled.js
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { loadState } from '@nextcloud/initial-state'
+
+const isOcmInvitesEnabled = loadState('contacts', 'isOcmInvitesEnabled', false)
+export default isOcmInvitesEnabled

--- a/src/services/isOcmInvitesEnabled.js
+++ b/src/services/isOcmInvitesEnabled.js
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { loadState } from '@nextcloud/initial-state'
+
+const isOcmInvitesEnabled = loadState('contacts', 'isOcmInvitesEnabled', false)
+export default isOcmInvitesEnabled

--- a/src/store/ocminvites.ts
+++ b/src/store/ocminvites.ts
@@ -1,0 +1,210 @@
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { OcmInviteData, OcmInviteEntry } from '../models/ocminvite.ts'
+
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+import { defineStore } from 'pinia'
+import { toOcmInviteEntry } from '../models/ocminvite.ts'
+import logger from '../services/logger.js'
+
+interface SortedEntry {
+	key: string
+	value: string | number | boolean | undefined
+}
+
+interface OcmInvitesState {
+	ocmInvites: Record<string, OcmInviteEntry>
+	sortedOcmInvites: SortedEntry[]
+	orderKey: keyof OcmInviteData
+	inviteListStatus: 'idle' | 'loading' | 'success' | 'error'
+	inviteListError: string | null
+}
+
+interface NewInvitePayload {
+	email?: string
+	message?: string
+}
+
+interface AttachEmailPayload {
+	token: string
+	email?: string
+	message?: string
+}
+
+function getSortValue(value: SortedEntry['value']): string {
+	if (typeof value === 'number' || typeof value === 'boolean') {
+		return String(value)
+	}
+	if (typeof value === 'string') {
+		return value.toLowerCase()
+	}
+	return ''
+}
+
+function sortData(a: SortedEntry, b: SortedEntry): number {
+	const byValue = getSortValue(a.value).localeCompare(getSortValue(b.value), undefined, { numeric: true })
+	if (byValue !== 0) {
+		return byValue
+	}
+	return a.key.localeCompare(b.key)
+}
+
+const useOcmInvitesStore = defineStore('ocminvites', {
+	state: (): OcmInvitesState => ({
+		// Object-keyed map for O(1) lookups; the sortedOcmInvites array
+		// keeps a precomputed display order so list views do not pay the
+		// cost of resorting on every render.
+		// https://codepen.io/skjnldsv/pen/ZmKvQo
+		ocmInvites: {},
+		sortedOcmInvites: [],
+		orderKey: 'recipientEmail',
+		inviteListStatus: 'idle',
+		inviteListError: null,
+	}),
+
+	getters: {
+		getOcmInvite: (state) => (key: string): OcmInviteEntry | undefined => state.ocmInvites[key],
+	},
+
+	actions: {
+		async fetchOcmInvites(): Promise<void> {
+			this.inviteListStatus = 'loading'
+			this.inviteListError = null
+			try {
+				const response = await axios.get(generateUrl('/apps/contacts/ocm/invitations'))
+				if (!Array.isArray(response.data)) {
+					throw new Error('Invalid invite list payload from server')
+				}
+				const invites = response.data
+				this.replaceInvites(invites)
+				this.sortInvites()
+				this.inviteListStatus = 'success'
+			} catch (error) {
+				this.inviteListStatus = 'error'
+				this.inviteListError = error instanceof Error ? error.message : String(error)
+				logger.error('Error fetching OCM invites: ' + error)
+				throw error
+			}
+		},
+
+		async deleteOcmInvite(invite: OcmInviteEntry): Promise<void> {
+			const token = invite.token
+			const url = generateUrl('/apps/contacts/ocm/invitations/{token}', { token })
+			try {
+				await axios.delete(url)
+				this.removeOcmInvite(invite.key)
+			} catch (error) {
+				logger.error('Error deleting OCM invite with token ' + token)
+				throw error
+			}
+		},
+
+		async resendOcmInvite(invite: OcmInviteEntry) {
+			const token = invite.token
+			const url = generateUrl('/apps/contacts/ocm/invitations/{token}/resend', { token })
+			try {
+				return await axios.patch(url)
+			} catch (error) {
+				logger.error('Error resending OCM invite with token ' + token)
+				throw error
+			}
+		},
+
+		async newOcmInvite(invite: NewInvitePayload) {
+			const url = generateUrl('/apps/contacts/ocm/invitations')
+			const payload = {
+				email: invite.email || '',
+				message: invite.message || '',
+			}
+			let response
+			try {
+				response = await axios.post(url, payload)
+			} catch (error) {
+				logger.error('Error creating a new OCM invite for ' + invite.email)
+				throw error
+			}
+			try {
+				await this.fetchOcmInvites()
+			} catch (error) {
+				logger.error('Invite created but refresh failed for ' + invite.email)
+			}
+			return response
+		},
+
+		async attachEmailAndSendOcmInvite({ token, email, message }: AttachEmailPayload) {
+			const url = generateUrl('/apps/contacts/ocm/invitations/{token}/email', { token })
+			const payload = {
+				email: email || '',
+				message: message || '',
+			}
+			let response
+			try {
+				response = await axios.patch(url, payload)
+			} catch (error) {
+				logger.error('Error attaching email to OCM invite with token ' + token)
+				throw error
+			}
+			if (response?.data) {
+				this.updateOcmInvite(response.data)
+			}
+			return response
+		},
+
+		/**
+		 * Stores a fresh batch of raw invite payloads from the API. Skips
+		 * any entry without a token because we cannot key it.
+		 */
+		replaceInvites(invites: OcmInviteData[] = []): void {
+			this.ocmInvites = invites.reduce<Record<string, OcmInviteEntry>>((list, raw) => {
+				const entry = toOcmInviteEntry(raw)
+				if (entry) {
+					list[entry.key] = entry
+				} else {
+					logger.error('Invalid invite object received from API', { raw })
+				}
+				return list
+			}, {})
+		},
+
+		/**
+		 * Recomputes the sorted index from the current invite map.
+		 * Filtering with computed properties was too slow on large
+		 * lists; a precomputed index is cheap to read and only refreshed
+		 * on writes.
+		 */
+		sortInvites(): void {
+			const invites = Object.values(this.ocmInvites) as OcmInviteEntry[]
+			this.sortedOcmInvites = invites
+				.map((invite) => ({ key: invite.key, value: invite[this.orderKey] }))
+				.sort(sortData)
+		},
+
+		removeOcmInvite(key: string): void {
+			const index = this.sortedOcmInvites.findIndex((entry) => entry.key === key)
+			if (index !== -1) {
+				this.sortedOcmInvites.splice(index, 1)
+			}
+			delete this.ocmInvites[key]
+		},
+
+		/**
+		 * Replaces a single cached invite with a fresh server payload,
+		 * keyed by token.
+		 */
+		updateOcmInvite(raw: OcmInviteData): void {
+			const entry = toOcmInviteEntry(raw)
+			if (!entry) {
+				logger.error('Invalid invite object received from API', { raw })
+				return
+			}
+			this.ocmInvites = { ...this.ocmInvites, [entry.key]: entry }
+			this.sortInvites()
+		},
+	},
+})
+
+export default useOcmInvitesStore

--- a/src/store/ocminvites.ts
+++ b/src/store/ocminvites.ts
@@ -1,0 +1,210 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { OcmInviteData, OcmInviteEntry } from '../models/ocminvite.ts'
+
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+import { defineStore } from 'pinia'
+import { toOcmInviteEntry } from '../models/ocminvite.ts'
+import logger from '../services/logger.js'
+
+interface SortedEntry {
+	key: string
+	value: string | number | boolean | undefined
+}
+
+interface OcmInvitesState {
+	ocmInvites: Record<string, OcmInviteEntry>
+	sortedOcmInvites: SortedEntry[]
+	orderKey: keyof OcmInviteData
+	inviteListStatus: 'idle' | 'loading' | 'success' | 'error'
+	inviteListError: string | null
+}
+
+interface NewInvitePayload {
+	email?: string
+	message?: string
+}
+
+interface AttachEmailPayload {
+	token: string
+	email?: string
+	message?: string
+}
+
+function getSortValue(value: SortedEntry['value']): string {
+	if (typeof value === 'number' || typeof value === 'boolean') {
+		return String(value)
+	}
+	if (typeof value === 'string') {
+		return value.toLowerCase()
+	}
+	return ''
+}
+
+function sortData(a: SortedEntry, b: SortedEntry): number {
+	const byValue = getSortValue(a.value).localeCompare(getSortValue(b.value), undefined, { numeric: true })
+	if (byValue !== 0) {
+		return byValue
+	}
+	return a.key.localeCompare(b.key)
+}
+
+const useOcmInvitesStore = defineStore('ocminvites', {
+	state: (): OcmInvitesState => ({
+		// Object-keyed map for O(1) lookups; the sortedOcmInvites array
+		// keeps a precomputed display order so list views do not pay the
+		// cost of resorting on every render.
+		// https://codepen.io/skjnldsv/pen/ZmKvQo
+		ocmInvites: {},
+		sortedOcmInvites: [],
+		orderKey: 'recipientEmail',
+		inviteListStatus: 'idle',
+		inviteListError: null,
+	}),
+
+	getters: {
+		getOcmInvite: (state) => (key: string): OcmInviteEntry | undefined => state.ocmInvites[key],
+	},
+
+	actions: {
+		async fetchOcmInvites(): Promise<void> {
+			this.inviteListStatus = 'loading'
+			this.inviteListError = null
+			try {
+				const response = await axios.get(generateUrl('/apps/contacts/ocm/invitations'))
+				if (!Array.isArray(response.data)) {
+					throw new Error('Invalid invite list payload from server')
+				}
+				const invites = response.data
+				this.replaceInvites(invites)
+				this.sortInvites()
+				this.inviteListStatus = 'success'
+			} catch (error) {
+				this.inviteListStatus = 'error'
+				this.inviteListError = error instanceof Error ? error.message : String(error)
+				logger.error('Error fetching OCM invites: ' + error)
+				throw error
+			}
+		},
+
+		async deleteOcmInvite(invite: OcmInviteEntry): Promise<void> {
+			const token = invite.token
+			const url = generateUrl('/apps/contacts/ocm/invitations/{token}', { token })
+			try {
+				await axios.delete(url)
+				this.removeOcmInvite(invite.key)
+			} catch (error) {
+				logger.error('Error deleting OCM invite with token ' + token)
+				throw error
+			}
+		},
+
+		async resendOcmInvite(invite: OcmInviteEntry) {
+			const token = invite.token
+			const url = generateUrl('/apps/contacts/ocm/invitations/{token}/resend', { token })
+			try {
+				return await axios.patch(url)
+			} catch (error) {
+				logger.error('Error resending OCM invite with token ' + token)
+				throw error
+			}
+		},
+
+		async newOcmInvite(invite: NewInvitePayload) {
+			const url = generateUrl('/apps/contacts/ocm/invitations')
+			const payload = {
+				email: invite.email || '',
+				message: invite.message || '',
+			}
+			let response
+			try {
+				response = await axios.post(url, payload)
+			} catch (error) {
+				logger.error('Error creating a new OCM invite for ' + invite.email)
+				throw error
+			}
+			try {
+				await this.fetchOcmInvites()
+			} catch (error) {
+				logger.error('Invite created but refresh failed for ' + invite.email)
+			}
+			return response
+		},
+
+		async attachEmailAndSendOcmInvite({ token, email, message }: AttachEmailPayload) {
+			const url = generateUrl('/apps/contacts/ocm/invitations/{token}/email', { token })
+			const payload = {
+				email: email || '',
+				message: message || '',
+			}
+			let response
+			try {
+				response = await axios.patch(url, payload)
+			} catch (error) {
+				logger.error('Error attaching email to OCM invite with token ' + token)
+				throw error
+			}
+			if (response?.data) {
+				this.updateOcmInvite(response.data)
+			}
+			return response
+		},
+
+		/**
+		 * Stores a fresh batch of raw invite payloads from the API. Skips
+		 * any entry without a token because we cannot key it.
+		 */
+		replaceInvites(invites: OcmInviteData[] = []): void {
+			this.ocmInvites = invites.reduce<Record<string, OcmInviteEntry>>((list, raw) => {
+				const entry = toOcmInviteEntry(raw)
+				if (entry) {
+					list[entry.key] = entry
+				} else {
+					logger.error('Invalid invite object received from API', { raw })
+				}
+				return list
+			}, {})
+		},
+
+		/**
+		 * Recomputes the sorted index from the current invite map.
+		 * Filtering with computed properties was too slow on large
+		 * lists; a precomputed index is cheap to read and only refreshed
+		 * on writes.
+		 */
+		sortInvites(): void {
+			const invites = Object.values(this.ocmInvites) as OcmInviteEntry[]
+			this.sortedOcmInvites = invites
+				.map((invite) => ({ key: invite.key, value: invite[this.orderKey] }))
+				.sort(sortData)
+		},
+
+		removeOcmInvite(key: string): void {
+			const index = this.sortedOcmInvites.findIndex((entry) => entry.key === key)
+			if (index !== -1) {
+				this.sortedOcmInvites.splice(index, 1)
+			}
+			delete this.ocmInvites[key]
+		},
+
+		/**
+		 * Replaces a single cached invite with a fresh server payload,
+		 * keyed by token.
+		 */
+		updateOcmInvite(raw: OcmInviteData): void {
+			const entry = toOcmInviteEntry(raw)
+			if (!entry) {
+				logger.error('Invalid invite object received from API', { raw })
+				return
+			}
+			this.ocmInvites = { ...this.ocmInvites, [entry.key]: entry }
+			this.sortInvites()
+		},
+	},
+})
+
+export default useOcmInvitesStore

--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -7,21 +7,50 @@
 	<Content :app-name="appName">
 		<!-- new-contact-button + navigation + settings -->
 		<RootNavigation
-			:loading="loadingContacts || loadingCircles">
+			:contacts-list="contactsList"
+			:loading="loadingContacts || loadingCircles || loadingInvites"
+			:selected-group="selectedGroup"
+			:selected-contact="selectedContact">
 			<div class="import-and-new-contact-buttons">
-				<SettingsImportContacts v-if="!loadingContacts && isEmptyGroup && !isChartView && !isCirclesView" />
+				<SettingsImportContacts
+					v-if="!loadingContacts && isEmptyGroup && !isChartView && !isCirclesView"
+					:is-ocm-invites-enabled="isOcmInvitesEnabled" />
 				<!-- new-contact-button -->
 				<NcButton
 					v-if="!loadingContacts"
 					:disabled="!defaultAddressbook"
 					variant="secondary"
-					wide
+					:class="getNewContactButtonClass()"
 					@click="newContact">
 					<template #icon>
 						<IconAdd :size="20" />
 					</template>
 					{{ isCirclesView ? t('contacts', 'Add member') : t('contacts', 'New contact') }}
 				</NcButton>
+				<!-- OCM invite actions: create, accept -->
+				<NcActions
+					v-if="isOcmInvitesEnabled"
+					class="ocm-invites-actions">
+					<template #icon>
+						<IconAccountSwitchOutline :size="20" />
+					</template>
+					<NcActionButton
+						close-after-click
+						@click="openCreateInvite">
+						<template #icon>
+							<IconAdd :size="20" />
+						</template>
+						{{ t('contacts', 'Create invitation') }}
+					</NcActionButton>
+					<NcActionButton
+						close-after-click
+						@click="openAcceptInvite">
+						<template #icon>
+							<IconAccountArrowDownOutline :size="20" />
+						</template>
+						{{ t('contacts', 'Accept invitation') }}
+					</NcActionButton>
+				</NcActions>
 			</div>
 		</RootNavigation>
 
@@ -35,6 +64,15 @@
 		<ChartContent
 			v-else-if="selectedChart"
 			:contacts-list="contacts" />
+		<OcmInvitesContent
+			v-if="isInvitesView"
+			:invites-list="invitesList"
+			:invite-actions-enabled="!!defaultAddressbook"
+			:error-message="ocmInvitesLoadError"
+			:loading="loadingInvites"
+			@open-create-invite="openCreateInvite"
+			@open-accept-invite="openAcceptInvite"
+			@retry-load="fetchOcmInvites" />
 		<ContactsContent
 			v-else
 			:contacts-list="contactsList"
@@ -50,6 +88,69 @@
 			<ImportView @close="closeImport" />
 		</Modal>
 
+		<!-- new invite form -->
+		<Modal
+			v-if="showNewInviteForm"
+			:no-close="loadingUpdate"
+			@close="cancelNewInvite">
+			<OcmInviteForm v-model:ocm-invite="ocmInvite" :loading-update="loadingUpdate">
+				<template #new-invite-actions>
+					<div class="new-invite-form__buttons-row">
+						<NcButton
+							variant="tertiary"
+							:disabled="loadingUpdate"
+							data-testid="ocm-invite-new-cancel-btn"
+							@click="cancelNewInvite">
+							{{ t("contacts", "Cancel") }}
+						</NcButton>
+						<NcButton
+							variant="primary"
+							:disabled="loadingUpdate"
+							data-testid="ocm-invite-new-submit-btn"
+							@click="sendNewInvite">
+							<template #icon>
+								<IconLoading v-if="loadingUpdate" :size="20" />
+								<IconCheck v-else :size="20" />
+							</template>
+							{{ newInvitePrimaryLabel }}
+						</NcButton>
+					</div>
+				</template>
+			</OcmInviteForm>
+		</Modal>
+		<Modal
+			v-if="showManualInvite"
+			:no-close="loadingUpdate"
+			@close="manualInviteCancel">
+			<OcmAcceptForm
+				:loading-update="loadingUpdate"
+				@accept="handleAccept"
+				@cancel="manualInviteCancel" />
+		</Modal>
+
+		<!-- invite accept dialog -->
+		<Modal
+			v-if="showInviteAcceptDialog"
+			:no-close="loadingUpdate"
+			@close="cancelInvite">
+			<OcmInviteAccept :token="inviteToken" :provider="inviteProvider">
+				<template #accept-invite-actions>
+					<div class="invite-accept-form__buttons-row">
+						<NcButton variant="tertiary" :disabled="loadingUpdate" @click="cancelInvite">
+							{{ t("contacts", "Cancel") }}
+						</NcButton>
+						<NcButton variant="primary" :disabled="loadingUpdate" @click="acceptInvite">
+							<template #icon>
+								<IconLoading v-if="loadingUpdate" :size="20" />
+								<IconCheck v-else :size="20" />
+							</template>
+							{{ t("contacts", "Accept") }}
+						</NcButton>
+					</div>
+				</template>
+			</OcmInviteAccept>
+		</Modal>
+
 		<!-- Select contacts group modal -->
 		<ContactsPicker />
 	</Content>
@@ -57,36 +158,59 @@
 
 <script>
 import { getCurrentUser } from '@nextcloud/auth'
+import axios from '@nextcloud/axios'
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
+import { loadState } from '@nextcloud/initial-state'
+import { generateUrl } from '@nextcloud/router'
 import {
 	NcContent as Content,
+	NcLoadingIcon as IconLoading,
 	NcModal as Modal,
+	NcActionButton,
+	NcActions,
 	NcButton,
 } from '@nextcloud/vue'
 import ICAL from 'ical.js'
+import { mapStores } from 'pinia'
+import IconAccountArrowDownOutline from 'vue-material-design-icons/AccountArrowDownOutline.vue'
+import IconAccountSwitchOutline from 'vue-material-design-icons/AccountSwitchOutline.vue'
+import IconCancel from 'vue-material-design-icons/Cancel.vue'
+import IconCheck from 'vue-material-design-icons/Check.vue'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
 import ChartContent from '../components/AppContent/ChartContent.vue'
 import CircleContent from '../components/AppContent/CircleContent.vue'
 import ContactsContent from '../components/AppContent/ContactsContent.vue'
+import OcmInvitesContent from '../components/AppContent/OcmInvitesContent.vue'
 import RootNavigation from '../components/AppNavigation/RootNavigation.vue'
 import SettingsImportContacts from '../components/AppNavigation/Settings/SettingsImportContacts.vue'
 import ContactsPicker from '../components/EntityPicker/ContactsPicker.vue'
+import OcmAcceptForm from '../components/Ocm/OcmAcceptForm.vue'
+import OcmInviteAccept from '../components/Ocm/OcmInviteAccept.vue'
+import OcmInviteForm from '../components/Ocm/OcmInviteForm.vue'
 import ImportView from './Processing/ImportView.vue'
 import IsMobileMixin from '../mixins/IsMobileMixin.ts'
 import RouterMixin from '../mixins/RouterMixin.js'
-import { GROUP_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS, ROUTE_CIRCLE, ROUTE_USER_GROUP } from '../models/constants.ts'
+import { GROUP_ALL_CONTACTS, GROUP_ALL_OCM_INVITES, GROUP_NO_GROUP_CONTACTS, ROUTE_CIRCLE, ROUTE_NAME_ALL_OCM_INVITES, ROUTE_NAME_INVITE_ACCEPT_DIALOG, ROUTE_NAME_OCM_INVITE, ROUTE_USER_GROUP } from '../models/constants.ts'
 import Contact from '../models/contact.js'
 import rfcProps from '../models/rfcProps.js'
 import client from '../services/cdav.js'
 import isCirclesEnabled from '../services/isCirclesEnabled.js'
+import isOcmInvitesEnabled from '../services/isOcmInvitesEnabled.js'
+import logger from '../services/logger.js'
+import useOcmInvitesStore from '../store/ocminvites.ts'
 import usePrincipalsStore from '../store/principals.js'
 import useUserGroupStore from '../store/userGroup.ts'
 
-export default {
+const inviteToken = loadState('contacts', 'inviteToken', '')
+const inviteProvider = loadState('contacts', 'inviteProvider', '')
+
+const _default = {
 	name: 'Contacts',
 
 	components: {
+		NcActionButton,
+		NcActions,
 		NcButton,
 		CircleContent,
 		ChartContent,
@@ -94,16 +218,30 @@ export default {
 		ContactsPicker,
 		Content,
 		ImportView,
+		IconAccountArrowDownOutline,
+		IconAccountSwitchOutline,
 		IconAdd,
+		IconCancel,
+		IconCheck,
+		IconLoading,
 		Modal,
+		OcmAcceptForm,
+		OcmInviteAccept,
+		OcmInviteForm,
+		OcmInvitesContent,
 		RootNavigation,
 		SettingsImportContacts,
 	},
 
-	mixins: [
-		IsMobileMixin,
-		RouterMixin,
-	],
+	mixins: [IsMobileMixin, RouterMixin],
+
+	// passed by the router
+	props: {
+		selectedInvite: {
+			type: String,
+			default: undefined,
+		},
+	},
 
 	data() {
 		return {
@@ -114,6 +252,15 @@ export default {
 			// Let's but the loading state to true if circles is enabled
 			loadingCircles: isCirclesEnabled,
 			loadingContacts: true,
+			loadingInvites: isOcmInvitesEnabled,
+			showInviteAcceptDialog: false,
+			showNewInviteForm: false,
+			showManualInvite: false,
+			isOcmInvitesEnabled,
+			inviteToken: inviteToken,
+			inviteProvider: inviteProvider,
+			ocmInvite: { email: '', message: '' },
+			loadingUpdate: false,
 		}
 	},
 
@@ -187,7 +334,12 @@ export default {
 		 * @return {Array}
 		 */
 		contactsList() {
-			if (this.selectedGroup === GROUP_ALL_CONTACTS) {
+			// make sure that the contacts list is also returned when we're viewing invites
+			if (
+				this.selectedGroup === GROUP_ALL_CONTACTS
+				|| this.$route.name === ROUTE_NAME_OCM_INVITE
+				|| this.$route.name === ROUTE_NAME_ALL_OCM_INVITES
+			) {
 				return this.sortedContacts
 			} else if (this.selectedGroup === GROUP_NO_GROUP_CONTACTS) {
 				return this.ungroupedContacts.map((contact) => this.sortedContacts.find((item) => item.key === contact.key))
@@ -201,6 +353,23 @@ export default {
 			return []
 		},
 
+		invitesList() {
+			return this.ocminvitesStore.sortedOcmInvites
+		},
+
+		ocmInvitesLoadError() {
+			return this.ocminvitesStore.inviteListError || ''
+		},
+
+		...mapStores(useOcmInvitesStore),
+
+		isInvitesView() {
+			return (
+				this.$route.name === ROUTE_NAME_OCM_INVITE
+				|| this.$route.name === ROUTE_NAME_ALL_OCM_INVITES
+			)
+		},
+
 		isCirclesView() {
 			return this.selectedGroup === ROUTE_CIRCLE || this.selectedGroup === ROUTE_USER_GROUP
 		},
@@ -208,20 +377,38 @@ export default {
 		ungroupedContacts() {
 			return this.sortedContacts.filter((contact) => this.contacts[contact.key].groups && this.contacts[contact.key].groups.length === 0)
 		},
+
+		/**
+		 * Primary action label for the "Invite someone" modal.
+		 *
+		 * Reads from the parent-side `ocmInvite.sendEmail` patch the child
+		 * emits via v-model. Defensive `!== false` is required because on
+		 * first paint the parent's `ocmInvite` is `{ email, message }`
+		 * (no `sendEmail` key); without the guard the label would briefly
+		 * render as "Generate invite" before the child's immediate watcher
+		 * emits and snaps it back to "Send invite" when email is required.
+		 */
+		newInvitePrimaryLabel() {
+			return this.ocmInvite.sendEmail !== false
+				? this.t('contacts', 'Send invitation')
+				: this.t('contacts', 'Generate invitation')
+		},
 	},
 
 	watch: {
 		// watch url change and group select
 		selectedGroup() {
-			if (!this.isMobile && !this.selectedChart) {
-				this.selectFirstContactIfNone()
-			}
+			this.syncPrimarySelectionIfNeeded()
 		},
 
 		// watch url change and contact select
 		selectedContact() {
-			if (!this.isMobile && !this.selectedChart) {
-				this.selectFirstContactIfNone()
+			this.syncPrimarySelectionIfNeeded()
+		},
+
+		invitesList() {
+			if (!this.isMobile && this.$route.name === ROUTE_NAME_ALL_OCM_INVITES) {
+				this.selectFirstOcmInviteIfNone()
 			}
 		},
 	},
@@ -235,7 +422,7 @@ export default {
 	},
 
 	async beforeMount() {
-		// get addressbooks then get contacts
+		// get addressbooks then get contacts and ocm invites
 		client.connect({ enableCardDAV: true }).then(() => {
 			this.logger.debug('Connected to dav!', { client })
 			const principalsStore = usePrincipalsStore()
@@ -253,6 +440,19 @@ export default {
 					// else, let's get those contacts!
 					} else {
 						this.fetchContacts()
+					}
+					if (isOcmInvitesEnabled) {
+						this.fetchOcmInvites()
+					}
+				})
+				.then(() => {
+					if (this.inviteToken !== '') {
+						if (this.inviteProvider !== '') {
+							this.showInviteAcceptDialog = true
+						} else {
+							showError(this.t('contacts', 'This invite link is incomplete. Ask the sender to generate a new one.'))
+							this.clearInviteAcceptRoute()
+						}
 					}
 				})
 				// check local storage for orderKey
@@ -312,10 +512,15 @@ export default {
 				}
 			}
 
+			// reset to default group if 'New contact' is triggered from within the OCM invites view
+			const group = this.isInvitesView
+				? GROUP_ALL_CONTACTS
+				: this.selectedGroup
+
 			// set group if it's selected already
 			// BUT NOT if it's the _fake_ groups like all contacts and not grouped
-			if ([GROUP_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS].indexOf(this.selectedGroup) === -1) {
-				contact.groups = [this.selectedGroup]
+			if ([GROUP_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS].indexOf(group) === -1) {
+				contact.groups = [group]
 			}
 			try {
 				// this will trigger the proper commits to groups, contacts and addressbook
@@ -323,7 +528,7 @@ export default {
 				await this.$router.push({
 					name: 'contact',
 					params: {
-						selectedGroup: this.selectedGroup,
+						selectedGroup: group,
 						selectedContact: contact.key,
 					},
 				})
@@ -331,16 +536,6 @@ export default {
 				showError(t('contacts', 'Unable to create the contact.'))
 				console.error(error)
 			}
-		},
-
-		/**
-		 * Dispatch sorting update request to the store
-		 *
-		 * @param {string} orderKey the object key to order by
-		 */
-		updateSorting(orderKey = 'displayName') {
-			this.$store.commit('setOrder', orderKey)
-			this.$store.commit('sortContacts')
 		},
 
 		/**
@@ -358,9 +553,42 @@ export default {
 				})).then(() => {
 				this.loadingContacts = false
 				if (!this.isMobile && !this.selectedChart) {
-					this.selectFirstContactIfNone()
+					if (
+						this.$route.name === ROUTE_NAME_OCM_INVITE
+						|| this.$route.name === ROUTE_NAME_ALL_OCM_INVITES
+					) {
+						this.selectFirstOcmInviteIfNone()
+					} else {
+						this.selectFirstContactIfNone()
+					}
 				}
 			})
+		},
+
+		async fetchOcmInvites() {
+			this.loadingInvites = true
+			try {
+				await this.ocminvitesStore.fetchOcmInvites()
+			} catch (error) {
+				logger.error('Could not fetch OCM invites', { error })
+			} finally {
+				this.loadingInvites = false
+			}
+		},
+
+		syncPrimarySelectionIfNeeded() {
+			if (this.isMobile || this.selectedChart || this.selectedInvite) {
+				return
+			}
+			if (this.$route.name === ROUTE_NAME_ALL_OCM_INVITES) {
+				this.selectFirstOcmInviteIfNone()
+				return
+			}
+			this.selectFirstContactIfNone()
+		},
+
+		manualInviteCancel() {
+			this.showManualInvite = false
 		},
 
 		/**
@@ -369,7 +597,7 @@ export default {
 		 */
 		selectFirstContactIfNone() {
 			// Do not redirect if pending import
-			if (this.$route.name === 'import') {
+			if (this.$route.name === 'import' || this.$route.name === ROUTE_NAME_INVITE_ACCEPT_DIALOG) {
 				return
 			}
 
@@ -394,12 +622,11 @@ export default {
 					&& GROUP_NO_GROUP_CONTACTS !== this.selectedGroup
 					&& ROUTE_CIRCLE !== this.selectedGroup
 					&& ROUTE_USER_GROUP !== this.selectedGroup) {
-					showError(t('contacts', 'Group {group} not found', { group: this.selectedGroup }))
-					console.error('Group not found', this.selectedGroup)
-
-					this.$router.push({
-						name: 'root',
-					})
+					// no 'group not found' error when displaying invite accept dialog
+					if (this.$route.name !== ROUTE_NAME_INVITE_ACCEPT_DIALOG) {
+						showError(t('contacts', 'Group {group} not found', { group: this.selectedGroup }))
+					}
+					this.$router.push({ name: 'root' })
 					return
 				}
 
@@ -414,6 +641,27 @@ export default {
 				}
 			}
 		},
+		/**
+		 * Select the first OCM invite of the list if none are selected already
+		 */
+		selectFirstOcmInviteIfNone() {
+			const inList
+				= this.invitesList.findIndex((invite) => invite.key === this.selectedInvite) > -1
+			if (this.selectedInvite === undefined || !inList) {
+				if (this.invitesList.length) {
+					this.$router.push({
+						name: ROUTE_NAME_OCM_INVITE,
+						params: {
+							selectedInvite: this.invitesList[0].key,
+						},
+					})
+				} else if (this.selectedInvite !== undefined) {
+					this.$router.push({
+						name: ROUTE_NAME_ALL_OCM_INVITES,
+					})
+				}
+			}
+		},
 
 		/**
 		 * Done importing, the user closed the import status screen
@@ -421,14 +669,142 @@ export default {
 		closeImport() {
 			this.$store.dispatch('changeStage', 'default')
 		},
+
+		/**
+		 * Accept the OCM invite and redirect to the new created contact
+		 */
+		async acceptInvite() {
+			if (this.loadingUpdate) {
+				return
+			}
+			this.loadingUpdate = true
+			try {
+				const url = generateUrl('/apps/contacts/ocm/invitations/{token}/accept', { token: this.inviteToken })
+				const response = await axios.patch(url, {
+					provider: this.inviteProvider,
+				})
+				this.showInviteAcceptDialog = false
+				window.location.assign(response.data.contact)
+			} catch (error) {
+				const serverMessage = error?.response?.data?.message
+				logger.error('Could not accept invite: ' + (serverMessage || 'unknown'), { error })
+				showError(serverMessage || this.t('contacts', 'Could not accept invite'))
+			} finally {
+				this.loadingUpdate = false
+			}
+		},
+		async handleAccept({ provider, token }) {
+			if (this.loadingUpdate) {
+				return
+			}
+			this.loadingUpdate = true
+			try {
+				const url = generateUrl('/apps/contacts/ocm/invitations/{token}/accept', { token })
+				const response = await axios.patch(url, {
+					provider,
+				})
+				this.showManualInvite = false
+				window.location.assign(response.data.contact)
+			} catch (error) {
+				const serverMessage = error?.response?.data?.message
+				logger.error('Could not accept invite: ' + (serverMessage || 'unknown'), { error })
+				showError(serverMessage || this.t('contacts', 'Could not accept invite'))
+			} finally {
+				this.loadingUpdate = false
+			}
+		},
+		cancelInvite() {
+			this.showInviteAcceptDialog = false
+			this.clearInviteAcceptRoute()
+		},
+		async sendNewInvite() {
+			if (this.loadingUpdate) {
+				return
+			}
+			// Validate: when the user wants to email the invite, email must be filled.
+			if (this.ocmInvite.sendEmail && !this.ocmInvite.email?.trim()) {
+				showError(this.t('contacts', 'Please enter an email address.'))
+				return
+			}
+			this.loadingUpdate = true
+			try {
+				const response = await this.ocminvitesStore.newOcmInvite(this.ocmInvite)
+				this.cancelNewInvite()
+				window.location.assign(response.data.invite)
+			} catch (error) {
+				const serverMessage = error?.response?.data?.message
+				showError(serverMessage || this.t('contacts', 'Could not create invite'))
+			} finally {
+				this.loadingUpdate = false
+			}
+		},
+		cancelNewInvite() {
+			this.showNewInviteForm = false
+			this.ocmInvite = { email: '', message: '' }
+		},
+		clearInviteAcceptRoute() {
+			if (this.$route.name !== ROUTE_NAME_INVITE_ACCEPT_DIALOG) {
+				return
+			}
+			this.$router.replace({ name: 'root' })
+		},
+		openCreateInvite() {
+			if (!this.isOcmInvitesEnabled) {
+				return
+			}
+			this.showNewInviteForm = true
+		},
+		openAcceptInvite() {
+			if (!this.isOcmInvitesEnabled) {
+				return
+			}
+			this.showManualInvite = true
+		},
+		getNewContactButtonClass() {
+			if (this.isOcmInvitesEnabled) {
+				return this.isEmptyGroup ? 'new-contact-button-ocm-invites-enabled-empty-group' : 'new-contact-button-ocm-invites-enabled'
+			}
+			return 'new-contact-button-wide'
+		},
 	},
 }
+
+export default _default
 </script>
 
 <style lang="scss" scoped>
 .import-and-new-contact-buttons {
+	position: relative;
 	display: flex;
-	flex-direction: column;
-	gap: 4px;
+	.new-contact-button-ocm-invites-enabled {
+		width: calc(100% - (var(--default-grid-baseline) + var(--default-clickable-area)));
+	}
+	.new-contact-button-ocm-invites-enabled-empty-group {
+		width: calc(50% - (var(--default-grid-baseline) + var(--default-clickable-area)) * .5);
+	}
+	.new-contact-button-wide {
+		width: 100%;
+	}
+	.ocm-invites-actions {
+		position: absolute;
+		top: 0;
+		inset-inline-end: 0;
+	}
+}
+
+.invite-accept-form__buttons-row {
+  display: flex;
+  justify-content: flex-end;
+  gap: calc(var(--default-grid-baseline) * 2);
+  margin-top: calc(var(--default-grid-baseline) * 4);
+}
+
+.new-invite-form__buttons-row {
+  margin-top: calc(var(--default-grid-baseline) * 4);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: calc(var(--default-grid-baseline) * 2);
+  justify-content: flex-end;
 }
 </style>

--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -9,19 +9,44 @@
 		<RootNavigation
 			:loading="loadingContacts || loadingCircles">
 			<div class="import-and-new-contact-buttons">
-				<SettingsImportContacts v-if="!loadingContacts && isEmptyGroup && !isChartView && !isCirclesView" />
+				<SettingsImportContacts v-if="!loadingContacts && isEmptyGroup && !isChartView && !isCirclesView"
+					:is-ocm-invites-enabled="isOcmInvitesEnabled" />
 				<!-- new-contact-button -->
 				<NcButton
 					v-if="!loadingContacts"
 					:disabled="!defaultAddressbook"
 					variant="secondary"
-					wide
+					:class="getNewContactButtonClass()"
 					@click="newContact">
 					<template #icon>
 						<IconAdd :size="20" />
 					</template>
 					{{ isCirclesView ? t('contacts', 'Add member') : t('contacts', 'New contact') }}
 				</NcButton>
+				<!-- OCM invite actions: create, accept -->
+				<NcActions
+					v-if="isOcmInvitesEnabled"
+					class="ocm-invites-actions">
+					<template #icon>
+						<IconAccountSwitchOutline :size="20" />
+					</template>
+					<NcActionButton
+						close-after-click
+						@click="openCreateInvite">
+						<template #icon>
+							<IconAdd :size="20" />
+						</template>
+						{{ t('contacts', 'Create invitation') }}
+					</NcActionButton>
+					<NcActionButton
+						close-after-click
+						@click="openAcceptInvite">
+						<template #icon>
+							<IconAccountArrowDownOutline :size="20" />
+						</template>
+						{{ t('contacts', 'Accept invitation') }}
+					</NcActionButton>
+				</NcActions>
 			</div>
 		</RootNavigation>
 
@@ -32,6 +57,15 @@
 		<ChartContent
 			v-else-if="selectedChart"
 			:contacts-list="contacts" />
+		<OcmInvitesContent
+			v-if="isInvitesView"
+			:invites-list="invitesList"
+			:invite-actions-enabled="!!defaultAddressbook"
+			:error-message="ocmInvitesLoadError"
+			:loading="loadingInvites"
+			@open-create-invite="openCreateInvite"
+			@open-accept-invite="openAcceptInvite"
+			@retry-load="fetchOcmInvites" />
 		<ContactsContent
 			v-else
 			:contacts-list="contactsList"
@@ -47,6 +81,69 @@
 			<ImportView @close="closeImport" />
 		</Modal>
 
+		<!-- new invite form -->
+		<Modal
+			v-if="showNewInviteForm"
+			:no-close="loadingUpdate"
+			@close="cancelNewInvite">
+			<OcmInviteForm v-model:ocm-invite="ocmInvite" :loading-update="loadingUpdate">
+				<template #new-invite-actions>
+					<div class="new-invite-form__buttons-row">
+						<NcButton
+							variant="tertiary"
+							:disabled="loadingUpdate"
+							data-testid="ocm-invite-new-cancel-btn"
+							@click="cancelNewInvite">
+							{{ t("contacts", "Cancel") }}
+						</NcButton>
+						<NcButton
+							variant="primary"
+							:disabled="loadingUpdate"
+							data-testid="ocm-invite-new-submit-btn"
+							@click="sendNewInvite">
+							<template #icon>
+								<IconLoading v-if="loadingUpdate" :size="20" />
+								<IconCheck v-else :size="20" />
+							</template>
+							{{ newInvitePrimaryLabel }}
+						</NcButton>
+					</div>
+				</template>
+			</OcmInviteForm>
+		</Modal>
+		<Modal
+			v-if="showManualInvite"
+			:no-close="loadingUpdate"
+			@close="manualInviteCancel">
+			<OcmAcceptForm
+				:loading-update="loadingUpdate"
+				@accept="handleAccept"
+				@cancel="manualInviteCancel" />
+		</Modal>
+
+		<!-- invite accept dialog -->
+		<Modal
+			v-if="showInviteAcceptDialog"
+			:no-close="loadingUpdate"
+			@close="cancelInvite">
+			<OcmInviteAccept :token="inviteToken" :provider="inviteProvider">
+				<template #accept-invite-actions>
+					<div class="invite-accept-form__buttons-row">
+						<NcButton variant="tertiary" :disabled="loadingUpdate" @click="cancelInvite">
+							{{ t("contacts", "Cancel") }}
+						</NcButton>
+						<NcButton variant="primary" :disabled="loadingUpdate" @click="acceptInvite">
+							<template #icon>
+								<IconLoading v-if="loadingUpdate" :size="20" />
+								<IconCheck v-else :size="20" />
+							</template>
+							{{ t("contacts", "Accept") }}
+						</NcButton>
+					</div>
+				</template>
+			</OcmInviteAccept>
+		</Modal>
+
 		<!-- Select contacts group modal -->
 		<ContactsPicker />
 	</Content>
@@ -54,37 +151,58 @@
 
 <script>
 import { getCurrentUser } from '@nextcloud/auth'
+import axios from '@nextcloud/axios'
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
+import { loadState } from '@nextcloud/initial-state'
+import { generateUrl } from '@nextcloud/router'
 import {
 	NcContent as Content,
+	NcLoadingIcon as IconLoading,
 	NcModal as Modal,
+	NcActionButton,
+	NcActions,
 	NcButton,
 } from '@nextcloud/vue'
 import ICAL from 'ical.js'
+import { mapStores } from 'pinia'
 import { defineAsyncComponent } from 'vue'
+import IconAccountArrowDownOutline from 'vue-material-design-icons/AccountArrowDownOutline.vue'
+import IconAccountSwitchOutline from 'vue-material-design-icons/AccountSwitchOutline.vue'
+import IconCheck from 'vue-material-design-icons/Check.vue'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
 import CircleContent from '../components/AppContent/CircleContent.vue'
 import ContactsContent from '../components/AppContent/ContactsContent.vue'
+import OcmInvitesContent from '../components/AppContent/OcmInvitesContent.vue'
 import RootNavigation from '../components/AppNavigation/RootNavigation.vue'
 import SettingsImportContacts from '../components/AppNavigation/Settings/SettingsImportContacts.vue'
 import ContactsPicker from '../components/EntityPicker/ContactsPicker.vue'
+import OcmAcceptForm from '../components/Ocm/OcmAcceptForm.vue'
+import OcmInviteAccept from '../components/Ocm/OcmInviteAccept.vue'
+import OcmInviteForm from '../components/Ocm/OcmInviteForm.vue'
 import ImportView from './Processing/ImportView.vue'
 import IsMobileMixin from '../mixins/IsMobileMixin.ts'
 import RouterMixin from '../mixins/RouterMixin.js'
-import { GROUP_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS, ROUTE_CIRCLE, ROUTE_USER_GROUP } from '../models/constants.ts'
+import { GROUP_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS, ROUTE_CIRCLE, ROUTE_NAME_ALL_OCM_INVITES, ROUTE_NAME_INVITE_ACCEPT_DIALOG, ROUTE_NAME_OCM_INVITE, ROUTE_USER_GROUP } from '../models/constants.ts'
 import Contact from '../models/contact.js'
 import rfcProps from '../models/rfcProps.js'
 import client from '../services/cdav.js'
+import isOcmInvitesEnabled from '../services/isOcmInvitesEnabled.js'
 import isTeamManagementEnabled from '../services/isTeamManagementEnabled.js'
 import logger from '../services/logger.js'
+import useOcmInvitesStore from '../store/ocminvites.ts'
 import usePrincipalsStore from '../store/principals.js'
 import useUserGroupStore from '../store/userGroup.ts'
 
-export default {
+const inviteToken = loadState('contacts', 'inviteToken', '')
+const inviteProvider = loadState('contacts', 'inviteProvider', '')
+
+const _default = {
 	name: 'Contacts',
 
 	components: {
+		NcActionButton,
+		NcActions,
 		NcButton,
 		CircleContent,
 		// Lazy loaded: pulls in d3 and is only rendered on the org chart view
@@ -93,16 +211,29 @@ export default {
 		ContactsPicker,
 		Content,
 		ImportView,
+		IconAccountArrowDownOutline,
+		IconAccountSwitchOutline,
 		IconAdd,
+		IconCheck,
+		IconLoading,
 		Modal,
+		OcmAcceptForm,
+		OcmInviteAccept,
+		OcmInviteForm,
+		OcmInvitesContent,
 		RootNavigation,
 		SettingsImportContacts,
 	},
 
-	mixins: [
-		IsMobileMixin,
-		RouterMixin,
-	],
+	mixins: [IsMobileMixin, RouterMixin],
+
+	// passed by the router
+	props: {
+		selectedInvite: {
+			type: String,
+			default: undefined,
+		},
+	},
 
 	data() {
 		return {
@@ -113,6 +244,15 @@ export default {
 			// Only wait for the teams to load if we manage them ourselves
 			loadingCircles: isTeamManagementEnabled,
 			loadingContacts: true,
+			loadingInvites: isOcmInvitesEnabled,
+			showInviteAcceptDialog: false,
+			showNewInviteForm: false,
+			showManualInvite: false,
+			isOcmInvitesEnabled,
+			inviteToken: inviteToken,
+			inviteProvider: inviteProvider,
+			ocmInvite: { email: '', message: '' },
+			loadingUpdate: false,
 		}
 	},
 
@@ -189,7 +329,12 @@ export default {
 			if (this.selectedAddressbook) {
 				return this.sortedContacts.filter((contact) => this.contacts[contact.key]?.addressbook.id === this.selectedAddressbook)
 			}
-			if (this.selectedGroup === GROUP_ALL_CONTACTS) {
+			// make sure that the contacts list is also returned when we're viewing invites
+			if (
+				this.selectedGroup === GROUP_ALL_CONTACTS
+				|| this.$route.name === ROUTE_NAME_OCM_INVITE
+				|| this.$route.name === ROUTE_NAME_ALL_OCM_INVITES
+			) {
 				return this.sortedContacts
 			} else if (this.selectedGroup === GROUP_NO_GROUP_CONTACTS) {
 				return this.ungroupedContacts.map((contact) => this.sortedContacts.find((item) => item.key === contact.key))
@@ -207,17 +352,48 @@ export default {
 			return this.selectedGroup === ROUTE_CIRCLE || this.selectedGroup === ROUTE_USER_GROUP
 		},
 
+		invitesList() {
+			return this.ocminvitesStore.sortedOcmInvites
+		},
+
+		ocmInvitesLoadError() {
+			return this.ocminvitesStore.inviteListError || ''
+		},
+
+		...mapStores(useOcmInvitesStore),
+
+		isInvitesView() {
+			return (
+				this.$route.name === ROUTE_NAME_OCM_INVITE
+				|| this.$route.name === ROUTE_NAME_ALL_OCM_INVITES
+			)
+		},
+
 		ungroupedContacts() {
 			return this.sortedContacts.filter((contact) => this.contacts[contact.key].groups && this.contacts[contact.key].groups.length === 0)
+		},
+
+		/**
+		 * Primary action label for the "Invite someone" modal.
+		 *
+		 * Reads from the parent-side `ocmInvite.sendEmail` patch the child
+		 * emits via v-model. Defensive `!== false` is required because on
+		 * first paint the parent's `ocmInvite` is `{ email, message }`
+		 * (no `sendEmail` key); without the guard the label would briefly
+		 * render as "Generate invite" before the child's immediate watcher
+		 * emits and snaps it back to "Send invite" when email is required.
+		 */
+		newInvitePrimaryLabel() {
+			return this.ocmInvite.sendEmail !== false
+				? this.t('contacts', 'Send invitation')
+				: this.t('contacts', 'Generate invitation')
 		},
 	},
 
 	watch: {
 		// watch url change and group select
 		selectedGroup() {
-			if (!this.isMobile && !this.selectedChart) {
-				this.selectFirstContactIfNone()
-			}
+			this.syncPrimarySelectionIfNeeded()
 		},
 
 		// watch url change and address book select
@@ -229,8 +405,12 @@ export default {
 
 		// watch url change and contact select
 		selectedContact() {
-			if (!this.isMobile && !this.selectedChart) {
-				this.selectFirstContactIfNone()
+			this.syncPrimarySelectionIfNeeded()
+		},
+
+		invitesList() {
+			if (!this.isMobile && this.$route.name === ROUTE_NAME_ALL_OCM_INVITES) {
+				this.selectFirstOcmInviteIfNone()
 			}
 		},
 	},
@@ -244,7 +424,7 @@ export default {
 	},
 
 	async beforeMount() {
-		// get addressbooks then get contacts
+		// get addressbooks then get contacts and ocm invites
 		client.connect({ enableCardDAV: true }).then(() => {
 			this.logger.debug('Connected to dav!', { client })
 			const principalsStore = usePrincipalsStore()
@@ -266,6 +446,19 @@ export default {
 					// else, let's get those contacts!
 					} else {
 						this.fetchContacts()
+					}
+					if (isOcmInvitesEnabled) {
+						this.fetchOcmInvites()
+					}
+				})
+				.then(() => {
+					if (this.inviteToken !== '') {
+						if (this.inviteProvider !== '') {
+							this.showInviteAcceptDialog = true
+						} else {
+							showError(this.t('contacts', 'This invite link is incomplete. Ask the sender to generate a new one.'))
+							this.clearInviteAcceptRoute()
+						}
 					}
 				})
 				// check local storage for orderKey
@@ -330,6 +523,11 @@ export default {
 				}
 			}
 
+			// reset to default group if 'New contact' is triggered from within the OCM invites view
+			const group = this.isInvitesView
+				? GROUP_ALL_CONTACTS
+				: this.selectedGroup
+
 			// set group if it's selected already
 			// BUT NOT if it's the _fake_ groups like all contacts and not grouped
 			if (this.selectedGroup && [GROUP_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS].indexOf(this.selectedGroup) === -1) {
@@ -355,16 +553,6 @@ export default {
 		},
 
 		/**
-		 * Dispatch sorting update request to the store
-		 *
-		 * @param {string} orderKey the object key to order by
-		 */
-		updateSorting(orderKey = 'displayName') {
-			this.$store.commit('setOrder', orderKey)
-			this.$store.commit('sortContacts')
-		},
-
-		/**
 		 * Fetch the contacts of each addressbooks
 		 */
 		fetchContacts() {
@@ -379,9 +567,42 @@ export default {
 				})).then(() => {
 				this.loadingContacts = false
 				if (!this.isMobile && !this.selectedChart) {
-					this.selectFirstContactIfNone()
+					if (
+						this.$route.name === ROUTE_NAME_OCM_INVITE
+						|| this.$route.name === ROUTE_NAME_ALL_OCM_INVITES
+					) {
+						this.selectFirstOcmInviteIfNone()
+					} else {
+						this.selectFirstContactIfNone()
+					}
 				}
 			})
+		},
+
+		async fetchOcmInvites() {
+			this.loadingInvites = true
+			try {
+				await this.ocminvitesStore.fetchOcmInvites()
+			} catch (error) {
+				logger.error('Could not fetch OCM invites', { error })
+			} finally {
+				this.loadingInvites = false
+			}
+		},
+
+		syncPrimarySelectionIfNeeded() {
+			if (this.isMobile || this.selectedChart || this.selectedInvite) {
+				return
+			}
+			if (this.$route.name === ROUTE_NAME_ALL_OCM_INVITES) {
+				this.selectFirstOcmInviteIfNone()
+				return
+			}
+			this.selectFirstContactIfNone()
+		},
+
+		manualInviteCancel() {
+			this.showManualInvite = false
 		},
 
 		/**
@@ -390,7 +611,7 @@ export default {
 		 */
 		selectFirstContactIfNone() {
 			// Do not redirect if pending import
-			if (this.$route.name === 'import') {
+			if (this.$route.name === 'import' || this.$route.name === ROUTE_NAME_INVITE_ACCEPT_DIALOG) {
 				return
 			}
 
@@ -423,9 +644,11 @@ export default {
 					&& GROUP_NO_GROUP_CONTACTS !== this.selectedGroup
 					&& ROUTE_CIRCLE !== this.selectedGroup
 					&& ROUTE_USER_GROUP !== this.selectedGroup) {
-					showError(t('contacts', 'Group {group} not found', { group: this.selectedGroup }))
-					logger.error('Group not found', { selectedGroup: this.selectedGroup })
-
+					// no 'group not found' error when displaying invite accept dialog
+					if (this.$route.name !== ROUTE_NAME_INVITE_ACCEPT_DIALOG) {
+						showError(t('contacts', 'Group {group} not found', { group: this.selectedGroup }))
+						logger.error('Group not found', { selectedGroup: this.selectedGroup })
+					}
 					this.$router.push({
 						name: 'root',
 					})
@@ -437,6 +660,27 @@ export default {
 				}
 			}
 		},
+		/**
+		 * Select the first OCM invite of the list if none are selected already
+		 */
+		selectFirstOcmInviteIfNone() {
+			const inList
+				= this.invitesList.findIndex((invite) => invite.key === this.selectedInvite) > -1
+			if (this.selectedInvite === undefined || !inList) {
+				if (this.invitesList.length) {
+					this.$router.push({
+						name: ROUTE_NAME_OCM_INVITE,
+						params: {
+							selectedInvite: this.invitesList[0].key,
+						},
+					})
+				} else if (this.selectedInvite !== undefined) {
+					this.$router.push({
+						name: ROUTE_NAME_ALL_OCM_INVITES,
+					})
+				}
+			}
+		},
 
 		/**
 		 * Done importing, the user closed the import status screen
@@ -444,14 +688,142 @@ export default {
 		closeImport() {
 			this.$store.dispatch('changeStage', 'default')
 		},
+
+		/**
+		 * Accept the OCM invite and redirect to the new created contact
+		 */
+		async acceptInvite() {
+			if (this.loadingUpdate) {
+				return
+			}
+			this.loadingUpdate = true
+			try {
+				const url = generateUrl('/apps/contacts/ocm/invitations/{token}/accept', { token: this.inviteToken })
+				const response = await axios.patch(url, {
+					provider: this.inviteProvider,
+				})
+				this.showInviteAcceptDialog = false
+				window.location.assign(response.data.contact)
+			} catch (error) {
+				const serverMessage = error?.response?.data?.message
+				logger.error('Could not accept invite: ' + (serverMessage || 'unknown'), { error })
+				showError(serverMessage || this.t('contacts', 'Could not accept invite'))
+			} finally {
+				this.loadingUpdate = false
+			}
+		},
+		async handleAccept({ provider, token }) {
+			if (this.loadingUpdate) {
+				return
+			}
+			this.loadingUpdate = true
+			try {
+				const url = generateUrl('/apps/contacts/ocm/invitations/{token}/accept', { token })
+				const response = await axios.patch(url, {
+					provider,
+				})
+				this.showManualInvite = false
+				window.location.assign(response.data.contact)
+			} catch (error) {
+				const serverMessage = error?.response?.data?.message
+				logger.error('Could not accept invite: ' + (serverMessage || 'unknown'), { error })
+				showError(serverMessage || this.t('contacts', 'Could not accept invite'))
+			} finally {
+				this.loadingUpdate = false
+			}
+		},
+		cancelInvite() {
+			this.showInviteAcceptDialog = false
+			this.clearInviteAcceptRoute()
+		},
+		async sendNewInvite() {
+			if (this.loadingUpdate) {
+				return
+			}
+			// Validate: when the user wants to email the invite, email must be filled.
+			if (this.ocmInvite.sendEmail && !this.ocmInvite.email?.trim()) {
+				showError(this.t('contacts', 'Please enter an email address.'))
+				return
+			}
+			this.loadingUpdate = true
+			try {
+				const response = await this.ocminvitesStore.newOcmInvite(this.ocmInvite)
+				this.cancelNewInvite()
+				window.location.assign(response.data.invite)
+			} catch (error) {
+				const serverMessage = error?.response?.data?.message
+				showError(serverMessage || this.t('contacts', 'Could not create invite'))
+			} finally {
+				this.loadingUpdate = false
+			}
+		},
+		cancelNewInvite() {
+			this.showNewInviteForm = false
+			this.ocmInvite = { email: '', message: '' }
+		},
+		clearInviteAcceptRoute() {
+			if (this.$route.name !== ROUTE_NAME_INVITE_ACCEPT_DIALOG) {
+				return
+			}
+			this.$router.replace({ name: 'root' })
+		},
+		openCreateInvite() {
+			if (!this.isOcmInvitesEnabled) {
+				return
+			}
+			this.showNewInviteForm = true
+		},
+		openAcceptInvite() {
+			if (!this.isOcmInvitesEnabled) {
+				return
+			}
+			this.showManualInvite = true
+		},
+		getNewContactButtonClass() {
+			if (this.isOcmInvitesEnabled) {
+				return this.isEmptyGroup ? 'new-contact-button-ocm-invites-enabled-empty-group' : 'new-contact-button-ocm-invites-enabled'
+			}
+			return 'new-contact-button-wide'
+		},
 	},
 }
+
+export default _default
 </script>
 
 <style lang="scss" scoped>
 .import-and-new-contact-buttons {
+	position: relative;
 	display: flex;
-	flex-direction: column;
-	gap: 4px;
+	.new-contact-button-ocm-invites-enabled {
+		width: calc(100% - (var(--default-grid-baseline) + var(--default-clickable-area)));
+	}
+	.new-contact-button-ocm-invites-enabled-empty-group {
+		width: calc(50% - (var(--default-grid-baseline) + var(--default-clickable-area)) * .5);
+	}
+	.new-contact-button-wide {
+		width: 100%;
+	}
+	.ocm-invites-actions {
+		position: absolute;
+		top: 0;
+		inset-inline-end: 0;
+	}
+}
+
+.invite-accept-form__buttons-row {
+  display: flex;
+  justify-content: flex-end;
+  gap: calc(var(--default-grid-baseline) * 2);
+  margin-top: calc(var(--default-grid-baseline) * 4);
+}
+
+.new-invite-form__buttons-row {
+  margin-top: calc(var(--default-grid-baseline) * 4);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: calc(var(--default-grid-baseline) * 2);
+  justify-content: flex-end;
 }
 </style>

--- a/src/wayf.js
+++ b/src/wayf.js
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { loadState } from '@nextcloud/initial-state'
+import { translatePlural as n, translate as t } from '@nextcloud/l10n'
+import { createApp } from 'vue'
+import Wayf from './components/Ocm/Wayf.vue'
+
+function mountWayf() {
+	const props = loadState('contacts', 'wayf')
+	const app = createApp(Wayf, props)
+	app.config.globalProperties.t = t
+	app.config.globalProperties.n = n
+	app.mount('#contacts-wayf')
+}
+
+if (!document.body.id) {
+	document.body.id = 'body-public'
+}
+
+if (document.readyState === 'loading') {
+	document.addEventListener('DOMContentLoaded', mountWayf)
+} else {
+	mountWayf()
+}

--- a/src/wayf.js
+++ b/src/wayf.js
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { loadState } from '@nextcloud/initial-state'
+import { translatePlural as n, translate as t } from '@nextcloud/l10n'
+import { createApp } from 'vue'
+import Wayf from './components/Ocm/Wayf.vue'
+
+function mountWayf() {
+	const props = loadState('contacts', 'wayf')
+	const app = createApp(Wayf, props)
+	app.config.globalProperties.t = t
+	app.config.globalProperties.n = n
+	app.mount('#contacts-wayf')
+}
+
+if (!document.body.id) {
+	document.body.id = 'body-public'
+}
+
+if (document.readyState === 'loading') {
+	document.addEventListener('DOMContentLoaded', mountWayf)
+} else {
+	mountWayf()
+}

--- a/templates/wayf.php
+++ b/templates/wayf.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+?>
+<div id="contacts-wayf"></div>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,4 +14,5 @@ require_once __DIR__ . '/../../../lib/base.php';
 require_once __DIR__ . '/../../../tests/autoload.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 
+Server::get(IAppManager::class)->loadApp('cloud_federation_api');
 Server::get(IAppManager::class)->loadApp('contacts');

--- a/tests/javascript/components/ocm-accept-form.test.js
+++ b/tests/javascript/components/ocm-accept-form.test.js
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+jest.mock('@nextcloud/vue/components/NcButton', () => ({ default: {} }), { virtual: true })
+jest.mock('@nextcloud/vue/components/NcLoadingIcon', () => ({ default: {} }), { virtual: true })
+jest.mock('@nextcloud/vue/components/NcTextField', () => ({ default: {} }), { virtual: true })
+jest.mock('vue-material-design-icons/Cancel.vue', () => ({ default: {} }), { virtual: true })
+jest.mock('vue-material-design-icons/Check.vue', () => ({ default: {} }), { virtual: true })
+
+import OcmAcceptForm from '../../../src/components/Ocm/OcmAcceptForm.vue'
+
+const component = OcmAcceptForm.default || OcmAcceptForm
+
+describe('OcmAcceptForm invite parser', () => {
+	test('parses token@provider format', () => {
+		const parsed = component.methods.parseInvite('token123@provider.example')
+		expect(parsed).toEqual({
+			token: 'token123',
+			provider: 'provider.example',
+		})
+	})
+
+	test('parses absolute invite URL format', () => {
+		const parsed = component.methods.parseInvite('https://cloud.example/ocm/invite-accept-dialog?token=abc123&providerDomain=provider.example')
+		expect(parsed).toEqual({
+			token: 'abc123',
+			provider: 'provider.example',
+		})
+	})
+
+	test('parses encoded invite format', () => {
+		const encoded = Buffer.from('token123@provider.example', 'utf8').toString('base64')
+		const parsed = component.methods.parseInvite(encoded)
+		expect(parsed).toEqual({
+			token: 'token123',
+			provider: 'provider.example',
+		})
+	})
+
+	test('throws on invalid invite input', () => {
+		expect(() => component.methods.parseInvite('not-an-invite')).toThrow('Could not parse invite')
+	})
+})

--- a/tests/javascript/store/ocminvites.test.js
+++ b/tests/javascript/store/ocminvites.test.js
@@ -1,0 +1,324 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+jest.mock('@nextcloud/axios', () => ({
+	__esModule: true,
+	default: {
+		get: jest.fn(),
+		post: jest.fn(),
+		patch: jest.fn(),
+		delete: jest.fn(),
+	},
+}))
+
+jest.mock('@nextcloud/router', () => ({
+	__esModule: true,
+	generateUrl: (path, params = {}) => {
+		let result = path
+		for (const [key, value] of Object.entries(params)) {
+			result = result.replaceAll(`{${key}}`, encodeURIComponent(String(value)))
+		}
+		return result
+	},
+}))
+
+import axios from '@nextcloud/axios'
+import { createPinia, setActivePinia } from 'pinia'
+
+import { toOcmInviteEntry } from '../../../src/models/ocminvite.ts'
+import useOcmInvitesStore from '../../../src/store/ocminvites.ts'
+
+const TOKEN = 'token-1234'
+
+const flatInvitePayload = (overrides = {}) => ({
+	accepted: false,
+	acceptedAt: null,
+	createdAt: 1_800_000_000,
+	expiredAt: 1_800_000_000 + 2_592_000,
+	recipientEmail: 'recipient@example.org',
+	recipientName: null,
+	recipientProvider: null,
+	recipientUserId: null,
+	token: TOKEN,
+	userId: 'alice',
+	...overrides,
+})
+
+describe('ocminvites store', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+		setActivePinia(createPinia())
+	})
+
+	describe('attachEmailAndSendOcmInvite', () => {
+		test('PATCHes the per-invite email endpoint with the email and message payload', async () => {
+			axios.patch.mockResolvedValue({ data: flatInvitePayload() })
+
+			const store = useOcmInvitesStore()
+			await store.attachEmailAndSendOcmInvite({
+				token: TOKEN,
+				email: 'recipient@example.org',
+				message: 'hello',
+			})
+
+			expect(axios.patch).toHaveBeenCalledTimes(1)
+			const [url, payload] = axios.patch.mock.calls[0]
+			expect(url).toBe(`/apps/contacts/ocm/invitations/${TOKEN}/email`)
+			expect(payload).toEqual({
+				email: 'recipient@example.org',
+				message: 'hello',
+			})
+		})
+
+		test('coerces missing email and message to empty strings', async () => {
+			axios.patch.mockResolvedValue({ data: flatInvitePayload() })
+
+			const store = useOcmInvitesStore()
+			await store.attachEmailAndSendOcmInvite({ token: TOKEN })
+
+			const [, payload] = axios.patch.mock.calls[0]
+			expect(payload).toEqual({ email: '', message: '' })
+		})
+
+		test('stores a fresh invite entry from a flat backend response', async () => {
+			axios.patch.mockResolvedValue({ data: flatInvitePayload() })
+
+			const store = useOcmInvitesStore()
+			const response = await store.attachEmailAndSendOcmInvite({
+				token: TOKEN,
+				email: 'recipient@example.org',
+				message: '',
+			})
+
+			expect(response.data.token).toBe(TOKEN)
+			const stored = store.ocmInvites[TOKEN]
+			expect(stored.key).toBe(TOKEN)
+			expect(stored.token).toBe(TOKEN)
+			expect(stored.recipientEmail).toBe('recipient@example.org')
+			expect(store.sortedOcmInvites).toHaveLength(1)
+			expect(store.sortedOcmInvites[0].key).toBe(TOKEN)
+		})
+
+		test('rethrows when the request fails and leaves state untouched', async () => {
+			const failure = new Error('boom')
+			axios.patch.mockRejectedValue(failure)
+
+			const store = useOcmInvitesStore()
+			await expect(
+				store.attachEmailAndSendOcmInvite({
+					token: TOKEN,
+					email: 'recipient@example.org',
+					message: '',
+				}),
+			).rejects.toBe(failure)
+
+			expect(store.ocmInvites).toEqual({})
+			expect(store.sortedOcmInvites).toEqual([])
+		})
+	})
+
+	describe('fetchOcmInvites', () => {
+		test('replaces existing invite map with latest server payload', async () => {
+			axios.get.mockResolvedValue({
+				data: [flatInvitePayload({ token: 'fresh-token', recipientEmail: 'fresh@example.org' })],
+			})
+
+			const store = useOcmInvitesStore()
+			store.ocmInvites = {
+				'stale-token': toOcmInviteEntry(flatInvitePayload({ token: 'stale-token', recipientEmail: 'stale@example.org' })),
+			}
+
+			await store.fetchOcmInvites()
+
+			expect(Object.keys(store.ocmInvites)).toEqual(['fresh-token'])
+			expect(store.ocmInvites['fresh-token'].recipientEmail).toBe('fresh@example.org')
+			expect(store.inviteListStatus).toBe('success')
+			expect(store.inviteListError).toBeNull()
+		})
+
+		test('sorts by recipientEmail value, not token key', async () => {
+			axios.get.mockResolvedValue({
+				data: [
+					flatInvitePayload({ token: 'z-token', recipientEmail: 'zeta@example.org' }),
+					flatInvitePayload({ token: 'a-token', recipientEmail: 'alpha@example.org' }),
+				],
+			})
+
+			const store = useOcmInvitesStore()
+			await store.fetchOcmInvites()
+
+			expect(store.sortedOcmInvites.map(entry => entry.key)).toEqual(['a-token', 'z-token'])
+			expect(store.inviteListStatus).toBe('success')
+			expect(store.inviteListError).toBeNull()
+		})
+
+		test('rethrows and sets error state when request fails', async () => {
+			const failure = new Error('network down')
+			axios.get.mockRejectedValue(failure)
+
+			const store = useOcmInvitesStore()
+			await expect(store.fetchOcmInvites()).rejects.toBe(failure)
+
+			expect(store.inviteListStatus).toBe('error')
+			expect(store.inviteListError).toContain('network down')
+		})
+
+		test('rejects malformed payloads and sets error state', async () => {
+			axios.get.mockResolvedValue({ data: { invalid: true } })
+
+			const store = useOcmInvitesStore()
+			await expect(store.fetchOcmInvites()).rejects.toThrow('Invalid invite list payload from server')
+
+			expect(store.inviteListStatus).toBe('error')
+			expect(store.inviteListError).toBe('Invalid invite list payload from server')
+		})
+	})
+
+	describe('updateOcmInvite action', () => {
+		test('replaces the invite for the matching token without dropping others', () => {
+			const store = useOcmInvitesStore()
+			store.ocmInvites = {
+				'other-token': toOcmInviteEntry({ token: 'other-token', recipientEmail: 'other@example.org' }),
+			}
+
+			store.updateOcmInvite(flatInvitePayload({ recipientEmail: 'fresh@example.org' }))
+
+			expect(Object.keys(store.ocmInvites)).toEqual(expect.arrayContaining(['other-token', TOKEN]))
+			expect(store.ocmInvites[TOKEN].recipientEmail).toBe('fresh@example.org')
+			expect(store.ocmInvites['other-token'].recipientEmail).toBe('other@example.org')
+		})
+
+		test('ignores payloads without a token and never mutates state', () => {
+			const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+			const store = useOcmInvitesStore()
+
+			store.updateOcmInvite({ recipientEmail: 'no-token@example.org' })
+
+			expect(store.ocmInvites).toEqual({})
+			expect(errorSpy).toHaveBeenCalled()
+			errorSpy.mockRestore()
+		})
+	})
+
+	describe('removeOcmInvite action', () => {
+		test('removes only the targeted invite from the sorted list', () => {
+			const a = toOcmInviteEntry({ token: 'a' })
+			const b = toOcmInviteEntry({ token: 'b' })
+			const store = useOcmInvitesStore()
+			store.ocmInvites = { a, b }
+			store.sortedOcmInvites = [a, b]
+
+			store.removeOcmInvite('a')
+
+			expect(store.sortedOcmInvites.map(i => i.key)).toEqual(['b'])
+			expect(store.ocmInvites).not.toHaveProperty('a')
+			expect(store.ocmInvites).toHaveProperty('b')
+		})
+
+		test('does not splice the last entry when the key is unknown', () => {
+			const a = toOcmInviteEntry({ token: 'a' })
+			const b = toOcmInviteEntry({ token: 'b' })
+			const store = useOcmInvitesStore()
+			store.ocmInvites = { a, b }
+			store.sortedOcmInvites = [a, b]
+
+			store.removeOcmInvite('missing-key')
+
+			expect(store.sortedOcmInvites.map(i => i.key)).toEqual(['a', 'b'])
+			expect(store.ocmInvites).toEqual({ a, b })
+		})
+	})
+
+	describe('deleteOcmInvite', () => {
+		test('throws when revoke request fails', async () => {
+			const failure = new Error('delete failed')
+			axios.delete.mockRejectedValue(failure)
+
+			const store = useOcmInvitesStore()
+			const invite = toOcmInviteEntry(flatInvitePayload())
+			await expect(store.deleteOcmInvite(invite)).rejects.toBe(failure)
+		})
+	})
+
+	describe('create/resend behavior', () => {
+		test('newOcmInvite refreshes invite list after create', async () => {
+			axios.post.mockResolvedValue({ data: { invite: '/invite/link' } })
+			axios.get.mockResolvedValue({ data: [flatInvitePayload({ token: 'new-token' })] })
+
+			const store = useOcmInvitesStore()
+			await store.newOcmInvite({
+				email: 'recipient@example.org',
+				message: 'See you soon',
+			})
+
+			expect(axios.post).toHaveBeenCalledTimes(1)
+			expect(axios.post).toHaveBeenCalledWith('/apps/contacts/ocm/invitations', {
+				email: 'recipient@example.org',
+				message: 'See you soon',
+			})
+			expect(axios.get).toHaveBeenCalledTimes(1)
+			expect(store.ocmInvites['new-token']).toBeDefined()
+		})
+
+		test('newOcmInvite defaults optional create payload fields', async () => {
+			axios.post.mockResolvedValue({ data: { invite: '/invite/link' } })
+			axios.get.mockResolvedValue({ data: [] })
+
+			const store = useOcmInvitesStore()
+			await store.newOcmInvite({})
+
+			expect(axios.post).toHaveBeenCalledWith('/apps/contacts/ocm/invitations', {
+				email: '',
+				message: '',
+			})
+		})
+
+		test('resendOcmInvite returns resend response without reloading invites', async () => {
+			const resendResponse = { data: { invite: '/invite/link' } }
+			axios.patch.mockResolvedValue(resendResponse)
+
+			const store = useOcmInvitesStore()
+			const invite = toOcmInviteEntry(flatInvitePayload())
+			await expect(store.resendOcmInvite(invite)).resolves.toBe(resendResponse)
+
+			expect(axios.patch).toHaveBeenCalledTimes(1)
+			expect(axios.get).not.toHaveBeenCalled()
+		})
+
+		test('newOcmInvite resolves when refresh fetch fails', async () => {
+			const failure = new Error('refresh failed')
+			const createResponse = { data: { invite: '/invite/link' } }
+			axios.post.mockResolvedValue(createResponse)
+			axios.get.mockRejectedValue(failure)
+
+			const store = useOcmInvitesStore()
+			await expect(store.newOcmInvite({ email: 'recipient@example.org', message: '' })).resolves.toBe(createResponse)
+
+			expect(store.inviteListStatus).toBe('error')
+			expect(store.inviteListError).toContain('refresh failed')
+		})
+
+		test('newOcmInvite rejects when create request fails', async () => {
+			const failure = new Error('create failed')
+			axios.post.mockRejectedValue(failure)
+
+			const store = useOcmInvitesStore()
+			await expect(store.newOcmInvite({ email: 'recipient@example.org', message: '' })).rejects.toBe(failure)
+
+			expect(axios.get).not.toHaveBeenCalled()
+		})
+
+		test('resendOcmInvite rejects when resend request fails', async () => {
+			const failure = new Error('resend failed')
+			axios.patch.mockRejectedValue(failure)
+
+			const store = useOcmInvitesStore()
+			const invite = toOcmInviteEntry(flatInvitePayload())
+			await expect(store.resendOcmInvite(invite)).rejects.toBe(failure)
+
+			expect(axios.get).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/tests/javascript/views/contacts-ocm-flows.test.js
+++ b/tests/javascript/views/contacts-ocm-flows.test.js
@@ -1,0 +1,202 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+jest.mock('@nextcloud/auth', () => ({
+	getCurrentUser: jest.fn(() => ({ uid: 'alice' })),
+}))
+
+jest.mock('@nextcloud/axios', () => ({
+	__esModule: true,
+	default: {
+		patch: jest.fn(),
+	},
+}))
+
+jest.mock('@nextcloud/dialogs', () => ({
+	showError: jest.fn(),
+}))
+
+jest.mock('@nextcloud/event-bus', () => ({
+	emit: jest.fn(),
+}))
+
+jest.mock('@nextcloud/initial-state', () => ({
+	loadState: jest.fn((app, key, fallback) => fallback),
+}))
+
+jest.mock('@nextcloud/router', () => ({
+	generateUrl: (path, params = {}) => {
+		let result = path
+		for (const [key, value] of Object.entries(params)) {
+			result = result.replace(`{${key}}`, String(value))
+		}
+		return result
+	},
+}))
+
+jest.mock('@nextcloud/vue', () => ({
+	NcButton: {},
+	NcContent: {},
+	NcLoadingIcon: {},
+	NcModal: {},
+}))
+
+jest.mock('ical.js', () => ({}))
+
+jest.mock('pinia', () => ({
+	mapStores: () => ({}),
+}))
+
+jest.mock('../../../src/components/AppContent/ChartContent.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/AppContent/CircleContent.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/AppContent/ContactsContent.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/AppContent/OcmInvitesContent.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/AppNavigation/RootNavigation.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/AppNavigation/Settings/SettingsImportContacts.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/EntityPicker/ContactsPicker.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/Ocm/OcmAcceptForm.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/Ocm/OcmInviteAccept.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/Ocm/OcmInviteForm.vue', () => ({ default: {} }))
+jest.mock('../../../src/views/Processing/ImportView.vue', () => ({ default: {} }))
+jest.mock('../../../src/mixins/IsMobileMixin.ts', () => ({ default: {} }))
+jest.mock('../../../src/mixins/RouterMixin.js', () => ({ default: {} }))
+jest.mock('../../../src/models/constants.ts', () => ({
+	GROUP_ALL_CONTACTS: 'all',
+	GROUP_ALL_OCM_INVITES: 'all-ocm',
+	GROUP_NO_GROUP_CONTACTS: 'nogroup',
+	ROUTE_CIRCLE: 'circle',
+	ROUTE_NAME_ALL_OCM_INVITES: 'all_ocm_invites',
+	ROUTE_NAME_INVITE_ACCEPT_DIALOG: 'invite_accept_dialog',
+	ROUTE_NAME_OCM_INVITE: 'ocm_invite',
+	ROUTE_USER_GROUP: 'user-group',
+}))
+jest.mock('../../../src/models/contact.js', () => ({ default: class Contact {} }))
+jest.mock('../../../src/models/rfcProps.js', () => ({ default: {} }))
+jest.mock('../../../src/services/cdav.js', () => ({ default: {} }))
+jest.mock('../../../src/services/isCirclesEnabled.js', () => ({ default: false }))
+jest.mock('../../../src/services/isOcmInvitesEnabled.js', () => ({ default: true }))
+jest.mock('../../../src/services/logger.js', () => ({
+	__esModule: true,
+	default: {
+		error: jest.fn(),
+	},
+}))
+jest.mock('../../../src/store/ocminvites.ts', () => ({ default: jest.fn() }))
+jest.mock('../../../src/store/principals.js', () => ({ default: jest.fn() }))
+jest.mock('../../../src/store/userGroup.ts', () => ({ default: jest.fn() }))
+jest.mock('vue-material-design-icons/AccountArrowDownOutline.vue', () => ({ default: {} }))
+jest.mock('vue-material-design-icons/AccountSwitchOutline.vue', () => ({ default: {} }))
+jest.mock('vue-material-design-icons/Cancel.vue', () => ({ default: {} }))
+jest.mock('vue-material-design-icons/Check.vue', () => ({ default: {} }))
+jest.mock('vue-material-design-icons/Plus.vue', () => ({ default: {} }))
+
+import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+import Contacts from '../../../src/views/Contacts.vue'
+
+const view = Contacts.default || Contacts
+
+describe('Contacts OCM flow methods', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+	})
+
+	test('sendNewInvite keeps draft modal open on create failure', async () => {
+		const createFailure = { response: { data: { message: 'Could not create invite' } } }
+		const vm = {
+			loadingUpdate: false,
+			showNewInviteForm: true,
+			ocmInvite: { email: 'recipient@example.org', message: '', sendEmail: false },
+			ocmInvitesConfig: { optionalMail: true },
+			ocminvitesStore: {
+				newOcmInvite: jest.fn().mockRejectedValue(createFailure),
+			},
+			cancelNewInvite: jest.fn(),
+			t: (app, text) => text,
+		}
+
+		await view.methods.sendNewInvite.call(vm)
+
+		expect(vm.cancelNewInvite).not.toHaveBeenCalled()
+		expect(vm.showNewInviteForm).toBe(true)
+		expect(showError).toHaveBeenCalledWith('Could not create invite')
+		expect(vm.loadingUpdate).toBe(false)
+	})
+
+	test('sendNewInvite reports the short missing email message', async () => {
+		const vm = {
+			loadingUpdate: false,
+			ocmInvite: { email: '', message: '', sendEmail: true },
+			ocmInvitesConfig: { optionalMail: true },
+			ocminvitesStore: {
+				newOcmInvite: jest.fn(),
+			},
+			t: (app, text) => text,
+		}
+
+		await view.methods.sendNewInvite.call(vm)
+
+		expect(showError).toHaveBeenCalledWith('Please enter an email address.')
+		expect(vm.ocminvitesStore.newOcmInvite).not.toHaveBeenCalled()
+		expect(vm.loadingUpdate).toBe(false)
+	})
+
+	test('sendNewInvite submits link-only invites with an empty email', async () => {
+		const createFailure = { response: { data: { message: 'backend reached' } } }
+		const vm = {
+			loadingUpdate: false,
+			ocmInvite: { email: '', message: 'hello', sendEmail: false },
+			showNewInviteForm: true,
+			ocminvitesStore: {
+				newOcmInvite: jest.fn().mockRejectedValue(createFailure),
+			},
+			cancelNewInvite: jest.fn(),
+			t: (app, text) => text,
+		}
+
+		await view.methods.sendNewInvite.call(vm)
+
+		expect(vm.ocminvitesStore.newOcmInvite).toHaveBeenCalledWith(vm.ocmInvite)
+		expect(vm.cancelNewInvite).not.toHaveBeenCalled()
+		expect(showError).toHaveBeenCalledWith('backend reached')
+		expect(showError).not.toHaveBeenCalledWith('Please enter an email address.')
+		expect(vm.loadingUpdate).toBe(false)
+	})
+
+	test('handleAccept keeps manual modal open on failure', async () => {
+		axios.patch.mockRejectedValueOnce({ response: { data: { message: 'manual accept failed' } } })
+		const vm = {
+			loadingUpdate: false,
+			showManualInvite: true,
+			t: (app, text) => text,
+		}
+
+		await view.methods.handleAccept.call(vm, {
+			provider: 'provider.example',
+			token: 'invite-token',
+		})
+
+		expect(vm.showManualInvite).toBe(true)
+		expect(showError).toHaveBeenCalledWith('manual accept failed')
+		expect(vm.loadingUpdate).toBe(false)
+	})
+
+	test('acceptInvite keeps deep-link dialog open on failure', async () => {
+		axios.patch.mockRejectedValueOnce({ response: { data: { message: 'deep-link failed' } } })
+		const vm = {
+			loadingUpdate: false,
+			showInviteAcceptDialog: true,
+			inviteToken: 'invite-token',
+			inviteProvider: 'provider.example',
+			t: (app, text) => text,
+		}
+
+		await view.methods.acceptInvite.call(vm)
+
+		expect(vm.showInviteAcceptDialog).toBe(true)
+		expect(showError).toHaveBeenCalledWith('deep-link failed')
+		expect(vm.loadingUpdate).toBe(false)
+	})
+})

--- a/tests/javascript/views/contacts-ocm-flows.test.js
+++ b/tests/javascript/views/contacts-ocm-flows.test.js
@@ -1,0 +1,201 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+jest.mock('@nextcloud/auth', () => ({
+	getCurrentUser: jest.fn(() => ({ uid: 'alice' })),
+}))
+
+jest.mock('@nextcloud/axios', () => ({
+	__esModule: true,
+	default: {
+		patch: jest.fn(),
+	},
+}))
+
+jest.mock('@nextcloud/dialogs', () => ({
+	showError: jest.fn(),
+}))
+
+jest.mock('@nextcloud/event-bus', () => ({
+	emit: jest.fn(),
+}))
+
+jest.mock('@nextcloud/initial-state', () => ({
+	loadState: jest.fn((app, key, fallback) => fallback),
+}))
+
+jest.mock('@nextcloud/router', () => ({
+	generateUrl: (path, params = {}) => {
+		let result = path
+		for (const [key, value] of Object.entries(params)) {
+			result = result.replace(`{${key}}`, String(value))
+		}
+		return result
+	},
+}))
+
+jest.mock('@nextcloud/vue', () => ({
+	NcButton: {},
+	NcContent: {},
+	NcLoadingIcon: {},
+	NcModal: {},
+}))
+
+jest.mock('ical.js', () => ({}))
+
+jest.mock('pinia', () => ({
+	mapStores: () => ({}),
+}))
+
+jest.mock('../../../src/components/AppContent/ChartContent.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/AppContent/CircleContent.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/AppContent/ContactsContent.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/AppContent/OcmInvitesContent.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/AppNavigation/RootNavigation.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/AppNavigation/Settings/SettingsImportContacts.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/EntityPicker/ContactsPicker.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/Ocm/OcmAcceptForm.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/Ocm/OcmInviteAccept.vue', () => ({ default: {} }))
+jest.mock('../../../src/components/Ocm/OcmInviteForm.vue', () => ({ default: {} }))
+jest.mock('../../../src/views/Processing/ImportView.vue', () => ({ default: {} }))
+jest.mock('../../../src/mixins/IsMobileMixin.ts', () => ({ default: {} }))
+jest.mock('../../../src/mixins/RouterMixin.js', () => ({ default: {} }))
+jest.mock('../../../src/models/constants.ts', () => ({
+	GROUP_ALL_CONTACTS: 'all',
+	GROUP_ALL_OCM_INVITES: 'all-ocm',
+	GROUP_NO_GROUP_CONTACTS: 'nogroup',
+	ROUTE_CIRCLE: 'circle',
+	ROUTE_NAME_ALL_OCM_INVITES: 'all_ocm_invites',
+	ROUTE_NAME_INVITE_ACCEPT_DIALOG: 'invite_accept_dialog',
+	ROUTE_NAME_OCM_INVITE: 'ocm_invite',
+	ROUTE_USER_GROUP: 'user-group',
+}))
+jest.mock('../../../src/models/contact.js', () => ({ default: class Contact {} }))
+jest.mock('../../../src/models/rfcProps.js', () => ({ default: {} }))
+jest.mock('../../../src/services/cdav.js', () => ({ default: {} }))
+jest.mock('../../../src/services/isOcmInvitesEnabled.js', () => ({ default: true }))
+jest.mock('../../../src/services/logger.js', () => ({
+	__esModule: true,
+	default: {
+		error: jest.fn(),
+	},
+}))
+jest.mock('../../../src/store/ocminvites.ts', () => ({ default: jest.fn() }))
+jest.mock('../../../src/store/principals.js', () => ({ default: jest.fn() }))
+jest.mock('../../../src/store/userGroup.ts', () => ({ default: jest.fn() }))
+jest.mock('vue-material-design-icons/AccountArrowDownOutline.vue', () => ({ default: {} }))
+jest.mock('vue-material-design-icons/AccountSwitchOutline.vue', () => ({ default: {} }))
+jest.mock('vue-material-design-icons/Cancel.vue', () => ({ default: {} }))
+jest.mock('vue-material-design-icons/Check.vue', () => ({ default: {} }))
+jest.mock('vue-material-design-icons/Plus.vue', () => ({ default: {} }))
+
+import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+import Contacts from '../../../src/views/Contacts.vue'
+
+const view = Contacts.default || Contacts
+
+describe('Contacts OCM flow methods', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+	})
+
+	test('sendNewInvite keeps draft modal open on create failure', async () => {
+		const createFailure = { response: { data: { message: 'Could not create invite' } } }
+		const vm = {
+			loadingUpdate: false,
+			showNewInviteForm: true,
+			ocmInvite: { email: 'recipient@example.org', message: '', sendEmail: false },
+			ocmInvitesConfig: { optionalMail: true },
+			ocminvitesStore: {
+				newOcmInvite: jest.fn().mockRejectedValue(createFailure),
+			},
+			cancelNewInvite: jest.fn(),
+			t: (app, text) => text,
+		}
+
+		await view.methods.sendNewInvite.call(vm)
+
+		expect(vm.cancelNewInvite).not.toHaveBeenCalled()
+		expect(vm.showNewInviteForm).toBe(true)
+		expect(showError).toHaveBeenCalledWith('Could not create invite')
+		expect(vm.loadingUpdate).toBe(false)
+	})
+
+	test('sendNewInvite reports the short missing email message', async () => {
+		const vm = {
+			loadingUpdate: false,
+			ocmInvite: { email: '', message: '', sendEmail: true },
+			ocmInvitesConfig: { optionalMail: true },
+			ocminvitesStore: {
+				newOcmInvite: jest.fn(),
+			},
+			t: (app, text) => text,
+		}
+
+		await view.methods.sendNewInvite.call(vm)
+
+		expect(showError).toHaveBeenCalledWith('Please enter an email address.')
+		expect(vm.ocminvitesStore.newOcmInvite).not.toHaveBeenCalled()
+		expect(vm.loadingUpdate).toBe(false)
+	})
+
+	test('sendNewInvite submits link-only invites with an empty email', async () => {
+		const createFailure = { response: { data: { message: 'backend reached' } } }
+		const vm = {
+			loadingUpdate: false,
+			ocmInvite: { email: '', message: 'hello', sendEmail: false },
+			showNewInviteForm: true,
+			ocminvitesStore: {
+				newOcmInvite: jest.fn().mockRejectedValue(createFailure),
+			},
+			cancelNewInvite: jest.fn(),
+			t: (app, text) => text,
+		}
+
+		await view.methods.sendNewInvite.call(vm)
+
+		expect(vm.ocminvitesStore.newOcmInvite).toHaveBeenCalledWith(vm.ocmInvite)
+		expect(vm.cancelNewInvite).not.toHaveBeenCalled()
+		expect(showError).toHaveBeenCalledWith('backend reached')
+		expect(showError).not.toHaveBeenCalledWith('Please enter an email address.')
+		expect(vm.loadingUpdate).toBe(false)
+	})
+
+	test('handleAccept keeps manual modal open on failure', async () => {
+		axios.patch.mockRejectedValueOnce({ response: { data: { message: 'manual accept failed' } } })
+		const vm = {
+			loadingUpdate: false,
+			showManualInvite: true,
+			t: (app, text) => text,
+		}
+
+		await view.methods.handleAccept.call(vm, {
+			provider: 'provider.example',
+			token: 'invite-token',
+		})
+
+		expect(vm.showManualInvite).toBe(true)
+		expect(showError).toHaveBeenCalledWith('manual accept failed')
+		expect(vm.loadingUpdate).toBe(false)
+	})
+
+	test('acceptInvite keeps deep-link dialog open on failure', async () => {
+		axios.patch.mockRejectedValueOnce({ response: { data: { message: 'deep-link failed' } } })
+		const vm = {
+			loadingUpdate: false,
+			showInviteAcceptDialog: true,
+			inviteToken: 'invite-token',
+			inviteProvider: 'provider.example',
+			t: (app, text) => text,
+		}
+
+		await view.methods.acceptInvite.call(vm)
+
+		expect(vm.showInviteAcceptDialog).toBe(true)
+		expect(showError).toHaveBeenCalledWith('deep-link failed')
+		expect(vm.loadingUpdate).toBe(false)
+	})
+})

--- a/tests/stubs/oca_dav_events_sabrepluginaddevent.php
+++ b/tests/stubs/oca_dav_events_sabrepluginaddevent.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\DAV\Events;
 
 use OCP\EventDispatcher\Event;

--- a/tests/unit/ContactsMenu/Provider/DetailsProviderTest.php
+++ b/tests/unit/ContactsMenu/Provider/DetailsProviderTest.php
@@ -139,7 +139,6 @@ class DetailsProviderTest extends Base {
 		$iconUrl = 'core/img/actions/info.svg';
 		$resultUri = "$domain/index.php/apps/contacts/direct/contact/ZTNhNzE2MTQtYzYwMi00ZWI1LTk5OTQtNDdlZWM1NTE1NDJiLcOpfmNvbnRhY3RzLTE=";
 
-
 		$entry->expects($this->exactly(3))
 			->method('getProperty')
 			->will($this->returnValueMap([

--- a/tests/unit/Controller/ContactsControllerTest.php
+++ b/tests/unit/Controller/ContactsControllerTest.php
@@ -24,7 +24,6 @@ class ContactsControllerTest extends TestCase {
 	/** @var IURLGenerator|MockObject */
 	private $urlGenerator;
 
-
 	protected function setUp(): void {
 		parent::setUp();
 

--- a/tests/unit/Controller/FederatedInvitesControllerTest.php
+++ b/tests/unit/Controller/FederatedInvitesControllerTest.php
@@ -1,0 +1,819 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Controller;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OC\App\CompareVersion;
+use OCA\Contacts\Db\FederatedInvite;
+use OCA\Contacts\Db\FederatedInviteMapper;
+use OCA\Contacts\Service\FederatedInvitesService;
+use OCA\Contacts\Service\GroupSharingService;
+use OCA\Contacts\Service\SocialApiService;
+use OCA\Contacts\WayfProvider;
+use OCA\FederatedFileSharing\AddressHandler;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Contacts\IManager;
+use OCP\Defaults;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\L10N\IFactory;
+use OCP\Mail\IMailer;
+use OCP\OCM\IOCMDiscoveryService;
+use OCP\OCM\IOCMProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+abstract class TestIOCMDiscoveryService implements IOCMDiscoveryService {
+	abstract public function discover(
+		string $remote,
+		bool $skipCache = false,
+	): IOCMProvider;
+
+	abstract public function requestRemoteOcmEndpoint(
+		?string $capability,
+		string $remote,
+		string $ocmSubPath,
+		?array $payload = null,
+		string $method = 'get',
+		?IClient $client = null,
+		?array $options = null,
+		bool $signed = true,
+	): IResponse;
+}
+
+class FederatedInvitesControllerTest extends TestCase {
+	private const UID = 'alice';
+	private const OTHER_UID = 'bob';
+	private const TOKEN = 'token-1234';
+
+	private FederatedInvitesController $controller;
+
+	private IRequest|MockObject $request;
+	private AddressHandler|MockObject $addressHandler;
+	private Defaults|MockObject $defaults;
+	private FederatedInviteMapper|MockObject $mapper;
+	private FederatedInvitesService|MockObject $invitesService;
+	private IAppManager|MockObject $appManager;
+	private IClientService|MockObject $httpClient;
+	private IConfig|MockObject $config;
+	private IInitialState|MockObject $initialState;
+	private IFactory|MockObject $languageFactory;
+	private IManager|MockObject $contactsManager;
+	private IMailer|MockObject $mailer;
+	private TestIOCMDiscoveryService|MockObject $discovery;
+	private IUserSession|MockObject $userSession;
+	private WayfProvider|MockObject $wayfProvider;
+	private SocialApiService|MockObject $socialApi;
+	private ITimeFactory|MockObject $timeFactory;
+	private CompareVersion|MockObject $compareVersion;
+	private GroupSharingService|MockObject $groupSharingService;
+	private IL10N|MockObject $l10n;
+	private IURLGenerator|MockObject $urlGenerator;
+	private IUserManager|MockObject $userManager;
+	private LoggerInterface|MockObject $logger;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->addressHandler = $this->createMock(AddressHandler::class);
+		$this->defaults = $this->createMock(Defaults::class);
+		$this->mapper = $this->createMock(FederatedInviteMapper::class);
+		$this->invitesService = $this->createMock(FederatedInvitesService::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->httpClient = $this->createMock(IClientService::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->initialState = $this->createMock(IInitialState::class);
+		$this->languageFactory = $this->createMock(IFactory::class);
+		$this->contactsManager = $this->createMock(IManager::class);
+		$this->mailer = $this->createMock(IMailer::class);
+		$this->discovery = $this->createMock(TestIOCMDiscoveryService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->wayfProvider = $this->createMock(WayfProvider::class);
+		$this->socialApi = $this->createMock(SocialApiService::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->compareVersion = $this->createMock(CompareVersion::class);
+		$this->groupSharingService = $this->createMock(GroupSharingService::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->l10n->method('t')->willReturnCallback(static fn (string $text, array $params = []): string => vsprintf($text, $params));
+		$this->invitesService->method('isOcmInvitesEnabled')->willReturn(true);
+		$this->mapper->method('deleteSupersededInvitesForRecipientEmail')->willReturn(0);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn(self::UID);
+		$user->method('getDisplayName')->willReturn('Alice');
+		$user->method('getEMailAddress')->willReturn('alice@example.org');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$this->controller = new FederatedInvitesController(
+			$this->request,
+			$this->addressHandler,
+			$this->defaults,
+			$this->mapper,
+			$this->invitesService,
+			$this->httpClient,
+			$this->initialState,
+			$this->mailer,
+			$this->discovery,
+			$this->userSession,
+			$this->wayfProvider,
+			$this->timeFactory,
+			$this->l10n,
+			$this->urlGenerator,
+			$this->logger,
+		);
+	}
+
+	private function makeInvite(?string $email = null, bool $accepted = false, string $uid = self::UID): FederatedInvite {
+		$invite = new FederatedInvite();
+		$invite->setUserId($uid);
+		$invite->setToken(self::TOKEN);
+		$invite->setRecipientEmail($email);
+		$invite->setAccepted($accepted);
+		$invite->setCreatedAt(1_700_000_000);
+		$invite->setExpiredAt(1_700_000_000 + 2_592_000);
+		return $invite;
+	}
+
+	public function testGetInvitesReturnsStructuredErrorWhenMapperFails(): void {
+		$this->mapper->expects($this->once())
+			->method('findOpenInvitesByUid')
+			->with(self::UID)
+			->willThrowException(new \RuntimeException('db fail'));
+
+		$response = $this->controller->getInvites();
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame('ocm_invites_fetch_failed', $response->getData()['code']);
+	}
+
+	public function testAttachEmailAndSendUpdatesAndSends(): void {
+		$invite = $this->makeInvite(null);
+
+		$this->mapper->expects($this->once())
+			->method('findInviteByTokenAndUid')
+			->with(self::TOKEN, self::UID)
+			->willReturn($invite);
+		$this->mapper->method('findOpenInvitesByRecipientEmail')->willReturn([]);
+		$this->mailer->method('validateMailAddress')->willReturn(true);
+		$this->mailer->method('createMessage')->willReturn($this->createMock(\OCP\Mail\IMessage::class));
+		$this->mailer->method('send')->willReturn([]);
+		$this->wayfProvider->method('getWayfEndpoint')->willReturn('https://example.org/wayf');
+		$this->invitesService->method('getProviderFQDN')->willReturn('example.org');
+		$this->invitesService->method('getInviteExpirationDate')->willReturnCallback(static fn (int $t): int => $t + 2_592_000);
+		$now = $this->createMock(\DateTimeImmutable::class);
+		$now->method('getTimestamp')->willReturn(1_800_000_000);
+		$this->timeFactory->method('now')->willReturn($now);
+
+		$this->mapper->expects($this->once())
+			->method('claimInviteForEmail')
+			->with(self::TOKEN, self::UID, 'recipient@example.org', 1_800_000_000, 1_800_000_000 + 2_592_000)
+			->willReturn(true);
+		$this->mapper->expects($this->never())->method('revertInviteEmail');
+
+		$response = $this->controller->attachEmailAndSend(self::TOKEN, 'recipient@example.org', 'hello');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$body = $response->getData();
+		$this->assertSame('recipient@example.org', $body['recipientEmail']);
+		$this->assertSame(self::TOKEN, $body['token']);
+		$this->assertSame(1_800_000_000, $body['createdAt']);
+	}
+
+	public function testAttachEmailAndSendRejectsWhenClaimLosesRace(): void {
+		$invite = $this->makeInvite(null);
+
+		$this->mapper->method('findInviteByTokenAndUid')->willReturn($invite);
+		$this->mapper->method('findOpenInvitesByRecipientEmail')->willReturn([]);
+		$this->mailer->method('validateMailAddress')->willReturn(true);
+		$this->invitesService->method('getInviteExpirationDate')->willReturnCallback(static fn (int $t): int => $t + 2_592_000);
+		$now = $this->createMock(\DateTimeImmutable::class);
+		$now->method('getTimestamp')->willReturn(1_800_000_000);
+		$this->timeFactory->method('now')->willReturn($now);
+
+		$this->mapper->expects($this->once())
+			->method('claimInviteForEmail')
+			->willReturn(false);
+		$this->mailer->expects($this->never())->method('send');
+		$this->mapper->expects($this->never())->method('revertInviteEmail');
+
+		$response = $this->controller->attachEmailAndSend(self::TOKEN, 'recipient@example.org');
+
+		$this->assertSame(Http::STATUS_CONFLICT, $response->getStatus());
+		$this->assertSame('ocm_invite_claim_failed', $response->getData()['code']);
+		$this->assertNull($invite->getRecipientEmail());
+	}
+
+	public function testAttachEmailAndSendReturnsClaimExceptionCodeWhenClaimFails(): void {
+		$invite = $this->makeInvite(null);
+
+		$this->mapper->method('findInviteByTokenAndUid')->willReturn($invite);
+		$this->mapper->method('findOpenInvitesByRecipientEmail')->willReturn([]);
+		$this->mailer->method('validateMailAddress')->willReturn(true);
+		$this->invitesService->method('getInviteExpirationDate')->willReturnCallback(static fn (int $t): int => $t + 2_592_000);
+		$now = $this->createMock(\DateTimeImmutable::class);
+		$now->method('getTimestamp')->willReturn(1_800_000_000);
+		$this->timeFactory->method('now')->willReturn($now);
+
+		$this->mapper->expects($this->once())
+			->method('claimInviteForEmail')
+			->willThrowException(new \RuntimeException('claim boom'));
+		$this->mailer->expects($this->never())->method('send');
+		$this->mapper->expects($this->never())->method('revertInviteEmail');
+
+		$response = $this->controller->attachEmailAndSend(self::TOKEN, 'recipient@example.org');
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame('ocm_invite_claim_exception', $response->getData()['code']);
+	}
+
+	public function testAttachEmailAndSendRejectsWhenInviteBelongsToAnotherUser(): void {
+		$this->mapper->expects($this->once())
+			->method('findInviteByTokenAndUid')
+			->with(self::TOKEN, self::UID)
+			->willThrowException(new DoesNotExistException('not found'));
+
+		$this->mailer->expects($this->never())->method('send');
+		$this->mapper->expects($this->never())->method('claimInviteForEmail');
+		$this->mapper->expects($this->never())->method('revertInviteEmail');
+
+		$response = $this->controller->attachEmailAndSend(self::TOKEN, 'recipient@example.org');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+	}
+
+	public function testAttachEmailAndSendRejectsWhenInviteAlreadyAccepted(): void {
+		$invite = $this->makeInvite(null, accepted: true);
+		$this->mapper->method('findInviteByTokenAndUid')->willReturn($invite);
+
+		$this->mailer->expects($this->never())->method('send');
+		$this->mapper->expects($this->never())->method('claimInviteForEmail');
+
+		$response = $this->controller->attachEmailAndSend(self::TOKEN, 'recipient@example.org');
+
+		$this->assertSame(Http::STATUS_CONFLICT, $response->getStatus());
+		$this->assertSame('ocm_invite_already_accepted', $response->getData()['code']);
+	}
+
+	public function testAttachEmailAndSendRejectsWhenInviteAlreadyHasEmail(): void {
+		$invite = $this->makeInvite('existing@example.org');
+		$this->mapper->method('findInviteByTokenAndUid')->willReturn($invite);
+
+		$this->mailer->expects($this->never())->method('send');
+		$this->mapper->expects($this->never())->method('claimInviteForEmail');
+
+		$response = $this->controller->attachEmailAndSend(self::TOKEN, 'recipient@example.org');
+
+		$this->assertSame(Http::STATUS_CONFLICT, $response->getStatus());
+		$this->assertSame('ocm_invite_already_has_email', $response->getData()['code']);
+	}
+
+	public function testAttachEmailAndSendRejectsInvalidEmail(): void {
+		$invite = $this->makeInvite(null);
+		$this->mapper->method('findInviteByTokenAndUid')->willReturn($invite);
+		$this->mailer->method('validateMailAddress')->willReturn(false);
+
+		$this->mailer->expects($this->never())->method('send');
+		$this->mapper->expects($this->never())->method('claimInviteForEmail');
+
+		$response = $this->controller->attachEmailAndSend(self::TOKEN, 'not-an-email');
+
+		$this->assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
+		$this->assertNull($invite->getRecipientEmail());
+	}
+
+	public function testAttachEmailAndSendRejectsCollidingOpenInvite(): void {
+		$invite = $this->makeInvite(null);
+		$other = $this->makeInvite('recipient@example.org');
+		$other->setToken('other-token');
+
+		$this->mapper->method('findInviteByTokenAndUid')->willReturn($invite);
+		$this->mapper->method('findOpenInvitesByRecipientEmail')->willReturn([$other]);
+		$this->mailer->method('validateMailAddress')->willReturn(true);
+
+		$this->mailer->expects($this->never())->method('send');
+		$this->mapper->expects($this->never())->method('claimInviteForEmail');
+
+		$response = $this->controller->attachEmailAndSend(self::TOKEN, 'recipient@example.org');
+
+		$this->assertSame(Http::STATUS_CONFLICT, $response->getStatus());
+		$this->assertSame('ocm_invite_duplicate_recipient_email', $response->getData()['code']);
+	}
+
+	public function testAttachEmailAndSendRevertsOnMailerFailure(): void {
+		$invite = $this->makeInvite(null);
+		$originalCreatedAt = $invite->getCreatedAt();
+		$originalExpiredAt = $invite->getExpiredAt();
+
+		$this->mapper->method('findInviteByTokenAndUid')->willReturn($invite);
+		$this->mapper->method('findOpenInvitesByRecipientEmail')->willReturn([]);
+		$this->mailer->method('validateMailAddress')->willReturn(true);
+		$this->mailer->method('createMessage')->willReturn($this->createMock(\OCP\Mail\IMessage::class));
+		$this->mailer->method('send')->willReturn(['recipient@example.org']);
+		$this->wayfProvider->method('getWayfEndpoint')->willReturn('https://example.org/wayf');
+		$this->invitesService->method('getProviderFQDN')->willReturn('example.org');
+		$this->invitesService->method('getInviteExpirationDate')->willReturnCallback(static fn (int $t): int => $t + 2_592_000);
+		$now = $this->createMock(\DateTimeImmutable::class);
+		$now->method('getTimestamp')->willReturn(1_800_000_000);
+		$this->timeFactory->method('now')->willReturn($now);
+
+		$this->mapper->expects($this->once())
+			->method('claimInviteForEmail')
+			->willReturn(true);
+		$this->mapper->expects($this->once())
+			->method('revertInviteEmail')
+			->with(self::TOKEN, self::UID, 'recipient@example.org', $originalCreatedAt, $originalExpiredAt)
+			->willReturn(true);
+
+		$response = $this->controller->attachEmailAndSend(self::TOKEN, 'recipient@example.org');
+
+		$this->assertNotSame(Http::STATUS_OK, $response->getStatus());
+	}
+
+	public function testAttachEmailAndSendReturnsRevertFailureWhenRevertMisses(): void {
+		$invite = $this->makeInvite(null);
+		$originalCreatedAt = $invite->getCreatedAt();
+		$originalExpiredAt = $invite->getExpiredAt();
+
+		$this->mapper->method('findInviteByTokenAndUid')->willReturn($invite);
+		$this->mapper->method('findOpenInvitesByRecipientEmail')->willReturn([]);
+		$this->mailer->method('validateMailAddress')->willReturn(true);
+		$this->mailer->method('createMessage')->willReturn($this->createMock(\OCP\Mail\IMessage::class));
+		$this->mailer->method('send')->willReturn(['recipient@example.org']);
+		$this->wayfProvider->method('getWayfEndpoint')->willReturn('https://example.org/wayf');
+		$this->invitesService->method('getProviderFQDN')->willReturn('example.org');
+		$this->invitesService->method('getInviteExpirationDate')->willReturnCallback(static fn (int $t): int => $t + 2_592_000);
+		$now = $this->createMock(\DateTimeImmutable::class);
+		$now->method('getTimestamp')->willReturn(1_800_000_000);
+		$this->timeFactory->method('now')->willReturn($now);
+
+		$this->mapper->expects($this->once())
+			->method('claimInviteForEmail')
+			->willReturn(true);
+		$this->mapper->expects($this->once())
+			->method('revertInviteEmail')
+			->with(self::TOKEN, self::UID, 'recipient@example.org', $originalCreatedAt, $originalExpiredAt)
+			->willReturn(false);
+
+		$response = $this->controller->attachEmailAndSend(self::TOKEN, 'recipient@example.org');
+
+		$this->assertSame(Http::STATUS_BAD_GATEWAY, $response->getStatus());
+		$body = $response->getData();
+		$this->assertSame('ocm_invite_revert_failed', $body['code']);
+		$this->assertNotEmpty($body['mailError']);
+	}
+
+	public function testAttachEmailAndSendEscapesUserContentInHtmlBody(): void {
+		$invite = $this->makeInvite(null);
+		$this->mapper->method('findInviteByTokenAndUid')->willReturn($invite);
+		$this->mapper->method('findOpenInvitesByRecipientEmail')->willReturn([]);
+		$this->mailer->method('validateMailAddress')->willReturn(true);
+		$this->wayfProvider->method('getWayfEndpoint')->willReturn('https://example.org/wayf');
+		$this->invitesService->method('getProviderFQDN')->willReturn('example.org');
+		$this->invitesService->method('getInviteExpirationDate')->willReturnCallback(static fn (int $t): int => $t + 2_592_000);
+		$now = $this->createMock(\DateTimeImmutable::class);
+		$now->method('getTimestamp')->willReturn(1_800_000_000);
+		$this->timeFactory->method('now')->willReturn($now);
+		$this->mapper->method('claimInviteForEmail')->willReturn(true);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn(self::UID);
+		$user->method('getDisplayName')->willReturn('Eve <script>');
+		$user->method('getEMailAddress')->willReturn(null);
+		$session = $this->createMock(IUserSession::class);
+		$session->method('getUser')->willReturn($user);
+		$reflection = new \ReflectionProperty(FederatedInvitesController::class, 'userSession');
+		$reflection->setAccessible(true);
+		$reflection->setValue($this->controller, $session);
+
+		$capturedHtml = null;
+		$capturedPlain = null;
+		$message = $this->createMock(\OCP\Mail\IMessage::class);
+		$message->method('setHtmlBody')->willReturnCallback(function ($body) use (&$capturedHtml, $message) {
+			$capturedHtml = $body;
+			return $message;
+		});
+		$message->method('setPlainBody')->willReturnCallback(function ($body) use (&$capturedPlain, $message) {
+			$capturedPlain = $body;
+			return $message;
+		});
+		$this->mailer->method('createMessage')->willReturn($message);
+		$this->mailer->method('send')->willReturn([]);
+
+		$response = $this->controller->attachEmailAndSend(self::TOKEN, 'recipient@example.org');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertNotNull($capturedHtml);
+		$this->assertStringNotContainsString('<script>', (string)$capturedHtml);
+		$this->assertStringContainsString('Eve &lt;script&gt;', (string)$capturedHtml);
+		$this->assertNotNull($capturedPlain);
+	}
+
+	public function testAttachEmailAndSendRevertsWhenMailerThrows(): void {
+		$invite = $this->makeInvite(null);
+		$originalCreatedAt = $invite->getCreatedAt();
+		$originalExpiredAt = $invite->getExpiredAt();
+
+		$this->mapper->method('findInviteByTokenAndUid')->willReturn($invite);
+		$this->mapper->method('findOpenInvitesByRecipientEmail')->willReturn([]);
+		$this->mailer->method('validateMailAddress')->willReturn(true);
+		$this->mailer->method('createMessage')->willReturn($this->createMock(\OCP\Mail\IMessage::class));
+		$this->mailer->method('send')->willThrowException(new \RuntimeException('SMTP refused'));
+		$this->wayfProvider->method('getWayfEndpoint')->willReturn('https://example.org/wayf');
+		$this->invitesService->method('getProviderFQDN')->willReturn('example.org');
+		$this->invitesService->method('getInviteExpirationDate')->willReturnCallback(static fn (int $t): int => $t + 2_592_000);
+		$now = $this->createMock(\DateTimeImmutable::class);
+		$now->method('getTimestamp')->willReturn(1_800_000_000);
+		$this->timeFactory->method('now')->willReturn($now);
+
+		$this->mapper->expects($this->once())
+			->method('claimInviteForEmail')
+			->willReturn(true);
+		$this->mapper->expects($this->once())
+			->method('revertInviteEmail')
+			->with(self::TOKEN, self::UID, 'recipient@example.org', $originalCreatedAt, $originalExpiredAt)
+			->willReturn(true);
+
+		$response = $this->controller->attachEmailAndSend(self::TOKEN, 'recipient@example.org');
+
+		$this->assertSame(Http::STATUS_BAD_GATEWAY, $response->getStatus());
+	}
+
+	public function testResendInviteRejectsWhenInviteBelongsToAnotherUser(): void {
+		$this->mapper->expects($this->once())
+			->method('findInviteByTokenAndUid')
+			->with(self::TOKEN, self::UID)
+			->willThrowException(new DoesNotExistException('not found'));
+
+		$this->mailer->expects($this->never())->method('send');
+
+		$response = $this->controller->resendInvite(self::TOKEN);
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+	}
+
+	public function testResendInvitePreservesLifetimeOnSuccessfulSend(): void {
+		$invite = $this->makeInvite('recipient@example.org');
+		$createdAt = $invite->getCreatedAt();
+		$expiredAt = $invite->getExpiredAt();
+		$capturedHtml = null;
+		$capturedPlain = null;
+		$message = $this->createMock(\OCP\Mail\IMessage::class);
+		$message->method('setHtmlBody')->willReturnCallback(function ($body) use (&$capturedHtml, $message) {
+			$capturedHtml = $body;
+			return $message;
+		});
+		$message->method('setPlainBody')->willReturnCallback(function ($body) use (&$capturedPlain, $message) {
+			$capturedPlain = $body;
+			return $message;
+		});
+
+		$this->mapper->method('findInviteByTokenAndUid')->willReturn($invite);
+		$this->mailer->method('validateMailAddress')->willReturn(true);
+		$this->mailer->method('createMessage')->willReturn($message);
+		$this->mailer->method('send')->willReturn([]);
+		$this->wayfProvider->method('getWayfEndpoint')->willReturn('https://example.org/wayf');
+		$this->invitesService->method('getProviderFQDN')->willReturn('example.org');
+
+		$this->mapper->expects($this->never())->method('update');
+
+		$response = $this->controller->resendInvite(self::TOKEN);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($createdAt, $invite->getCreatedAt());
+		$this->assertSame($expiredAt, $invite->getExpiredAt());
+		$this->assertStringContainsString('This is a copy of an invite sent to you previously by Alice', (string)$capturedPlain);
+		$this->assertStringNotContainsString('invite send to you', (string)$capturedPlain);
+		$this->assertStringContainsString('This is a copy of an invite sent to you previously by Alice', (string)$capturedHtml);
+	}
+
+	public function testCreateInviteAllowsLinkOnlyWhenOptionalMailEnabled(): void {
+		$capturedInvite = null;
+		$now = $this->createMock(\DateTimeImmutable::class);
+		$now->method('getTimestamp')->willReturn(1_800_000_000);
+
+		$this->invitesService->method('isOptionalMailEnabled')->willReturn(true);
+		$this->invitesService->method('getInviteExpirationDate')->willReturn(1_800_000_000 + 2_592_000);
+		$this->timeFactory->method('now')->willReturn($now);
+		$this->mapper->expects($this->once())
+			->method('insert')
+			->willReturnCallback(static function (FederatedInvite $invite) use (&$capturedInvite): FederatedInvite {
+				$capturedInvite = $invite;
+				return $invite;
+			});
+		$this->mailer->expects($this->never())->method('createMessage');
+		$this->mailer->expects($this->never())->method('send');
+		$this->urlGenerator->method('linkToRoute')->with('contacts.page.index')->willReturn('/apps/contacts/');
+		$this->urlGenerator->method('getAbsoluteURL')->willReturnCallback(static fn (string $path): string => 'https://local.example' . $path);
+
+		$response = $this->controller->createInvite('', '');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertNotNull($capturedInvite);
+		$this->assertSame(self::UID, $capturedInvite->getUserId());
+		$this->assertStringContainsString('/apps/contacts/ocm-invites/', $response->getData()['invite']);
+	}
+
+	public function testCreateInviteIncludesPersonalMessageInFirstEmail(): void {
+		$capturedHtml = null;
+		$capturedPlain = null;
+		$message = $this->createMock(\OCP\Mail\IMessage::class);
+		$message->method('setHtmlBody')->willReturnCallback(function ($body) use (&$capturedHtml, $message) {
+			$capturedHtml = $body;
+			return $message;
+		});
+		$message->method('setPlainBody')->willReturnCallback(function ($body) use (&$capturedPlain, $message) {
+			$capturedPlain = $body;
+			return $message;
+		});
+		$now = $this->createMock(\DateTimeImmutable::class);
+		$now->method('getTimestamp')->willReturn(1_800_000_000);
+
+		$this->invitesService->method('isOptionalMailEnabled')->willReturn(true);
+		$this->invitesService->method('getInviteExpirationDate')->willReturn(1_800_000_000 + 2_592_000);
+		$this->timeFactory->method('now')->willReturn($now);
+		$this->mapper->method('findOpenInvitesByRecipientEmail')->willReturn([]);
+		$this->mapper->method('insert')->willReturnArgument(0);
+		$this->mailer->method('validateMailAddress')->willReturn(true);
+		$this->mailer->method('createMessage')->willReturn($message);
+		$this->mailer->method('send')->willReturn([]);
+		$this->wayfProvider->method('getWayfEndpoint')->willReturn('https://example.org/wayf');
+		$this->invitesService->method('getProviderFQDN')->willReturn('example.org');
+		$this->urlGenerator->method('linkToRoute')->with('contacts.page.index')->willReturn('/apps/contacts/');
+		$this->urlGenerator->method('getAbsoluteURL')->willReturnCallback(static fn (string $path): string => 'https://local.example' . $path);
+
+		$response = $this->controller->createInvite('recipient@example.org', '<b>hello</b>', '');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertStringContainsString('&lt;b&gt;hello&lt;/b&gt;', (string)$capturedHtml);
+		$this->assertStringNotContainsString('<b>hello</b>', (string)$capturedHtml);
+		$this->assertStringContainsString('<b>hello</b>', (string)$capturedPlain);
+	}
+
+	public function testCreateInviteRejectsMissingEmailWhenOptionalMailDisabled(): void {
+		$this->invitesService->expects($this->once())
+			->method('isOptionalMailEnabled')
+			->willReturn(false);
+		$this->mapper->expects($this->never())->method('insert');
+
+		$response = $this->controller->createInvite('', '', '');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('Email address is required.', $response->getData()['message']);
+	}
+
+	public function testAcceptInviteReturnsContactUrlOnSuccess(): void {
+		$client = $this->createMock(\OCP\Http\Client\IClient::class);
+		$provider = $this->createMock(IOCMProvider::class);
+		$remoteResponse = $this->createMock(IResponse::class);
+		$remoteBody = json_encode([
+			'userID' => 'bob',
+			'email' => 'bob@example.org',
+			'name' => 'Bob',
+		]);
+		$this->assertIsString($remoteBody);
+		$remoteResponse->method('getBody')->willReturn($remoteBody);
+
+		$this->httpClient->method('newClient')->willReturn($client);
+		$this->discovery->method('discover')->with('https://remote.example')->willReturn($provider);
+		$provider->method('hasCapability')->with('invites')->willReturn(true);
+		$this->discovery->expects($this->once())
+			->method('requestRemoteOcmEndpoint')
+			->with(
+				null,
+				'https://remote.example',
+				'/invite-accepted',
+				$this->callback(static function (array $payload): bool {
+					return $payload['token'] === self::TOKEN
+						&& $payload['userID'] === self::UID
+						&& $payload['email'] === 'alice@example.org'
+						&& $payload['name'] === 'Alice';
+				}),
+				'POST',
+				$client,
+			)
+			->willReturn($remoteResponse);
+		$this->addressHandler->method('removeProtocolFromUrl')->with('https://remote.example')->willReturn('remote.example');
+		$this->invitesService->method('getProviderFQDN')->willReturn('local.example');
+		$this->invitesService->method('createNewContact')->with(
+			'bob@remote.example',
+			'bob@example.org',
+			'Bob',
+			null,
+		)->willReturn('contact-uid~contacts');
+		$this->urlGenerator->method('linkToRoute')->with('contacts.page.index')->willReturn('/apps/contacts/');
+		$this->urlGenerator->method('getAbsoluteURL')->willReturnCallback(static fn (string $path): string => 'https://local.example' . $path);
+
+		$response = $this->controller->acceptInvite(self::TOKEN, 'remote.example');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			'https://local.example/apps/contacts/All contacts/' . base64_encode('contact-uid~contacts'),
+			$response->getData()['contact'],
+		);
+	}
+
+	public function testAcceptInviteRejectsAuthenticatedUserWithoutEmail(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn(self::UID);
+		$user->method('getDisplayName')->willReturn('Alice');
+		$user->method('getEMailAddress')->willReturn('');
+		$session = $this->createMock(IUserSession::class);
+		$session->method('getUser')->willReturn($user);
+		$reflection = new \ReflectionProperty(FederatedInvitesController::class, 'userSession');
+		$reflection->setAccessible(true);
+		$reflection->setValue($this->controller, $session);
+		$this->invitesService->method('getProviderFQDN')->willReturn('local.example');
+		$this->discovery->expects($this->never())->method('requestRemoteOcmEndpoint');
+
+		$response = $this->controller->acceptInvite(self::TOKEN, 'remote.example');
+
+		$this->assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
+		$this->assertSame('Could not accept invite, user data is incomplete.', $response->getData()['message']);
+	}
+
+	public function testAcceptInviteRejectsMalformedInviteAcceptedPayload(): void {
+		$client = $this->createMock(\OCP\Http\Client\IClient::class);
+		$provider = $this->createMock(\OCP\OCM\IOCMProvider::class);
+		$remoteResponse = $this->createMock(IResponse::class);
+		$remoteBody = json_encode([
+			'userID' => 'bob',
+		]);
+		$this->assertIsString($remoteBody);
+		$remoteResponse->method('getBody')->willReturn($remoteBody);
+
+		$this->httpClient->method('newClient')->willReturn($client);
+		$this->discovery->method('discover')->willReturn($provider);
+		$provider->method('hasCapability')->with('invites')->willReturn(true);
+		$this->discovery->method('requestRemoteOcmEndpoint')->willReturn($remoteResponse);
+		$this->invitesService->method('getProviderFQDN')->willReturn('local.example');
+		$this->invitesService->expects($this->never())->method('createNewContact');
+
+		$response = $this->controller->acceptInvite(self::TOKEN, 'remote.example');
+
+		$this->assertSame(Http::STATUS_BAD_GATEWAY, $response->getStatus());
+		$this->assertSame(
+			'Could not accept invite because the remote provider returned an invalid response.',
+			$response->getData()['message'],
+		);
+	}
+
+	public function testAcceptInviteRejectsInviteAcceptedPayloadWithEmptyEmail(): void {
+		$client = $this->createMock(\OCP\Http\Client\IClient::class);
+		$provider = $this->createMock(\OCP\OCM\IOCMProvider::class);
+		$remoteResponse = $this->createMock(IResponse::class);
+		$remoteBody = json_encode([
+			'userID' => 'bob',
+			'email' => '',
+			'name' => 'Bob',
+		]);
+		$this->assertIsString($remoteBody);
+		$remoteResponse->method('getBody')->willReturn($remoteBody);
+
+		$this->httpClient->method('newClient')->willReturn($client);
+		$this->discovery->method('discover')->willReturn($provider);
+		$provider->method('hasCapability')->with('invites')->willReturn(true);
+		$this->discovery->method('requestRemoteOcmEndpoint')->willReturn($remoteResponse);
+		$this->invitesService->method('getProviderFQDN')->willReturn('local.example');
+		$this->invitesService->expects($this->never())->method('createNewContact');
+
+		$response = $this->controller->acceptInvite(self::TOKEN, 'remote.example');
+
+		$this->assertSame(Http::STATUS_BAD_GATEWAY, $response->getStatus());
+		$this->assertSame(
+			'Could not accept invite because the remote provider returned an invalid response.',
+			$response->getData()['message'],
+		);
+	}
+
+	public function testDiscoverRejectsBlockedTargets(): void {
+		$response = $this->controller->discover('localhost');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('invalid base', $response->getData()['error']);
+	}
+
+	public function testDiscoverAllowsBlockedTargetsWhenSsrfGuardDisabled(): void {
+		$provider = $this->createMock(\OCP\OCM\ICapabilityAwareOCMProvider::class);
+		$provider->method('getInviteAcceptDialog')->willReturn('/index.php/apps/contacts/ocm/invite-accept-dialog');
+
+		$this->invitesService->expects($this->atLeastOnce())
+			->method('isSsrfGuardDisabled')
+			->willReturn(true);
+		$this->discovery->expects($this->once())
+			->method('discover')
+			->with('https://localhost')
+			->willReturn($provider);
+
+		$response = $this->controller->discover('localhost');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('https://localhost', $response->getData()['base']);
+	}
+
+	public function testDiscoverUsesFallbackDialogAndOmitsRawPayload(): void {
+		$provider = $this->createMock(\OCP\OCM\ICapabilityAwareOCMProvider::class);
+		$provider->method('getInviteAcceptDialog')->willReturn('');
+
+		$this->discovery->expects($this->once())
+			->method('discover')
+			->with('https://remote.example')
+			->willReturn($provider);
+		$this->wayfProvider->method('getInviteAcceptDialogPath')->willReturn('/index.php/apps/contacts/ocm/invite-accept-dialog');
+
+		$response = $this->controller->discover('remote.example');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$body = $response->getData();
+		$this->assertSame('https://remote.example', $body['base']);
+		$this->assertSame('remote.example', $body['providerDomain']);
+		$this->assertSame('https://remote.example/index.php/apps/contacts/ocm/invite-accept-dialog', $body['inviteAcceptDialogAbsolute']);
+		$this->assertArrayNotHasKey('raw', $body);
+	}
+
+	public function testWayfUsesIncomingProviderDomainWhenPresent(): void {
+		$this->request->expects($this->once())
+			->method('getParam')
+			->with('providerDomain', '')
+			->willReturn('sender.example');
+		$this->wayfProvider->expects($this->once())
+			->method('getMeshProviders')
+			->willReturn(['mesh' => []]);
+		$this->urlGenerator->expects($this->never())->method('getBaseUrl');
+		$this->initialState->expects($this->once())
+			->method('provideInitialState')
+			->with('wayf', $this->callback(static function (array $state): bool {
+				return $state['providerDomain'] === 'sender.example'
+					&& $state['token'] === self::TOKEN
+					&& isset($state['federations']);
+			}));
+
+		$response = $this->controller->wayf(self::TOKEN);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}
+
+	public function testWayfFallsBackToBaseHostWhenProviderDomainMissing(): void {
+		$this->request->expects($this->once())
+			->method('getParam')
+			->with('providerDomain', '')
+			->willReturn('');
+		$this->wayfProvider->expects($this->once())
+			->method('getMeshProviders')
+			->willReturn(['mesh' => []]);
+		$this->urlGenerator->expects($this->once())
+			->method('getBaseUrl')
+			->willReturn('https://receiver.example');
+		$this->initialState->expects($this->once())
+			->method('provideInitialState')
+			->with('wayf', $this->callback(static function (array $state): bool {
+				return $state['providerDomain'] === 'receiver.example'
+					&& $state['token'] === self::TOKEN
+					&& isset($state['federations']);
+			}));
+
+		$response = $this->controller->wayf(self::TOKEN);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}
+
+	public function testAcceptInviteRejectsInvalidProviderTarget(): void {
+		$response = $this->controller->acceptInvite(self::TOKEN, '127.0.0.1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	public function testSetOcmInviteBoolSettingReturnsForbiddenOnUnknownKey(): void {
+		$this->invitesService->expects($this->once())
+			->method('setOcmInviteBoolSetting')
+			->with('not_a_real_key', true)
+			->willReturn(false);
+
+		$response = $this->controller->setOcmInviteBoolSetting('not_a_real_key', true);
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}
+}

--- a/tests/unit/Controller/PageControllerTest.php
+++ b/tests/unit/Controller/PageControllerTest.php
@@ -9,6 +9,7 @@ namespace OCA\Contacts\Controller;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OC\App\CompareVersion;
+use OCA\Contacts\Service\FederatedInvitesService;
 use OCA\Contacts\Service\GroupSharingService;
 use OCA\Contacts\Service\SocialApiService;
 use OCP\App\IAppManager;
@@ -48,6 +49,7 @@ class PageControllerTest extends TestCase {
 	/** @var CompareVersion|MockObject */
 	private $compareVersion;
 
+	private FederatedInvitesService|MockObject $federatedInvitesService;
 	private GroupSharingService|MockObject $groupSharingService;
 
 	protected function setUp(): void {
@@ -61,10 +63,12 @@ class PageControllerTest extends TestCase {
 		$this->socialApi = $this->createMock(SocialApiService::class);
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->compareVersion = $this->createMock(CompareVersion::class);
+		$this->federatedInvitesService = $this->createMock(FederatedInvitesService::class);
 		$this->groupSharingService = $this->createMock(GroupSharingService::class);
 
 		$this->controller = new PageController(
 			$this->request,
+			$this->federatedInvitesService,
 			$this->config,
 			$this->initialStateService,
 			$this->languageFactory,

--- a/tests/unit/Controller/PageControllerTest.php
+++ b/tests/unit/Controller/PageControllerTest.php
@@ -10,6 +10,7 @@ namespace OCA\Contacts\Controller;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OC\App\CompareVersion;
 use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\Service\FederatedInvitesService;
 use OCA\Contacts\Service\GroupSharingService;
 use OCA\Contacts\Service\SocialApiService;
 use OCP\App\IAppManager;
@@ -50,6 +51,7 @@ class PageControllerTest extends TestCase {
 	/** @var CompareVersion|MockObject */
 	private $compareVersion;
 
+	private FederatedInvitesService|MockObject $federatedInvitesService;
 	private GroupSharingService|MockObject $groupSharingService;
 
 	protected function setUp(): void {
@@ -63,6 +65,7 @@ class PageControllerTest extends TestCase {
 		$this->socialApi = $this->createMock(SocialApiService::class);
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->compareVersion = $this->createMock(CompareVersion::class);
+		$this->federatedInvitesService = $this->createMock(FederatedInvitesService::class);
 		$this->groupSharingService = $this->createMock(GroupSharingService::class);
 
 		$this->controller = $this->buildController(new StaticServerVersion(Application::MAX_SERVER_VERSION_WITH_TEAM_MANAGEMENT));
@@ -71,6 +74,7 @@ class PageControllerTest extends TestCase {
 	private function buildController(ServerVersion $serverVersion): PageController {
 		return new PageController(
 			$this->request,
+			$this->federatedInvitesService,
 			$this->config,
 			$this->initialStateService,
 			$this->languageFactory,
@@ -82,7 +86,6 @@ class PageControllerTest extends TestCase {
 			$serverVersion,
 		);
 	}
-
 
 	public function testIndex() {
 		$user = $this->createMock(IUser::class);

--- a/tests/unit/Listener/FederatedInviteAcceptedListenerTest.php
+++ b/tests/unit/Listener/FederatedInviteAcceptedListenerTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Tests\Unit\Listener;
+
+use OCA\Contacts\Listener\FederatedInviteAcceptedListener;
+use OCA\Contacts\Service\FederatedInvitesService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\EventDispatcher\Event;
+use OCP\OCM\Events\OCMEndpointRequestEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class FederatedInviteAcceptedListenerTest extends TestCase {
+
+	private FederatedInvitesService&MockObject $federatedInvitesService;
+	private LoggerInterface&MockObject $logger;
+
+	private FederatedInviteAcceptedListener $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->federatedInvitesService = $this->createMock(FederatedInvitesService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->listener = new FederatedInviteAcceptedListener(
+			$this->federatedInvitesService,
+			$this->logger,
+		);
+	}
+
+	private function newEvent(string $capability = 'invite-accepted', ?array $payload = null): OCMEndpointRequestEvent {
+		return new OCMEndpointRequestEvent('POST', $capability, $payload);
+	}
+
+	public function testHandleIgnoresUnrelatedEvent(): void {
+		$this->federatedInvitesService->expects(self::never())->method('inviteAccepted');
+		$this->logger->expects(self::never())->method('error');
+
+		$this->listener->handle(new Event());
+	}
+
+	public function testHandleIgnoresUnrelatedCapability(): void {
+		$event = $this->newEvent('notifications', [
+			'token' => 'token-123',
+		]);
+
+		$this->federatedInvitesService->expects(self::never())->method('inviteAccepted');
+		$this->logger->expects(self::never())->method('error');
+
+		$this->listener->handle($event);
+
+		self::assertNull($event->getResponse());
+	}
+
+	public function testHandleDelegatesInviteAcceptedPayloadToService(): void {
+		$payload = [
+			'recipientProvider' => 'https://nextcloud2.docker',
+			'token' => 'token-123',
+			'userID' => 'michiel',
+			'email' => 'michiel@example.test',
+			'name' => 'Michiel',
+		];
+		$event = $this->newEvent(payload: $payload);
+		$response = new JSONResponse(['userID' => 'einstein'], Http::STATUS_OK);
+
+		$this->federatedInvitesService->expects(self::once())
+			->method('inviteAccepted')
+			->with(
+				'https://nextcloud2.docker',
+				'token-123',
+				'michiel',
+				'michiel@example.test',
+				'Michiel',
+			)
+			->willReturn($response);
+		$this->logger->expects(self::never())->method('error');
+
+		$this->listener->handle($event);
+
+		self::assertSame($response, $event->getResponse());
+	}
+
+	public function testHandleRejectsEmptyEmailBeforeCallingService(): void {
+		$payload = [
+			'recipientProvider' => 'https://nextcloud2.docker',
+			'token' => 'token-123',
+			'userID' => 'michiel',
+			'email' => '',
+			'name' => 'Michiel',
+		];
+		$event = $this->newEvent(payload: $payload);
+
+		$this->federatedInvitesService->expects(self::never())->method('inviteAccepted');
+		$this->logger->expects(self::once())
+			->method('error')
+			->with(
+				'Could not accept invite, user data is incomplete.',
+				self::callback(static function (array $context): bool {
+					return ($context['app'] ?? null) === 'contacts'
+						&& in_array('email', $context['payloadKeys'] ?? [], true);
+				}),
+			);
+
+		$this->listener->handle($event);
+
+		self::assertInstanceOf(JSONResponse::class, $event->getResponse());
+		self::assertSame(Http::STATUS_NOT_FOUND, $event->getResponse()?->getStatus());
+	}
+
+	public function testHandleRejectsMalformedPayloadBeforeCallingService(): void {
+		$payload = [
+			'recipientProvider' => 'https://nextcloud2.docker',
+			'token' => '',
+			'userID' => 'michiel',
+			'email' => 'michiel@example.test',
+			'name' => 'Michiel',
+		];
+		$event = $this->newEvent(payload: $payload);
+
+		$this->federatedInvitesService->expects(self::never())->method('inviteAccepted');
+		$this->logger->expects(self::once())
+			->method('error')
+			->with(
+				'Could not accept invite, user data is incomplete.',
+				self::callback(static function (array $context): bool {
+					return ($context['app'] ?? null) === 'contacts'
+						&& in_array('token', $context['payloadKeys'] ?? [], true);
+				}),
+			);
+
+		$this->listener->handle($event);
+
+		self::assertInstanceOf(JSONResponse::class, $event->getResponse());
+		self::assertSame(Http::STATUS_NOT_FOUND, $event->getResponse()?->getStatus());
+		self::assertSame(
+			'Could not accept invite, user data is incomplete.',
+			$event->getResponse()?->getData()['message'],
+		);
+	}
+}

--- a/tests/unit/Listener/OcmDiscoveryListenerTest.php
+++ b/tests/unit/Listener/OcmDiscoveryListenerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Tests\Unit\Listener;
+
+use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\ConfigLexicon as ContactsConfigLexicon;
+use OCA\Contacts\Listener\OcmDiscoveryListener;
+use OCA\Contacts\Service\FederatedInvitesService;
+use OCP\IAppConfig;
+use OCP\IURLGenerator;
+use OCP\OCM\Events\LocalOCMDiscoveryEvent;
+use OCP\OCM\Events\ResourceTypeRegisterEvent;
+use OCP\OCM\IOCMProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class OcmDiscoveryListenerTest extends TestCase {
+	private IAppConfig&MockObject $appConfig;
+	private IURLGenerator&MockObject $urlGenerator;
+	private LoggerInterface&MockObject $logger;
+
+	private OcmDiscoveryListener $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->listener = new OcmDiscoveryListener(
+			$this->appConfig,
+			$this->urlGenerator,
+			$this->logger,
+		);
+	}
+
+	public function testHandleReturnsEarlyWhenInvitesDisabled(): void {
+		$provider = $this->createMock(IOCMProvider::class);
+
+		$this->appConfig->expects($this->once())
+			->method('getValueBool')
+			->with(Application::APP_ID, ContactsConfigLexicon::OCM_INVITES_ENABLED)
+			->willReturn(false);
+		$this->appConfig->expects($this->never())->method('getValueString');
+		$this->urlGenerator->expects($this->never())->method('linkToRouteAbsolute');
+		$provider->expects($this->never())->method('setCapabilities');
+		$provider->expects($this->never())->method('setInviteAcceptDialog');
+		$this->logger->expects($this->never())->method('warning');
+
+		$this->listener->handle($this->newOcmDiscoveryEvent($provider));
+	}
+
+	public function testHandleRegistersInviteCapabilityAndDialogRoute(): void {
+		$provider = $this->createMock(IOCMProvider::class);
+
+		$this->appConfig->expects($this->once())
+			->method('getValueBool')
+			->with(Application::APP_ID, ContactsConfigLexicon::OCM_INVITES_ENABLED)
+			->willReturn(true);
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRouteAbsolute')
+			->with(FederatedInvitesService::OCM_INVITE_ACCEPT_DIALOG_ROUTE_NAME)
+			->willReturn('https://cloud.example/ocm/invite-dialog');
+		$provider->expects($this->once())
+			->method('setCapabilities')
+			->with(['invite-accepted'])
+			->willReturnSelf();
+		$provider->expects($this->once())
+			->method('setInviteAcceptDialog')
+			->with('https://cloud.example/ocm/invite-dialog')
+			->willReturnSelf();
+		$this->logger->expects($this->never())->method('warning');
+
+		$this->listener->handle($this->newOcmDiscoveryEvent($provider));
+	}
+
+	public function testHandleWarnsWhenDialogRouteResolutionFails(): void {
+		$provider = $this->createMock(IOCMProvider::class);
+
+		$exception = new \RuntimeException('route boom');
+		$this->appConfig->expects($this->once())
+			->method('getValueBool')
+			->with(Application::APP_ID, ContactsConfigLexicon::OCM_INVITES_ENABLED)
+			->willReturn(true);
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRouteAbsolute')
+			->with(FederatedInvitesService::OCM_INVITE_ACCEPT_DIALOG_ROUTE_NAME)
+			->willThrowException($exception);
+		$provider->expects($this->once())
+			->method('setCapabilities')
+			->with(['invite-accepted'])
+			->willReturnSelf();
+		$provider->expects($this->never())->method('setInviteAcceptDialog');
+
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with(
+				$this->stringContains('route cannot be resolved'),
+				$this->callback(static function (array $context) use ($exception): bool {
+					return ($context['app'] ?? null) === Application::APP_ID
+						&& ($context['route'] ?? null) === FederatedInvitesService::OCM_INVITE_ACCEPT_DIALOG_ROUTE_NAME
+						&& ($context['exception'] ?? null) === $exception;
+				}),
+			);
+
+		$this->listener->handle($this->newOcmDiscoveryEvent($provider));
+	}
+
+	public function testHandleDeprecatedResourceTypeEventDoesNotMutateProvider(): void {
+		$provider = $this->createMock(IOCMProvider::class);
+
+		$this->appConfig->expects($this->once())
+			->method('getValueBool')
+			->with(Application::APP_ID, ContactsConfigLexicon::OCM_INVITES_ENABLED)
+			->willReturn(true);
+		$this->urlGenerator->expects($this->never())->method('linkToRouteAbsolute');
+		$provider->expects($this->never())->method('setCapabilities');
+		$provider->expects($this->never())->method('setInviteAcceptDialog');
+		$this->logger->expects($this->never())->method('warning');
+
+		$this->listener->handle(new ResourceTypeRegisterEvent($provider));
+	}
+
+	private function newOcmDiscoveryEvent(IOCMProvider $provider): LocalOCMDiscoveryEvent {
+		return new LocalOCMDiscoveryEvent($provider);
+	}
+}

--- a/tests/unit/Service/FederatedInvitesServiceTest.php
+++ b/tests/unit/Service/FederatedInvitesServiceTest.php
@@ -1,0 +1,410 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Contacts\Tests;
+
+use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\Db\FederatedInvite;
+use OCA\Contacts\Db\FederatedInviteMapper;
+use OCA\Contacts\Exception\ContactAlreadyExistsException;
+use OCA\Contacts\Service\FederatedInvitesService;
+use OCA\Contacts\Service\SocialApiService;
+use OCA\DAV\CardDAV\CardDavBackend;
+use OCA\FederatedFileSharing\AddressHandler;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class FederatedInvitesServiceTest extends TestCase {
+
+	private AddressHandler&MockObject $addressHandler;
+	private IAppConfig&MockObject $appConfig;
+	private ITimeFactory&MockObject $timeFactory;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IUserManager&MockObject $userManager;
+	private IUserSession&MockObject $userSession;
+	private FederatedInviteMapper&MockObject $federatedInviteMapper;
+	private LoggerInterface&MockObject $logger;
+	private SocialApiService&MockObject $socialApiService;
+
+	private FederatedInvitesService $federatedInvitesService;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->addressHandler = $this->createMock(AddressHandler::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->federatedInviteMapper = $this->createMock(FederatedInviteMapper::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->socialApiService = $this->createMock(SocialApiService::class);
+
+		$this->federatedInvitesService = new FederatedInvitesService(
+			$this->addressHandler,
+			$this->appConfig,
+			$this->timeFactory,
+			$this->urlGenerator,
+			$this->userManager,
+			$this->userSession,
+			$this->federatedInviteMapper,
+			$this->logger,
+			$this->socialApiService,
+		);
+	}
+
+	private function buildInvitation(
+		string $token = 'token-123',
+		string $userId = 'sender',
+		bool $accepted = false,
+		?int $expiredAt = null,
+	): FederatedInvite {
+		$invitation = new FederatedInvite();
+		$invitation->setToken($token);
+		$invitation->setUserId($userId);
+		$invitation->setAccepted($accepted);
+		$invitation->setExpiredAt($expiredAt);
+		return $invitation;
+	}
+
+	private function buildUser(string $uid = 'sender', ?string $email = 'sender@example.org', string $name = 'Sender User'): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$user->method('getEMailAddress')->willReturn($email);
+		$user->method('getDisplayName')->willReturn($name);
+		return $user;
+	}
+
+	public function testSetOcmInviteBoolSettingWritesAllowedKey(): void {
+		$this->appConfig->expects(self::once())
+			->method('setValueBool')
+			->with('contacts', 'ocm_invites_optional_mail', true);
+
+		$result = $this->federatedInvitesService->setOcmInviteBoolSetting('ocm_invites_optional_mail', true);
+
+		$this->assertTrue($result);
+	}
+
+	public function testSetOcmInviteBoolSettingRejectsUnknownKey(): void {
+		$this->appConfig->expects(self::never())
+			->method('setValueBool');
+
+		$result = $this->federatedInvitesService->setOcmInviteBoolSetting('ocm_invites_arbitrary_unknown_key', true);
+
+		$this->assertFalse($result);
+	}
+
+	public function testIsSsrfGuardDisabledReadsConfigToggle(): void {
+		$this->appConfig->expects(self::once())
+			->method('getValueBool')
+			->with(Application::APP_ID, 'ocm_invites_disable_ssrf_guard')
+			->willReturn(true);
+
+		$this->assertTrue($this->federatedInvitesService->isSsrfGuardDisabled());
+	}
+
+	public function testCreateNewContactUsesReturnedAddressBookUriInContactRef(): void {
+		$this->socialApiService->expects(self::once())
+			->method('createContact')
+			->with('remote@example.org', 'remote@example.org', 'Remote User', 'sender')
+			->willReturn([
+				'UID' => 'new-contact-uid',
+				'ADDRESSBOOK_URI' => 'work',
+			]);
+
+		$result = $this->federatedInvitesService->createNewContact(
+			'remote@example.org',
+			'remote@example.org',
+			'Remote User',
+			'sender',
+		);
+
+		$this->assertSame('new-contact-uid~work', $result);
+	}
+
+	public function testCreateNewContactFallsBackToPersonalAddressBookUri(): void {
+		$this->socialApiService->expects(self::once())
+			->method('createContact')
+			->with('remote@example.org', 'remote@example.org', 'Remote User', 'sender')
+			->willReturn([
+				'UID' => 'new-contact-uid',
+			]);
+
+		$result = $this->federatedInvitesService->createNewContact(
+			'remote@example.org',
+			'remote@example.org',
+			'Remote User',
+			'sender',
+		);
+
+		$this->assertSame(
+			'new-contact-uid~' . CardDavBackend::PERSONAL_ADDRESSBOOK_URI,
+			$result,
+		);
+	}
+
+	public function testSetOcmInviteBoolSettingCoversEachAllowedKey(): void {
+		$keys = FederatedInvitesService::OCM_INVITES_BOOL_KEYS;
+		$this->assertNotEmpty(
+			$keys,
+			'OCM_INVITES_BOOL_KEYS must not be empty; otherwise the allowlist coverage is vacuous.',
+		);
+
+		$expectedCalls = [];
+		foreach ($keys as $key) {
+			$expectedCalls[] = [Application::APP_ID, $key, false];
+		}
+
+		$invocation = $this->exactly(count($keys));
+		$this->appConfig->expects($invocation)
+			->method('setValueBool')
+			->willReturnCallback(function (string $appId, string $configKey, bool $value) use (&$expectedCalls, $invocation): bool {
+				$index = $invocation->numberOfInvocations() - 1;
+				$this->assertSame($expectedCalls[$index][0], $appId);
+				$this->assertSame($expectedCalls[$index][1], $configKey);
+				$this->assertSame($expectedCalls[$index][2], $value);
+				return true;
+			});
+
+		foreach ($keys as $key) {
+			$this->assertTrue(
+				$this->federatedInvitesService->setOcmInviteBoolSetting($key, false),
+				"Allowed key '$key' should be writable",
+			);
+		}
+	}
+
+	public function testInviteAcceptedRejectsEmptyToken(): void {
+		$response = $this->federatedInvitesService->inviteAccepted(
+			'https://nextcloud2.docker',
+			'',
+			'michiel',
+			'michiel@example.test',
+			'Michiel',
+		);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('Invalid or non existing token', $response->getData()['message']);
+	}
+
+	public function testInviteAcceptedRejectsMissingInvite(): void {
+		$this->federatedInviteMapper->expects(self::once())
+			->method('findByToken')
+			->with('token-123')
+			->willThrowException(new DoesNotExistException('not found'));
+
+		$response = $this->federatedInvitesService->inviteAccepted(
+			'https://nextcloud2.docker',
+			'token-123',
+			'michiel',
+			'michiel@example.test',
+			'Michiel',
+		);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('Invalid or non existing token', $response->getData()['message']);
+	}
+
+	public function testInviteAcceptedRejectsAlreadyAcceptedInvite(): void {
+		$invitation = $this->buildInvitation(accepted: true);
+		$this->federatedInviteMapper->expects(self::once())
+			->method('findByToken')
+			->with('token-123')
+			->willReturn($invitation);
+
+		$response = $this->federatedInvitesService->inviteAccepted(
+			'https://nextcloud2.docker',
+			'token-123',
+			'michiel',
+			'michiel@example.test',
+			'Michiel',
+		);
+
+		$this->assertSame(Http::STATUS_CONFLICT, $response->getStatus());
+		$this->assertSame('Invite already accepted', $response->getData()['message']);
+	}
+
+	public function testInviteAcceptedRejectsMissingRecipientEmail(): void {
+		$this->federatedInviteMapper->expects(self::never())->method('findByToken');
+
+		$response = $this->federatedInvitesService->inviteAccepted(
+			'https://nextcloud2.docker',
+			'token-123',
+			'michiel',
+			'',
+			'Michiel',
+		);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('Could not accept invite, user data is incomplete.', $response->getData()['message']);
+	}
+
+	public function testInviteAcceptedRejectsMissingSenderEmail(): void {
+		$invitation = $this->buildInvitation();
+		$this->federatedInviteMapper->expects(self::once())
+			->method('findByToken')
+			->with('token-123')
+			->willReturn($invitation);
+		$this->timeFactory->expects(self::once())
+			->method('getTime')
+			->willReturn(1_800_000_000);
+		$this->userManager->expects(self::once())
+			->method('get')
+			->with('sender')
+			->willReturn($this->buildUser(email: null));
+
+		$response = $this->federatedInvitesService->inviteAccepted(
+			'https://nextcloud2.docker',
+			'token-123',
+			'michiel',
+			'michiel@example.test',
+			'Michiel',
+		);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('Invalid or non existing token', $response->getData()['message']);
+	}
+
+	public function testInviteAcceptedMarksInviteAcceptedAndCreatesSenderSideContact(): void {
+		$invitation = $this->buildInvitation();
+		$this->federatedInviteMapper->expects(self::once())
+			->method('findByToken')
+			->with('token-123')
+			->willReturn($invitation);
+		$this->timeFactory->expects(self::once())
+			->method('getTime')
+			->willReturn(1_800_000_000);
+		$this->userManager->expects(self::once())
+			->method('get')
+			->with('sender')
+			->willReturn($this->buildUser());
+		$this->federatedInviteMapper->expects(self::once())
+			->method('update')
+			->with(self::callback(static function (FederatedInvite $updated): bool {
+				return $updated->isAccepted() === true
+					&& $updated->getAcceptedAt() === 1_800_000_000
+					&& $updated->getRecipientProvider() === 'https://nextcloud2.docker'
+					&& $updated->getRecipientUserId() === 'michiel'
+					&& $updated->getRecipientName() === 'Michiel'
+					&& $updated->getRecipientEmail() === 'michiel@example.test';
+			}))
+			->willReturnCallback(static fn (FederatedInvite $updated): FederatedInvite => $updated);
+		$this->addressHandler->expects(self::once())
+			->method('removeProtocolFromUrl')
+			->with('https://nextcloud2.docker')
+			->willReturn('nextcloud2.docker');
+		$this->socialApiService->expects(self::once())
+			->method('createContact')
+			->with('michiel@nextcloud2.docker', 'michiel@example.test', 'Michiel', 'sender')
+			->willReturn([
+				'UID' => 'created-uid',
+				'ADDRESSBOOK_URI' => 'work',
+			]);
+
+		$response = $this->federatedInvitesService->inviteAccepted(
+			'https://nextcloud2.docker',
+			'token-123',
+			'michiel',
+			'michiel@example.test',
+			'Michiel',
+		);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([
+			'userID' => 'sender',
+			'email' => 'sender@example.org',
+			'name' => 'Sender User',
+		], $response->getData());
+	}
+
+	public function testInviteAcceptedReturnsInternalServerErrorWhenSenderContactCreationFails(): void {
+		$invitation = $this->buildInvitation();
+		$this->federatedInviteMapper->expects(self::once())
+			->method('findByToken')
+			->with('token-123')
+			->willReturn($invitation);
+		$this->timeFactory->expects(self::once())
+			->method('getTime')
+			->willReturn(1_800_000_000);
+		$this->userManager->expects(self::once())
+			->method('get')
+			->with('sender')
+			->willReturn($this->buildUser());
+		$this->addressHandler->expects(self::once())
+			->method('removeProtocolFromUrl')
+			->with('https://nextcloud2.docker')
+			->willReturn('nextcloud2.docker');
+		$this->socialApiService->expects(self::once())
+			->method('createContact')
+			->with('michiel@nextcloud2.docker', 'michiel@example.test', 'Michiel', 'sender')
+			->willReturn(null);
+		$this->federatedInviteMapper->expects(self::never())->method('update');
+
+		$response = $this->federatedInvitesService->inviteAccepted(
+			'https://nextcloud2.docker',
+			'token-123',
+			'michiel',
+			'michiel@example.test',
+			'Michiel',
+		);
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame('Could not create sender-side contact after invite acceptance.', $response->getData()['message']);
+	}
+
+	public function testInviteAcceptedReturnsSuccessWhenContactAlreadyExists(): void {
+		$invitation = $this->buildInvitation();
+		$this->federatedInviteMapper->expects(self::once())
+			->method('findByToken')
+			->with('token-123')
+			->willReturn($invitation);
+		$this->timeFactory->expects(self::once())
+			->method('getTime')
+			->willReturn(1_800_000_000);
+		$this->userManager->expects(self::once())
+			->method('get')
+			->with('sender')
+			->willReturn($this->buildUser());
+		$this->federatedInviteMapper->expects(self::once())
+			->method('update')
+			->willReturnCallback(static fn (FederatedInvite $updated): FederatedInvite => $updated);
+		$this->addressHandler->expects(self::once())
+			->method('removeProtocolFromUrl')
+			->with('https://nextcloud2.docker')
+			->willReturn('nextcloud2.docker');
+		$this->socialApiService->expects(self::once())
+			->method('createContact')
+			->willThrowException(new ContactAlreadyExistsException('exists'));
+
+		$response = $this->federatedInvitesService->inviteAccepted(
+			'https://nextcloud2.docker',
+			'token-123',
+			'michiel',
+			'michiel@example.test',
+			'Michiel',
+		);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([
+			'userID' => 'sender',
+			'email' => 'sender@example.org',
+			'name' => 'Sender User',
+		], $response->getData());
+	}
+}

--- a/tests/unit/Service/ImageResizerTest.php
+++ b/tests/unit/Service/ImageResizerTest.php
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Contacts\Service;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;

--- a/tests/unit/Service/Social/DiasporaProviderTest.php
+++ b/tests/unit/Service/Social/DiasporaProviderTest.php
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Contacts\Service\Social;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;

--- a/tests/unit/Service/Social/FacebookProviderTest.php
+++ b/tests/unit/Service/Social/FacebookProviderTest.php
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Contacts\Service\Social;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;

--- a/tests/unit/Service/Social/GravatarProviderTest.php
+++ b/tests/unit/Service/Social/GravatarProviderTest.php
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Contacts\Service\Social;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;

--- a/tests/unit/Service/Social/InstagramProviderTest.php
+++ b/tests/unit/Service/Social/InstagramProviderTest.php
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Contacts\Service\Social;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
@@ -140,7 +139,6 @@ class InstagramProviderTest extends TestCase {
 					return $this->response;
 				});
 		}
-
 
 		$result = $this->provider->getImageUrls($contact);
 		$this->assertEquals($imgs, $result);

--- a/tests/unit/Service/Social/MastodonProviderTest.php
+++ b/tests/unit/Service/Social/MastodonProviderTest.php
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Contacts\Service\Social;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;

--- a/tests/unit/Service/Social/TelegramProviderTest.php
+++ b/tests/unit/Service/Social/TelegramProviderTest.php
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Contacts\Service\Social;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
@@ -153,7 +152,6 @@ class TelegramProviderTest extends TestCase {
 					return $this->response;
 				});
 		}
-
 
 		$result = $this->provider->getImageUrls($contact);
 		$this->assertEquals($imgs, $result);

--- a/tests/unit/Service/Social/TumblrProviderTest.php
+++ b/tests/unit/Service/Social/TumblrProviderTest.php
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Contacts\Service\Social;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;

--- a/tests/unit/Service/Social/XingProviderTest.php
+++ b/tests/unit/Service/Social/XingProviderTest.php
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Contacts\Service\Social;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;

--- a/tests/unit/Service/SocialApiServiceTest.php
+++ b/tests/unit/Service/SocialApiServiceTest.php
@@ -12,6 +12,7 @@ use ChristophWurst\Nextcloud\Testing\TestCase;
 
 use OCA\Contacts\Service\Social\CompositeSocialProvider;
 use OCA\Contacts\Service\Social\ISocialProvider;
+use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\ContactsManager;
 
 use OCP\AppFramework\Http;
@@ -23,11 +24,12 @@ use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
 use OCP\IAddressBook;
 use OCP\IConfig;
-use OCP\IL10N;
+use OCP\ICreateContactFromString;
 use OCP\IURLGenerator;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 class SocialApiServiceTest extends TestCase {
 	private SocialApiService $service;
@@ -40,14 +42,14 @@ class SocialApiServiceTest extends TestCase {
 	private $config;
 	/** @var IClientService&MockObject */
 	private $clientService;
-	/** @var IL10N&MockObject */
-	private $l10n;
 	/** @var IURLGenerator&MockObject */
 	private $urlGen;
 	/** @var ITimeFactory&MockObject */
 	private $timeFactory;
 	/** @var ImageResizer&MockObject */
 	private $imageResizer;
+	/** @var LoggerInterface&MockObject */
+	private $logger;
 	/** @var ContainerInterface&MockObject */
 	private $container;
 
@@ -76,9 +78,6 @@ class SocialApiServiceTest extends TestCase {
 		$addressbookEmpty
 			->method('search')
 			->willReturn(null);
-		$addressbookEmpty
-			->method('getPermissions')
-			->willReturn(Constants::PERMISSION_UPDATE);
 
 		$addressbook = $this->createMock(IAddressBook::class);
 		$addressbook
@@ -87,9 +86,6 @@ class SocialApiServiceTest extends TestCase {
 		$addressbook
 			->method('search')
 			->willReturn([$contact]);
-		$addressbook
-			->method('getPermissions')
-			->willReturn(Constants::PERMISSION_UPDATE);
 
 		return [
 			'no address book found' => [null, [], '', '', Http::STATUS_BAD_REQUEST],
@@ -117,10 +113,10 @@ class SocialApiServiceTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->socialProvider = $this->createMock(CompositeSocialProvider::class);
 		$this->clientService = $this->createMock(IClientService::class);
-		$this->l10n = $this->createMock(IL10N::class);
 		$this->urlGen = $this->createMock(IURLGenerator::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->imageResizer = $this->createMock(ImageResizer::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->container = $this->createMock(ContainerInterface::class);
 		$this->container
 			->method('get')
@@ -131,10 +127,10 @@ class SocialApiServiceTest extends TestCase {
 			$this->manager,
 			$this->config,
 			$this->clientService,
-			$this->l10n,
 			$this->urlGen,
 			$this->timeFactory,
 			$this->imageResizer,
+			$this->logger,
 		);
 	}
 
@@ -258,9 +254,6 @@ class SocialApiServiceTest extends TestCase {
 		$addressbook
 			->method('search')
 			->willReturn([$contact]);
-		$addressbook
-			->method('getPermissions')
-			->willReturn(Constants::PERMISSION_UPDATE);
 
 		$this->manager
 			->method('getUserAddressBooks')
@@ -339,9 +332,6 @@ class SocialApiServiceTest extends TestCase {
 		$addressbook
 			->method('search')
 			->willReturn([$contact]);
-		$addressbook
-			->method('getPermissions')
-			->willReturn(Constants::PERMISSION_UPDATE);
 
 		$this->manager
 			->method('getUserAddressBooks')
@@ -394,6 +384,70 @@ class SocialApiServiceTest extends TestCase {
 		$this->assertEquals(Http::STATUS_OK, $result->getStatus());
 	}
 
+	public function testUpdateContactAcceptsContentTypeWithParameters() {
+		$network = 'mastodon';
+		$body = 'the body';
+		$imageType = 'image/png';
+		$addressBookId = 'contacts';
+		$contactId = '3225c0d5-1bd2-43e5-a08c-4e65eaa406b0';
+		$contact = [
+			'URI' => $contactId,
+			'VERSION' => '4.0'
+		];
+
+		$this->config
+			->method('getAppValue')
+			->willReturn('yes');
+
+		$provider = $this->createMock(ISocialProvider::class);
+		$provider->method('supportsContact')->willReturn(true);
+		$provider->method('getImageUrls')->willReturn(['https://url1.com/an-url']);
+
+		$addressbook = $this->createMock(IAddressBook::class);
+		$addressbook->method('getUri')->willReturn('contacts');
+		$addressbook->method('search')->willReturn([$contact]);
+
+		$this->manager->method('getUserAddressBooks')->willReturn([$addressbook]);
+		$this->socialProvider->method('getSocialConnectors')->willReturn([$provider]);
+		$this->socialProvider->method('getSocialConnector')->willReturn($provider);
+
+		$response = $this->createMock(IResponse::class);
+		$response->method('getBody')->willReturn($body);
+		$response->method('getHeader')->willReturn($imageType);
+		$client = $this->createMock(IClient::class);
+		$client->method('get')->willReturn($response);
+		$this->clientService->method('newClient')->willReturn($client);
+		$this->imageResizer->expects($this->once())->method('resizeImage')->willReturn($body);
+		$addressbook->expects($this->once())->method('createOrUpdate');
+
+		$result = $this->service->updateContact($addressBookId, $contactId, $network);
+
+		$this->assertEquals(Http::STATUS_OK, $result->getStatus());
+	}
+
+	public function testUpdateContactWithUnknownNetworkReturnsBadRequest() {
+		$addressBookId = 'contacts';
+		$contactId = '3225c0d5-1bd2-43e5-a08c-4e65eaa406b0';
+		$contact = [
+			'URI' => $contactId,
+			'VERSION' => '4.0'
+		];
+		$addressbook = $this->createMock(IAddressBook::class);
+		$addressbook->method('getUri')->willReturn('contacts');
+		$addressbook->method('search')->willReturn([$contact]);
+
+		$this->config
+			->method('getAppValue')
+			->willReturn('yes');
+		$this->manager->method('getUserAddressBooks')->willReturn([$addressbook]);
+		$this->socialProvider->method('getSocialConnectors')->willReturn([]);
+		$this->socialProvider->expects($this->once())->method('getSocialConnector')->with('unknown')->willReturn(null);
+
+		$result = $this->service->updateContact($addressBookId, $contactId, 'unknown');
+
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $result->getStatus());
+	}
+
 	public function testUpdateContactWithUnallowedMimeVersion4() {
 		$network = 'mastodon';
 		$body = 'the body';
@@ -420,9 +474,6 @@ class SocialApiServiceTest extends TestCase {
 		$addressbook
 			->method('search')
 			->willReturn([$contact]);
-		$addressbook
-			->method('getPermissions')
-			->willReturn(Constants::PERMISSION_UPDATE);
 
 		$this->manager
 			->method('getUserAddressBooks')
@@ -517,17 +568,9 @@ class SocialApiServiceTest extends TestCase {
 		$addressbook1
 			->method('search')
 			->will($this->returnValueMap($searchMap1));
-		$addressbook1
-			->method('getPermissions')
-			->willReturn(Constants::PERMISSION_UPDATE);
-
 		$addressbook2
 			->method('search')
 			->will($this->returnValueMap($searchMap2));
-		$addressbook2
-			->method('getPermissions')
-			->willReturn(Constants::PERMISSION_UPDATE);
-
 		$this->manager
 			->method('getUserAddressBooks')
 			->willReturn([$addressbook1, $addressbook2]);
@@ -697,5 +740,220 @@ class SocialApiServiceTest extends TestCase {
 		// invalid addressbookId:
 		$result = $this->service->existsContact('11111111-1111-1111-1111-111111111111', 'not-existing', 'admin');
 		$this->assertEquals(false, $result);
+	}
+
+	public function testCreateContactPrefersPersonalAddressBook(): void {
+		$cloudId = 'mahdi@nextcloud2.docker';
+		$email = 'mahdi@example.org';
+		$name = 'Mahdi';
+		$persisted = ['UID' => 'new-uid'];
+
+		$workBook = $this->createMock(ICreateContactFromString::class);
+		$workBook->method('getUri')->willReturn('work');
+		$workBook->method('isShared')->willReturn(false);
+		$workBook->method('getPermissions')->willReturn(Constants::PERMISSION_CREATE);
+		$workBook->method('getKey')->willReturn('work-key');
+
+		$personalBook = $this->createMock(ICreateContactFromString::class);
+		$personalBook->method('getUri')->willReturn(CardDavBackend::PERSONAL_ADDRESSBOOK_URI);
+		$personalBook->method('getKey')->willReturn('personal-key');
+
+		$this->manager->expects($this->once())
+			->method('search')
+			->with($cloudId, ['CLOUD'])
+			->willReturn([]);
+		$this->manager->expects($this->once())
+			->method('getUserAddressBooks')
+			->willReturn([$workBook, $personalBook]);
+		$this->manager->expects($this->once())
+			->method('createOrUpdate')
+			->with(
+				['FN' => $name, 'EMAIL' => $email, 'CLOUD' => $cloudId],
+				'personal-key',
+			)
+			->willReturn($persisted);
+
+		$result = $this->service->createContact($cloudId, $email, $name, 'mahdi');
+		$this->assertNotNull($result);
+		$this->assertSame('new-uid', $result['UID']);
+		$this->assertSame(CardDavBackend::PERSONAL_ADDRESSBOOK_URI, $result['ADDRESSBOOK_URI']);
+	}
+
+	public function testCreateContactFallsBackToWritableOwnedAddressBook(): void {
+		$cloudId = 'mahdi@nextcloud2.docker';
+		$email = 'mahdi@example.org';
+		$name = 'Mahdi';
+		$persisted = ['UID' => 'new-uid'];
+
+		$sharedBook = $this->createMock(IAddressBook::class);
+		$sharedBook->method('getUri')->willReturn('shared');
+		$sharedBook->method('isShared')->willReturn(true);
+		$sharedBook->method('getPermissions')->willReturn(Constants::PERMISSION_CREATE);
+
+		$readOnlyBook = $this->createMock(IAddressBook::class);
+		$readOnlyBook->method('getUri')->willReturn('readonly');
+		$readOnlyBook->method('isShared')->willReturn(false);
+		$readOnlyBook->method('getPermissions')->willReturn(0);
+
+		$writableBook = $this->createMock(ICreateContactFromString::class);
+		$writableBook->method('getUri')->willReturn('team');
+		$writableBook->method('isShared')->willReturn(false);
+		$writableBook->method('getPermissions')->willReturn(Constants::PERMISSION_CREATE);
+		$writableBook->method('getKey')->willReturn('team-key');
+
+		$this->manager->expects($this->once())
+			->method('search')
+			->with($cloudId, ['CLOUD'])
+			->willReturn([]);
+		$this->manager->expects($this->once())
+			->method('getUserAddressBooks')
+			->willReturn([$sharedBook, $readOnlyBook, $writableBook]);
+		$this->manager->expects($this->once())
+			->method('createOrUpdate')
+			->with(
+				['FN' => $name, 'EMAIL' => $email, 'CLOUD' => $cloudId],
+				'team-key',
+			)
+			->willReturn($persisted);
+
+		$result = $this->service->createContact($cloudId, $email, $name, 'mahdi');
+		$this->assertNotNull($result);
+		$this->assertSame('team', $result['ADDRESSBOOK_URI']);
+	}
+
+	public function testCreateContactReturnsNullWhenNoSuitableAddressBook(): void {
+		$cloudId = 'mahdi@nextcloud2.docker';
+
+		$sharedBook = $this->createMock(IAddressBook::class);
+		$sharedBook->method('getUri')->willReturn('shared');
+		$sharedBook->method('isShared')->willReturn(true);
+		$sharedBook->method('getPermissions')->willReturn(Constants::PERMISSION_CREATE);
+
+		$readOnlyBook = $this->createMock(IAddressBook::class);
+		$readOnlyBook->method('getUri')->willReturn('readonly');
+		$readOnlyBook->method('isShared')->willReturn(false);
+		$readOnlyBook->method('getPermissions')->willReturn(0);
+
+		$this->manager->expects($this->once())
+			->method('search')
+			->with($cloudId, ['CLOUD'])
+			->willReturn([]);
+		$this->manager->expects($this->once())
+			->method('getUserAddressBooks')
+			->willReturn([$sharedBook, $readOnlyBook]);
+		$this->manager->expects($this->never())
+			->method('createOrUpdate');
+		$this->logger->expects($this->once())
+			->method('error')
+			->with($this->stringContains('No suitable address book found'), $this->anything());
+
+		$result = $this->service->createContact($cloudId, 'mahdi@example.org', 'Mahdi', 'mahdi');
+		$this->assertNull($result);
+	}
+
+	public function testCreateFederatedContactReturnsNullWhenContactExists(): void {
+		$cloudId = 'mahdi@nextcloud2.docker';
+		$existingContact = ['URI' => 'existing-contact-uri', 'CLOUD' => $cloudId];
+
+		$this->manager
+			->expects($this->once())
+			->method('search')
+			->with($cloudId, ['CLOUD'])
+			->willReturn([$existingContact]);
+
+		$this->manager
+			->expects($this->never())
+			->method('getUserAddressBooks');
+		$this->manager
+			->expects($this->never())
+			->method('createOrUpdate');
+
+		$result = $this->service->createFederatedContact($cloudId, 'mahdi@example.org', 'Mahdi', 'mahdi');
+		$this->assertNull($result);
+	}
+
+	public function testCreateFederatedContactReturnsNullWhenNoContactsAddressBook(): void {
+		$cloudId = 'mahdi@nextcloud2.docker';
+
+		$otherBook = $this->createMock(IAddressBook::class);
+		$otherBook->method('getUri')->willReturn('shared-with-me');
+		$otherBook->method('isShared')->willReturn(true);
+
+		$this->manager
+			->expects($this->once())
+			->method('search')
+			->with($cloudId, ['CLOUD'])
+			->willReturn([]);
+		$this->manager
+			->expects($this->once())
+			->method('getUserAddressBooks')
+			->willReturn([$otherBook]);
+		$this->manager
+			->expects($this->never())
+			->method('createOrUpdate');
+
+		$this->logger
+			->expects($this->once())
+			->method('error')
+			->with($this->stringContains('No suitable address book found'), $this->anything());
+
+		$result = $this->service->createFederatedContact($cloudId, 'mahdi@example.org', 'Mahdi', 'mahdi');
+		$this->assertNull($result);
+	}
+
+	public function testCreateFederatedContactPersistsToContactsAddressBook(): void {
+		$cloudId = 'mahdi@nextcloud2.docker';
+		$email = 'mahdi@example.org';
+		$name = 'Mahdi';
+		$bookKey = 'addressbookid-42';
+		$persisted = ['URI' => 'new-uri', 'FN' => $name, 'EMAIL' => $email, 'CLOUD' => $cloudId];
+
+		$contactsBook = $this->createMock(ICreateContactFromString::class);
+		$contactsBook->method('getUri')->willReturn('contacts');
+		$contactsBook->method('isShared')->willReturn(false);
+		$contactsBook->method('getPermissions')->willReturn(Constants::PERMISSION_CREATE);
+		$contactsBook->method('getKey')->willReturn($bookKey);
+
+		$otherBook = $this->createMock(IAddressBook::class);
+		$otherBook->method('getUri')->willReturn('work');
+
+		$this->manager
+			->expects($this->once())
+			->method('search')
+			->with($cloudId, ['CLOUD'])
+			->willReturn([]);
+		$this->manager
+			->expects($this->once())
+			->method('getUserAddressBooks')
+			->willReturn([$otherBook, $contactsBook]);
+		$this->manager
+			->expects($this->once())
+			->method('createOrUpdate')
+			->with(
+				['FN' => $name, 'EMAIL' => $email, 'CLOUD' => $cloudId],
+				$bookKey,
+			)
+			->willReturn($persisted);
+
+		$result = $this->service->createFederatedContact($cloudId, $email, $name, 'mahdi');
+		$this->assertSame($persisted, $result);
+	}
+
+	public function testCreateFederatedContactSwallowsExceptionsAndReturnsNull(): void {
+		$cloudId = 'mahdi@nextcloud2.docker';
+
+		$this->manager
+			->expects($this->once())
+			->method('search')
+			->with($cloudId, ['CLOUD'])
+			->willThrowException(new \RuntimeException('boom'));
+
+		$this->logger
+			->expects($this->once())
+			->method('error')
+			->with($this->stringContains('exception occurred creating a federated contact'), $this->anything());
+
+		$result = $this->service->createFederatedContact($cloudId, 'mahdi@example.org', 'Mahdi', 'mahdi');
+		$this->assertNull($result);
 	}
 }

--- a/tests/unit/Service/SocialApiServiceTest.php
+++ b/tests/unit/Service/SocialApiServiceTest.php
@@ -5,15 +5,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Contacts\Service;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
-
+use OCA\Contacts\Exception\ContactAlreadyExistsException;
 use OCA\Contacts\Service\Social\CompositeSocialProvider;
 use OCA\Contacts\Service\Social\ISocialProvider;
+use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\ContactsManager;
-
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Constants;
@@ -23,11 +22,11 @@ use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
 use OCP\IAddressBook;
 use OCP\IConfig;
-use OCP\IL10N;
+use OCP\ICreateContactFromString;
 use OCP\IURLGenerator;
-
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 class SocialApiServiceTest extends TestCase {
 	private SocialApiService $service;
@@ -40,14 +39,14 @@ class SocialApiServiceTest extends TestCase {
 	private $config;
 	/** @var IClientService&MockObject */
 	private $clientService;
-	/** @var IL10N&MockObject */
-	private $l10n;
 	/** @var IURLGenerator&MockObject */
 	private $urlGen;
 	/** @var ITimeFactory&MockObject */
 	private $timeFactory;
 	/** @var ImageResizer&MockObject */
 	private $imageResizer;
+	/** @var LoggerInterface&MockObject */
+	private $logger;
 	/** @var ContainerInterface&MockObject */
 	private $container;
 
@@ -117,10 +116,10 @@ class SocialApiServiceTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->socialProvider = $this->createMock(CompositeSocialProvider::class);
 		$this->clientService = $this->createMock(IClientService::class);
-		$this->l10n = $this->createMock(IL10N::class);
 		$this->urlGen = $this->createMock(IURLGenerator::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->imageResizer = $this->createMock(ImageResizer::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->container = $this->createMock(ContainerInterface::class);
 		$this->container
 			->method('get')
@@ -131,10 +130,10 @@ class SocialApiServiceTest extends TestCase {
 			$this->manager,
 			$this->config,
 			$this->clientService,
-			$this->l10n,
 			$this->urlGen,
 			$this->timeFactory,
 			$this->imageResizer,
+			$this->logger,
 		);
 	}
 
@@ -623,7 +622,6 @@ class SocialApiServiceTest extends TestCase {
 		}
 	}
 
-
 	public function testUpdateAddressbooksTimeout() {
 		$this->config
 			->method('getAppValue')
@@ -698,4 +696,204 @@ class SocialApiServiceTest extends TestCase {
 		$result = $this->service->existsContact('11111111-1111-1111-1111-111111111111', 'not-existing', 'admin');
 		$this->assertEquals(false, $result);
 	}
+
+	public function testCreateContactPrefersPersonalAddressBook(): void {
+		$cloudId = 'mahdi@nextcloud2.docker';
+		$email = 'mahdi@example.org';
+		$name = 'Mahdi';
+		$persisted = ['UID' => 'new-uid'];
+
+		$workBook = $this->createMock(ICreateContactFromString::class);
+		$workBook->method('getUri')->willReturn('work');
+		$workBook->method('isShared')->willReturn(false);
+		$workBook->method('getPermissions')->willReturn(Constants::PERMISSION_CREATE);
+		$workBook->method('getKey')->willReturn('work-key');
+
+		$personalBook = $this->createMock(ICreateContactFromString::class);
+		$personalBook->method('getUri')->willReturn(CardDavBackend::PERSONAL_ADDRESSBOOK_URI);
+		$personalBook->method('getKey')->willReturn('personal-key');
+
+		$this->manager->expects($this->once())
+			->method('search')
+			->with($cloudId, ['CLOUD'])
+			->willReturn([]);
+		$this->manager->expects($this->once())
+			->method('getUserAddressBooks')
+			->willReturn([$workBook, $personalBook]);
+		$this->manager->expects($this->once())
+			->method('createOrUpdate')
+			->with(
+				['FN' => $name, 'EMAIL' => $email, 'CLOUD' => $cloudId],
+				'personal-key',
+			)
+			->willReturn($persisted);
+
+		$result = $this->service->createContact($cloudId, $email, $name, 'mahdi');
+		$this->assertNotNull($result);
+		$this->assertSame('new-uid', $result['UID']);
+		$this->assertSame(CardDavBackend::PERSONAL_ADDRESSBOOK_URI, $result['ADDRESSBOOK_URI']);
+	}
+
+	public function testCreateContactFallsBackToWritableOwnedAddressBook(): void {
+		$cloudId = 'mahdi@nextcloud2.docker';
+		$email = 'mahdi@example.org';
+		$name = 'Mahdi';
+		$persisted = ['UID' => 'new-uid'];
+
+		$sharedBook = $this->createMock(IAddressBook::class);
+		$sharedBook->method('getUri')->willReturn('shared');
+		$sharedBook->method('isShared')->willReturn(true);
+		$sharedBook->method('getPermissions')->willReturn(Constants::PERMISSION_CREATE);
+
+		$readOnlyBook = $this->createMock(IAddressBook::class);
+		$readOnlyBook->method('getUri')->willReturn('readonly');
+		$readOnlyBook->method('isShared')->willReturn(false);
+		$readOnlyBook->method('getPermissions')->willReturn(0);
+
+		$writableBook = $this->createMock(ICreateContactFromString::class);
+		$writableBook->method('getUri')->willReturn('team');
+		$writableBook->method('isShared')->willReturn(false);
+		$writableBook->method('getPermissions')->willReturn(Constants::PERMISSION_CREATE);
+		$writableBook->method('getKey')->willReturn('team-key');
+
+		$this->manager->expects($this->once())
+			->method('search')
+			->with($cloudId, ['CLOUD'])
+			->willReturn([]);
+		$this->manager->expects($this->once())
+			->method('getUserAddressBooks')
+			->willReturn([$sharedBook, $readOnlyBook, $writableBook]);
+		$this->manager->expects($this->once())
+			->method('createOrUpdate')
+			->with(
+				['FN' => $name, 'EMAIL' => $email, 'CLOUD' => $cloudId],
+				'team-key',
+			)
+			->willReturn($persisted);
+
+		$result = $this->service->createContact($cloudId, $email, $name, 'mahdi');
+		$this->assertNotNull($result);
+		$this->assertSame('team', $result['ADDRESSBOOK_URI']);
+	}
+
+	public function testCreateContactReturnsNullWhenNoSuitableAddressBook(): void {
+		$cloudId = 'mahdi@nextcloud2.docker';
+
+		$sharedBook = $this->createMock(IAddressBook::class);
+		$sharedBook->method('getUri')->willReturn('shared');
+		$sharedBook->method('isShared')->willReturn(true);
+		$sharedBook->method('getPermissions')->willReturn(Constants::PERMISSION_CREATE);
+
+		$readOnlyBook = $this->createMock(IAddressBook::class);
+		$readOnlyBook->method('getUri')->willReturn('readonly');
+		$readOnlyBook->method('isShared')->willReturn(false);
+		$readOnlyBook->method('getPermissions')->willReturn(0);
+
+		$this->manager->expects($this->once())
+			->method('search')
+			->with($cloudId, ['CLOUD'])
+			->willReturn([]);
+		$this->manager->expects($this->once())
+			->method('getUserAddressBooks')
+			->willReturn([$sharedBook, $readOnlyBook]);
+		$this->manager->expects($this->never())
+			->method('createOrUpdate');
+		$this->logger->expects($this->once())
+			->method('error')
+			->with($this->stringContains('No suitable address book found'), $this->anything());
+
+		$result = $this->service->createContact($cloudId, 'mahdi@example.org', 'Mahdi', 'mahdi');
+		$this->assertNull($result);
+	}
+
+	public function testCreateFederatedContactReturnsNullWhenContactExists(): void {
+		$cloudId = 'mahdi@nextcloud2.docker';
+		$existingContact = ['URI' => 'existing-contact-uri', 'CLOUD' => $cloudId];
+
+		$this->manager
+			->expects($this->once())
+			->method('search')
+			->with($cloudId, ['CLOUD'])
+			->willReturn([$existingContact]);
+
+		$this->manager
+			->expects($this->never())
+			->method('getUserAddressBooks');
+		$this->manager
+			->expects($this->never())
+			->method('createOrUpdate');
+
+		$this->expectException(ContactAlreadyExistsException::class);
+
+		$result = $this->service->createContact($cloudId, 'mahdi@example.org', 'Mahdi', 'mahdi');
+		$this->assertNull($result);
+	}
+
+	public function testCreateFederatedContactReturnsNullWhenNoContactsAddressBook(): void {
+		$cloudId = 'mahdi@nextcloud2.docker';
+
+		$otherBook = $this->createMock(IAddressBook::class);
+		$otherBook->method('getUri')->willReturn('shared-with-me');
+		$otherBook->method('isShared')->willReturn(true);
+
+		$this->manager
+			->expects($this->once())
+			->method('search')
+			->with($cloudId, ['CLOUD'])
+			->willReturn([]);
+		$this->manager
+			->expects($this->once())
+			->method('getUserAddressBooks')
+			->willReturn([$otherBook]);
+		$this->manager
+			->expects($this->never())
+			->method('createOrUpdate');
+
+		$this->logger
+			->expects($this->once())
+			->method('error')
+			->with($this->stringContains('No suitable address book found'), $this->anything());
+
+		$result = $this->service->createContact($cloudId, 'mahdi@example.org', 'Mahdi', 'mahdi');
+		$this->assertNull($result);
+	}
+
+	public function testCreateFederatedContactPersistsToContactsAddressBook(): void {
+		$cloudId = 'mahdi@nextcloud2.docker';
+		$email = 'mahdi@example.org';
+		$name = 'Mahdi';
+		$bookKey = 'addressbookid-42';
+		$persisted = ['ADDRESSBOOK_URI' => 'contacts', 'FN' => $name, 'EMAIL' => $email, 'CLOUD' => $cloudId];
+
+		$contactsBook = $this->createMock(ICreateContactFromString::class);
+		$contactsBook->method('getUri')->willReturn('contacts');
+		$contactsBook->method('isShared')->willReturn(false);
+		$contactsBook->method('getPermissions')->willReturn(Constants::PERMISSION_CREATE);
+		$contactsBook->method('getKey')->willReturn($bookKey);
+
+		$otherBook = $this->createMock(IAddressBook::class);
+		$otherBook->method('getUri')->willReturn('work');
+
+		$this->manager
+			->expects($this->once())
+			->method('search')
+			->with($cloudId, ['CLOUD'])
+			->willReturn([]);
+		$this->manager
+			->expects($this->once())
+			->method('getUserAddressBooks')
+			->willReturn([$otherBook, $contactsBook]);
+		$this->manager
+			->expects($this->once())
+			->method('createOrUpdate')
+			->with(
+				['FN' => $name, 'EMAIL' => $email, 'CLOUD' => $cloudId],
+				$bookKey,
+			)
+			->willReturn($persisted);
+
+		$result = $this->service->createContact($cloudId, $email, $name, 'mahdi');
+		$this->assertSame($persisted, $result);
+	}
+
 }

--- a/tests/unit/Settings/AdminSettingsTest.php
+++ b/tests/unit/Settings/AdminSettingsTest.php
@@ -8,11 +8,21 @@
 namespace OCA\Contacts\Settings;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Contacts\Service\FederatedInvitesService;
+use OCA\Contacts\Service\ImageResizer;
+use OCA\Contacts\Service\Social\CompositeSocialProvider;
 use OCA\Contacts\Service\SocialApiService;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Contacts\IManager;
+use OCP\Http\Client\IClientService;
+use OCP\IConfig;
+use OCP\IURLGenerator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 class AdminSettingsTest extends TestCase {
 	private AdminSettings $settings;
@@ -20,14 +30,35 @@ class AdminSettingsTest extends TestCase {
 	/** @var IInitialState|MockObject */
 	private $initialState;
 
+	/** @var IConfig&MockObject */
+	private $config;
+
 	/** @var SocialApiService|MockObject */
 	private $socialApiService;
+
+	/** @var FederatedInvitesService|MockObject */
+	private $federatedInvitesService;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->initialState = $this->createMock(IInitialState::class);
-		$this->socialApiService = $this->createMock(SocialApiService::class);
-		$this->settings = new AdminSettings($this->initialState, $this->socialApiService);
+
+		// $this->socialApiService = $this->createMock(SocialApiService::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->socialApiService = new SocialApiService(
+			$this->createMock(CompositeSocialProvider::class),
+			$this->createMock(ContainerInterface::class),
+			$this->createMock(IManager::class),
+			$this->config,
+			$this->createMock(IClientService::class),
+			$this->createMock(IURLGenerator::class),
+			$this->createMock(ITimeFactory::class),
+			$this->createMock(ImageResizer::class),
+			$this->createMock(LoggerInterface::class),
+		);
+
+		$this->federatedInvitesService = $this->createMock(FederatedInvitesService::class);
+		$this->settings = new AdminSettings($this->initialState, $this->socialApiService, $this->federatedInvitesService);
 	}
 
 	public static function allowSocialSyncProvider(): array {
@@ -36,13 +67,16 @@ class AdminSettingsTest extends TestCase {
 
 	#[DataProvider('allowSocialSyncProvider')]
 	public function testGetFormProvidesBooleanInitialState(bool $allowed): void {
-		$this->socialApiService
-			->method('syncAllowedByAdmin')
-			->willReturn($allowed);
+		$this->config
+			->method('getAppValue')
+			->with('contacts', 'allowSocialSync', 'yes')
+			->willReturn($allowed == true ? 'yes' : 'no');
 		$this->initialState
-			->expects($this->once())
-			->method('provideInitialState')
-			->with('allowSocialSync', $allowed);
+			->expects($this->exactly(2))
+			->method('provideInitialState');
+
+		$result = $this->socialApiService->syncAllowedByAdmin();
+		$this->assertEquals($allowed === true, $result);
 
 		$form = $this->settings->getForm();
 		$this->assertInstanceOf(TemplateResponse::class, $form);

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,6 +12,7 @@ export default createAppConfig({
 	'files-action': path.join(__dirname, 'src', 'files-action.js'),
 	'admin-settings': path.join(__dirname, 'src', 'admin-settings.js'),
 	'oca': path.join(__dirname, 'src', 'oca.ts'),
+	'wayf': path.join(__dirname, 'src', 'wayf.js'),
 }, {
 	inlineCSS: false,
 	config: defineConfig(({ mode }) => ({


### PR DESCRIPTION
**~~This is a work in progress~~**
This PR implements https://github.com/nextcloud/contacts/issues/4416

### About
The goal of this feature is to allow for easy remote contact information exchange (cloud ID, email, name) between 2 users from different instances/organizations based on an invitation request.
The feature is an implementation of the invitation workflow from the OCM specification (https://datatracker.ietf.org/doc/draft-ietf-ocm-open-cloud-mesh/)<br><br>

A user (sender) creates the invitation. This invitation consists of an invite link and (encoded) invite code. The invitation is sent to another user (receiver) via email or through another channel, eg. chat.
After receiving the invitation, the receiver can accept the invitation by following the invite link or by pasting the (encoded) invite code into a manual accept form. 
After accepting, the exchange of user information will take place (OCM `/invite-accepted` endpoint) resulting in the creation of both users in each other's contacts list.
Following the invite link in the email is the most convenient way to accept. It will redirect the receiver via a WAYF (Where Are You From) page immediately to an accept dialog.  
Note: Manual acceptance of the invitation works with both the invite link and (encoded) invite code.

### Screenshots
<img width="1865" height="905" alt="1_contacts-app-main-page-Mike" src="https://github.com/user-attachments/assets/f067d3ef-aea0-453a-8c63-c07276071de3" />
Contacts page with new buttons 'Invite contact', 'Accept invite' and 'All invites'.<br><br>

<img width="1864" height="905" alt="2_fill-in-invite-form" src="https://github.com/user-attachments/assets/3d53aa27-0e6e-4416-ad03-709062d92115" />
Click 'Invite contact' and fill in form fields:

- Invite label for reference in the Invites list (optional)
- Recipient email (required)
- Personal message that will be sent with the email (optional)
- Check to send copy of the invite email to yourself (optional)

<img width="1865" height="905" alt="3_invite-sent-list" src="https://github.com/user-attachments/assets/3c267284-2063-4235-bf46-1264264fec95" />
'All invites' button displays the invites sent.<br><br>

<img width="1865" height="905" alt="3a_alt-way-to-share-invite" src="https://github.com/user-attachments/assets/21f89154-f84a-4a1d-bf1a-c26022612aab" />
It's also possible to share the invite by sending the invite link or code through an alternative channel (eg. chat).<br><br>

<img width="1113" height="818" alt="4_invite-email-to-Pete" src="https://github.com/user-attachments/assets/2fb81284-bf6f-451a-8074-b5aedaf40523" />
This what the email to the receiver of the invite looks like.<br><br>

<img width="1113" height="818" alt="5_copy-of-invite-email-to-Pete" src="https://github.com/user-attachments/assets/175e4e53-c7c7-48aa-90f1-a4eb07eff646" />
This is what the copy of the email to the sender of the invite looks like.<br><br>

<img width="1864" height="905" alt="6_wayf-page" src="https://github.com/user-attachments/assets/aa095b06-5ca3-4a15-877c-09a97e68ac69" />
Clicking on the invite link will direct the receiver to a WAYF (Where Are You From) page.<br>
Here you choose your institute. You can also fill in your institute's provider address if you are not on the list. A discovery process will run to check whether your provider supports OCM.<br><br>

<img width="1864" height="905" alt="7_login-after-wayf-page-select-Pete" src="https://github.com/user-attachments/assets/13b4ecec-2521-4fed-85b7-54fb07578d4b" />
Login after selecting your institute.<br><br>

<img width="1864" height="905" alt="8_accept-invite" src="https://github.com/user-attachments/assets/30a5129c-ef8a-4be4-a226-1a826726abc6" />
You will be redirected to an invite accept dialog.<br><br>

<img width="1864" height="905" alt="9_invite-accepted-Pete" src="https://github.com/user-attachments/assets/8a3c4f63-e1d4-4b09-be76-0d4ccc13b133" />
On acceptance the contact information exchange will take place via the OCM `/invite-accepted` endpoint. This will lead to the creation of a new contact (the sender) on the receiver's end.<br><br>

<img width="1864" height="905" alt="10_invite-accepted-Mike" src="https://github.com/user-attachments/assets/9084bbeb-d30e-4e1e-b554-79a6b5438259" />
And on the sender end the receiver contact info will also be added.<br><br>

<img width="1864" height="905" alt="11_alt-invite-without-email-Jimmie" src="https://github.com/user-attachments/assets/681e62e4-0604-44d0-ac73-447fb4beba2a" />
When the config setting `ocm_invites_optional_mail` is set to false, creating an invite will give you by default the option to share the invite through an alternative channel (eg. chat).<br><br>

<img width="1864" height="905" alt="12_alt-invite-no-email-copy-code" src="https://github.com/user-attachments/assets/31756f36-af11-414c-85de-df9e677e5661" />
Copy the invite link or code and send it via your channel of choice.<br><br>

<img width="1861" height="901" alt="12a_alt-invite-with-email" src="https://github.com/user-attachments/assets/900925d7-ccae-4d94-b92e-d0bc9b53cfaa" />
You may still decide to send the invite via email by clicking the 'Send via email' button.<br><br>

<img width="1861" height="892" alt="13_alt-manual-accept-invite-Dan" src="https://github.com/user-attachments/assets/8fb10a54-6271-4285-a989-147e52c6cfd8" />
The receiver of the invite can click 'Accept invite' and manually paste the invite link, code, or encoded invite code into the accept form.<br>
And this will lead to the exchange of contact information via the OCM /invite-accepted endpoint.<br><br>

<img width="1858" height="905" alt="14_alt-manual-invite-accepted-Dan" src="https://github.com/user-attachments/assets/0dffa2f3-e9a2-42f5-8b91-b97f46d42003" />
After contact info exchange the sender will be added as a new contact on the receiver's end.<br><br>

<img width="1868" height="906" alt="15_alt-manual-invite-accepted-Jimmie" src="https://github.com/user-attachments/assets/b20775bb-96b8-4746-aebf-df5d3b4d0b22" />
And the receiver will be added as a new contact on the sender's end.<br><br>

### OCM invites admin settings
<img width="1296" height="365" alt="ocm-invites-admin-settings" src="https://github.com/user-attachments/assets/a2065b64-60b5-46a1-a9e4-b387d20e3e44" />
