### PR TITLE
fix: enforce correct icaltype when constructing VCardTime

### DIFF
--- a/src/components/Properties/PropertyDateTime.vue
+++ b/src/components/Properties/PropertyDateTime.vue
@@ -134,7 +134,7 @@ export default {
 		vcardTimeLocalValue() {
 			if (typeof this.localValue === 'string') {
 				// eslint-disable-next-line new-cap
-				return new ICAL.VCardTime.fromDateAndOrTimeString(this.localValue)
+				return new ICAL.VCardTime.fromDateAndOrTimeString(this.localValue, this.propType)
 			}
 			return this.localValue
 		},

--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -66,7 +66,7 @@ export default class Contact {
 
 		// if no rev set, init one
 		if (!this.vCard.hasProperty('rev')) {
-			this.vCard.addPropertyWithValue('rev', ICAL.VCardTime.now().convertToZone(ICAL.Timezone.utcTimezone))
+			this.vCard.addPropertyWithValue('rev', ICAL.VCardTime.fromDateAndOrTimeString(new Date().toISOString(), 'date-time'))
 		}
 	}
 

--- a/src/services/checks/invalidREV.js
+++ b/src/services/checks/invalidREV.js
@@ -41,7 +41,7 @@ export default {
 			contact.vCard.removeProperty('rev')
 
 			// creatiing new value
-			contact.vCard.addPropertyWithValue('rev', ICAL.VCardTime.now().convertToZone(ICAL.Timezone.utcTimezone))
+			contact.vCard.addPropertyWithValue('rev', ICAL.VCardTime.fromDateAndOrTimeString(new Date().toISOString(), 'date-time'))
 
 			return true
 		} catch (error) {

--- a/src/store/contacts.js
+++ b/src/store/contacts.js
@@ -331,7 +331,7 @@ const actions = {
 		validate(contact)
 
 		// Update REV
-		contact.rev = ICAL.VCardTime.now().convertToZone(ICAL.Timezone.utcTimezone)
+		contact.rev = ICAL.VCardTime.fromDateAndOrTimeString(new Date().toISOString(), 'date-time')
 
 		const vData = contact.toStringStripQuotes()
 

--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -292,7 +292,7 @@ export default {
 
 			contact.fullName = t('contacts', 'Name')
 
-			contact.rev = ICAL.VCardTime.now().convertToZone(ICAL.Timezone.utcTimezone)
+			contact.rev = ICAL.VCardTime.fromDateAndOrTimeString(new Date().toISOString(), 'date-time')
 
 			// itterate over all properties (filter is not usable on objects and we need the key of the property)
 			const properties = rfcProps.properties


### PR DESCRIPTION
Extracted from #4298 

On my testing instance I don't see the "repaired invalid rev" error any longer.