### PR TITLE
chore: backport translations and run audits on 7.1

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'stable7.0']
+        branches: ['main', 'stable7.1']
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/.tx/backport
+++ b/.tx/backport
@@ -1,1 +1,1 @@
-stable7.0
+stable7.1


### PR DESCRIPTION
stable7.1 is the only maintained branch. 
Translation backports and audits should run on that branch.