### PR TITLE
fix: missing getLocale import

### DIFF
--- a/src/components/Properties/PropertyDateTime.vue
+++ b/src/components/Properties/PropertyDateTime.vue
@@ -75,6 +75,7 @@ import {
 	NcSelect,
 } from '@nextcloud/vue'
 import ICAL from 'ical.js'
+import { getLocale } from '@nextcloud/l10n'
 
 import PropertyMixin from '../../mixins/PropertyMixin.js'
 import PropertyTitle from './PropertyTitle.vue'


### PR DESCRIPTION
Fixes a console error:
```
ReferenceError: getLocale is not defined
    mounted PropertyDateTime.vue:145
```