### PR TITLE
fix: log error while saving contact

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -1066,6 +1066,7 @@ export default {
 				}
 				this.editMode = false
 			} catch (error) {
+				this.logger.error('error while saving contact', { error })
 				showError(t('contacts', 'Unable to update contact'))
 			}
 		},


### PR DESCRIPTION
When saving a contact fails there's a "Unable to update contact" toast, but no further information what might be wrong. Now the error is logged to the console. 