### PR TITLE
fix: rendering of phone numbers

### DIFF
--- a/src/services/updateDesignSet.js
+++ b/src/services/updateDesignSet.js
@@ -5,23 +5,6 @@
 import ICAL from 'ical.js'
 
 /**
- * Prevents ical.js from adding 'VALUE=PHONE-NUMBER' in vCard 3.0.
- * While not wrong according to the RFC, there's a bug in sabreio/vobject (used
- * by Nextcloud Server) that prevents saving vCards with this parameters.
- *
- * @link https://github.com/nextcloud/contacts/pull/1393#issuecomment-570945735
- * @return {boolean} Whether or not the design set has been altered.
- */
-const removePhoneNumberValueType = () => {
-	if (ICAL.design.vcard3.property.tel) {
-		delete ICAL.design.vcard3.property.tel
-		return true
-	}
-
-	return false
-}
-
-/**
  * Some clients group properties by naming them something like 'ITEM1.URL'.
  * These should be treated the same as their original (i.e. 'URL' in this
  * example), so we iterate through the vCard to find these properties and
@@ -78,7 +61,6 @@ export default function(vCard) {
 	let madeChanges = false
 
 	madeChanges |= setTypeMultiValueSeparateDQuote()
-	madeChanges |= removePhoneNumberValueType()
 	madeChanges |= addGroupedProperties(vCard)
 
 	return madeChanges


### PR DESCRIPTION
Fix #4564 

Additional details https://github.com/kewisch/ical.js/issues/905

There was a bug in sabre/vobject that stopped us from storing URIs with phone numbers. So, we had to use a workaround and not include them.[^1]

The fix for sabre/vobject is merged and included in stable31 and stable30.[^2]

It seems like this problem started after updating to ical.js 2.2.0 because of fixes in how vcard3 design sets were detected.[^3][^4]

Now it seems to work, but I don't understand why removing the tel property from the vcard3 design set worked when detecting the design set wasn't working before.

[^1]: https://github.com/nextcloud/contacts/pull/1393#issuecomment-570945735
[^2]: https://github.com/sabre-io/vobject/pull/486
[^3]: https://github.com/kewisch/ical.js/pull/680
[^4]: https://github.com/kewisch/ical.js/issues/363