### PR TITLE
chore: drop obsolete vue-click-outside dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "uuid": "^11.1.0",
         "validator": "^13.15.15",
         "vue": "~2.7.16",
-        "vue-click-outside": "^1.1.0",
         "vue-cropperjs": "^4.2.0",
         "vue-material-design-icons": "^5.3.1",
         "vue-router": "^3.6.5",
@@ -19757,10 +19756,6 @@
         "csstype": "^3.1.0"
       }
     },
-    "node_modules/vue-click-outside": {
-      "version": "1.1.0",
-      "integrity": "sha512-pNyvAA9mRXJwPHlHJyjMb4IONSc7khS5lxGcMyE2EIKgNMAO279PWM9Hyq0d5J4FkiSRdmFLwnbjDd5UtPizHQ=="
-    },
     "node_modules/vue-color": {
       "version": "2.8.1",
       "integrity": "sha512-BoLCEHisXi2QgwlhZBg9UepvzZZmi4176vbr+31Shen5WWZwSLVgdScEPcB+yrAtuHAz42309C0A4+WiL9lNBw==",
@@ -34336,10 +34331,6 @@
         "@vue/compiler-sfc": "2.7.16",
         "csstype": "^3.1.0"
       }
-    },
-    "vue-click-outside": {
-      "version": "1.1.0",
-      "integrity": "sha512-pNyvAA9mRXJwPHlHJyjMb4IONSc7khS5lxGcMyE2EIKgNMAO279PWM9Hyq0d5J4FkiSRdmFLwnbjDd5UtPizHQ=="
     },
     "vue-color": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "uuid": "^11.1.0",
     "validator": "^13.15.15",
     "vue": "~2.7.16",
-    "vue-click-outside": "^1.1.0",
     "vue-cropperjs": "^4.2.0",
     "vue-material-design-icons": "^5.3.1",
     "vue-router": "^3.6.5",

--- a/src/components/ContactDetails/ContactDetailsAvatar.vue
+++ b/src/components/ContactDetails/ContactDetailsAvatar.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<div v-click-outside="closeMenu" class="contact-header-avatar__wrapper">
+	<div class="contact-header-avatar__wrapper">
 		<input id="contact-avatar-upload"
 			ref="uploadInput"
 			type="file"

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,6 @@ import store from './store/index.js'
 import logger from './services/logger.js'
 
 /** GLOBAL COMPONENTS AND DIRECTIVE */
-import ClickOutside from 'vue-click-outside'
 import { Tooltip as VTooltip } from '@nextcloud/vue'
 
 // Global scss sheets
@@ -30,7 +29,6 @@ Vue.use(PiniaVuePlugin)
 const pinia = createPinia()
 
 // Register global directives
-Vue.directive('ClickOutside', ClickOutside)
 Vue.directive('Tooltip', VTooltip)
 
 sync(store, router)

--- a/src/oca/mountContactDetails.js
+++ b/src/oca/mountContactDetails.js
@@ -8,7 +8,6 @@ import ReadOnlyContactDetails from '../views/ReadOnlyContactDetails.vue'
 import { createPinia, PiniaVuePlugin } from 'pinia'
 
 /** GLOBAL COMPONENTS AND DIRECTIVE */
-import ClickOutside from 'vue-click-outside'
 import { Tooltip as VTooltip } from '@nextcloud/vue'
 
 import store from '../store/index.js'
@@ -24,7 +23,6 @@ export function mountContactDetails(el, contactEmailAddress) {
 	const pinia = createPinia()
 
 	// Register global directives
-	Vue.directive('ClickOutside', ClickOutside)
 	Vue.directive('Tooltip', VTooltip)
 
 	Vue.prototype.t = t


### PR DESCRIPTION
Looks like we stopped using this dependency but never removed it.

There are no references of "ClickOutside" in the code.