### PR TITLE
fix(groups): show read-only contacts hint only for contact groups

### DIFF
--- a/src/components/EntityPicker/ContactsPicker.vue
+++ b/src/components/EntityPicker/ContactsPicker.vue
@@ -16,6 +16,7 @@
 		:confirm-label="t('contacts', 'Add to {group}', { group: pickerforGroup.name })"
 		:data-types="pickerTypes"
 		:data-set="pickerData"
+		:empty-data-set-description="t('contacts', 'Please note that you can only add contacts from writable address books to contact groups. Contacts from read-only address books, such as the system address book, cannot be added.')"
 		@close="onContactPickerClose"
 		@submit="onContactPickerPick" />
 </template>

--- a/src/components/EntityPicker/EntityPicker.vue
+++ b/src/components/EntityPicker/EntityPicker.vue
@@ -41,7 +41,7 @@
 				<!-- No recommendations -->
 				<EmptyContent v-if="dataSet.length === 0"
 					:name="t('contacts', 'Search for people to add')"
-					:description="t('contacts', 'Please note that you can only add contacts from writable address books to contact groups. Contacts from read-only address books, such as the system address book, cannot be added.')">
+					:description="emptyDataSetDescription">
 					<template #icon>
 						<IconSearch :size="20" />
 					</template>
@@ -174,6 +174,11 @@ export default {
 		selection: {
 			type: Object,
 			default: null,
+		},
+
+		emptyDataSetDescription: {
+			type: String,
+			default: '',
 		},
 	},
 


### PR DESCRIPTION
Follow-up for https://github.com/nextcloud/contacts/pull/4528

To hide the description when adding a member to a team