### PR TITLE
fix(teams): Make team resources scrollable

### DIFF
--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -486,6 +486,7 @@ export default {
 
 	.circle-details-section {
 		margin-bottom: 2rem;
+		max-width: 500px;
 
 		.member-section-layout {
 			display: inline-block;
@@ -514,6 +515,8 @@ export default {
 			display: flex;
 			flex-direction: column;
 			gap: 2px;
+			max-height: 300px;
+			overflow-y: auto;
 
 			// Remove left padding added in ListItem (external component)
 			:deep(.list-item__wrapper) {


### PR DESCRIPTION

| Before | After |
| ---------- | ------- |
| <img width="651" height="960" alt="image" src="https://github.com/user-attachments/assets/2a994dc9-b82a-473d-b664-f260029ac1ff" /> |  <img width="651" height="960" alt="image" src="https://github.com/user-attachments/assets/b1cc8e03-2cba-49dd-b5dc-3397c4824c9f" /> |


### Video

https://github.com/user-attachments/assets/94006bbf-cb17-4b07-bf21-87613cc4ae84




### Todo
- [x] Merge first : https://github.com/nextcloud/contacts/pull/4617
- [x] Rebase