### PR TITLE
fix: always convert vcard photo urls to string

### DIFF
--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -230,7 +230,9 @@ export default class Contact {
 		}
 		const encoding = photo.getFirstParameter('encoding')
 		let photoType = photo.getFirstParameter('type')
-		const photoB64 = this.photo
+
+		// Always convert to a string as this might be a binary value (and not a string)
+		const photoB64 = this.photo.toString()
 
 		const isBinary = photo.type === 'binary' || encoding === 'b'
 


### PR DESCRIPTION
Fix console errors like:

```
TypeError: photoB64.startsWith is not a function
    getPhotoUrl contact.js:238
    loadPhotoUrl ContactDetailsAvatar.vue:387
    contact ContactDetailsAvatar.vue:196
```

**Context:** The photo usually is a string but in some cases it is an instance of `ICAL.Binary` which needs to be serialized (to a string) first.