### PR TITLE
Revert "fix: use built now function instead of manually creating date"

### DIFF
--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -66,7 +66,9 @@ export default class Contact {
 
 		// if no rev set, init one
 		if (!this.vCard.hasProperty('rev')) {
-			this.vCard.addPropertyWithValue('rev', ICAL.VCardTime.now().convertToZone(ICAL.Timezone.utcTimezone))
+			const rev = new ICAL.VCardTime(null, null, 'date-time')
+			rev.fromUnixTime(Date.now() / 1000)
+			this.vCard.addPropertyWithValue('rev', rev)
 		}
 	}
 

--- a/src/services/checks/invalidREV.js
+++ b/src/services/checks/invalidREV.js
@@ -41,7 +41,9 @@ export default {
 			contact.vCard.removeProperty('rev')
 
 			// creatiing new value
-			contact.vCard.addPropertyWithValue('rev', ICAL.VCardTime.now().convertToZone(ICAL.Timezone.utcTimezone))
+			const rev = new ICAL.VCardTime(null, null, 'date-time')
+			rev.fromUnixTime(Date.now() / 1000)
+			contact.vCard.addPropertyWithValue('rev', rev)
 
 			return true
 		} catch (error) {

--- a/src/store/contacts.js
+++ b/src/store/contacts.js
@@ -331,7 +331,9 @@ const actions = {
 		validate(contact)
 
 		// Update REV
-		contact.rev = ICAL.VCardTime.now().convertToZone(ICAL.Timezone.utcTimezone)
+		const rev = new ICAL.VCardTime()
+		rev.fromUnixTime(Date.now() / 1000)
+		contact.rev = rev
 
 		const vData = contact.toStringStripQuotes()
 

--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -281,7 +281,7 @@ export default {
 				emit('contacts:circles:append', this.selectedCircle.id)
 				return
 			}
-
+			const rev = new ICAL.VCardTime()
 			const contact = new Contact(`
 				BEGIN:VCARD
 				VERSION:4.0
@@ -291,8 +291,8 @@ export default {
 			this.defaultAddressbook)
 
 			contact.fullName = t('contacts', 'Name')
-
-			contact.rev = ICAL.VCardTime.now().convertToZone(ICAL.Timezone.utcTimezone)
+			rev.fromUnixTime(Date.now() / 1000)
+			contact.rev = rev
 
 			// itterate over all properties (filter is not usable on objects and we need the key of the property)
 			const properties = rfcProps.properties


### PR DESCRIPTION
discovered in #4521 
reverts https://github.com/nextcloud/contacts/pull/4573 

According to the pre-existing logic : 
https://github.com/nextcloud/contacts/blob/fix/invalid-rev/src/services/checks/invalidREV.js#L24-L30 
`vcardtime` is expected for v3 contacts and `icaltime` is expected for v4
With the reverted commit that was not respected. According to that logic even the repaired rev is wrong. 

creating rev from unix timestamp or js date are both supported by the library so I don't see anything wrong with the old method imo 
