### PR TITLE
feat: show a user's groups as teams

### DIFF
--- a/src/components/AppNavigation/CircleNavigationItem.vue
+++ b/src/components/AppNavigation/CircleNavigationItem.vue
@@ -92,6 +92,7 @@ import AccountGroupOutline from 'vue-material-design-icons/AccountGroupOutline.v
 
 import Circle from '../../models/circle.ts'
 import CircleActionsMixin from '../../mixins/CircleActionsMixin.js'
+import UserGroup from '../../models/userGroup.ts'
 
 export default {
 	name: 'CircleNavigationItem',
@@ -116,7 +117,7 @@ export default {
 
 	props: {
 		circle: {
-			type: Circle,
+			type: [Circle, UserGroup],
 			required: true,
 		},
 	},

--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -169,6 +169,7 @@
 
 <script>
 import { GROUP_ALL_CONTACTS, CHART_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS, GROUP_RECENTLY_CONTACTED, ELLIPSIS_COUNT, CIRCLE_DESC, CONTACTS_SETTINGS } from '../../models/constants.ts'
+import useUserGroupStore from '../../store/userGroup.ts'
 
 import {
 	NcActionInput as ActionInput,
@@ -182,6 +183,7 @@ import {
 } from '@nextcloud/vue'
 
 import naturalCompare from 'string-natural-compare'
+import { mapStores } from 'pinia'
 
 import CircleNavigationItem from './CircleNavigationItem.vue'
 import Cog from 'vue-material-design-icons/CogOutline.vue'
@@ -282,6 +284,9 @@ export default {
 		sortedContacts() {
 			return this.$store.getters.getSortedContacts
 		},
+		userGroups() {
+			return this.userGroupStore.userGroupList
+		},
 
 		// list all the contacts that doesn't have a group
 		ungroupedContacts() {
@@ -326,7 +331,8 @@ export default {
 
 		// generate circles menu from the circles store
 		circlesMenu() {
-			const menu = this.circles || []
+			const menu = [...(this.circles || []), ...(this.userGroups || [])]
+
 			menu.sort((a, b) => {
 				// If user is member of a and b, sort by level
 				if (a?.initiator?.level !== b?.initiator?.level && a?.initiator?.level && b?.initiator?.level) {
@@ -372,6 +378,7 @@ export default {
 				? t('contacts', 'Show all teams')
 				: t('contacts', 'Collapse teams')
 		},
+		...mapStores(useUserGroupStore),
 	},
 
 	methods: {

--- a/src/components/UserGroupDetails.vue
+++ b/src/components/UserGroupDetails.vue
@@ -1,0 +1,163 @@
+<!--
+   - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+   - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="usergroup-details-container">
+		<div class="usergroup-details-grid">
+			<div class="usergroup-details__header-wrapper">
+				<div class="usergroup-details-grid__avatar">
+					<NcAvatar :disable-tooltip="true"
+						:display-name="userGroup.displayName"
+						:is-no-user="true"
+						:size="75" />
+				</div>
+				<div class="usergroup-details__header">
+					<div class="usergroup-name-wrapper">
+						<h2 class="usergroup-name">
+							<span :title="userGroup.displayName">{{ userGroup.displayName }}</span>
+						</h2>
+						<div class="usergroup-details__subtitle">
+							{{ t('contacts', 'This is a read-only group managed by administrators. Group members can only view this group.') }}
+						</div>
+					</div>
+					<div class="actions">
+						<NcButton variant="secondary" @click.stop.prevent="copyToClipboard(userGroupUrl)">
+							<template #icon>
+								<CopyIcon :size="20" />
+							</template>
+							{{ t('contacts', 'Copy link') }}
+						</NcButton>
+					</div>
+				</div>
+			</div>
+			<div class="usergroup-details__main-content">
+				<h3 class="usergroup-details__content-heading">
+					{{ t('contacts', 'Members') }}
+				</h3>
+				<div class="usergroup-details__member-grid">
+					<UserGroupMember v-for="member in userGroup.members"
+						:key="`user-group-member-${member}`"
+						:member="member" />
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcAvatar, NcButton } from '@nextcloud/vue'
+import CopyIcon from 'vue-material-design-icons/ContentCopy.vue'
+
+import CopyToClipboardMixin from '../mixins/CopyToClipboardMixin.js'
+import UserGroup from '../models/userGroup.ts'
+import UserGroupMember from './UserGroupDetails/UserGroupMember.vue'
+
+export default {
+	name: 'UserGroupDetails',
+
+	components: {
+		CopyIcon,
+		NcAvatar,
+		NcButton,
+		UserGroupMember,
+	},
+
+	mixins: [CopyToClipboardMixin],
+
+	props: {
+		userGroup: {
+			type: UserGroup,
+			required: true,
+		},
+	},
+
+	computed: {
+		userGroupUrl() {
+			return window.location.href
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.usergroup-details {
+	&-container {
+		padding-inline: 20px;
+		margin-top: 1rem;
+	}
+
+	&-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 36px;
+		max-width: 800px;
+		margin-inline: auto;
+
+		.usergroup-name-wrapper {
+			width: 100%;
+		}
+	}
+
+	&__header-wrapper {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		align-items: center;
+		gap: 24px;
+	}
+
+	&__header {
+		background-color: transparent;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 2px;
+		width: 100%;
+
+		.usergroup-name {
+			font-size: 1.5rem;
+			font-weight: bold;
+			margin: 0px;
+			margin-bottom: 2px;
+		}
+	}
+
+	&__subtitle {
+		color: var(--color-text-maxcontrast);
+		margin-bottom: 8px;
+	}
+
+	&__main-content {
+		margin-inline-start: 99px;
+
+		@media (max-width: 768px) {
+			margin-inline-start: 0px;
+		}
+	}
+
+	&__content-heading {
+		font-weight: bold;
+		font-size: 1.2rem;
+		line-height: 0px;
+		margin-top: 4px;
+		margin-bottom: 8px;
+	}
+
+	&__member-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 8px;
+		max-width: 500px;
+
+		@media (max-width: 768px) {
+			grid-template-columns: 1fr;
+		}
+
+		@media (min-width: 1200px) {
+			grid-template-columns: repeat(3, 1fr);
+		}
+	}
+
+}
+</style>

--- a/src/components/UserGroupDetails/UserGroupMember.vue
+++ b/src/components/UserGroupDetails/UserGroupMember.vue
@@ -1,0 +1,93 @@
+<!--
+   - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+   - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="usergroup-member__container">
+		<NcAvatar :user="member" :size="32" />
+		<div class="usergroup-member__info">
+			<div v-if="!loading" class="usergroup-member__name">
+				{{ displayName }}
+			</div>
+			<div class="usergroup-member__role">
+				{{ t('contacts', 'Member') }}
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+import { NcAvatar } from '@nextcloud/vue'
+
+export default {
+	name: 'UserGroupMember',
+
+	components: {
+		NcAvatar,
+	},
+
+	props: {
+		member: {
+			type: String,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			loading: true,
+			displayName: '',
+		}
+	},
+
+	mounted() {
+		this.fetchMemberInfo()
+	},
+
+	methods: {
+		async fetchMemberInfo() {
+			const user = encodeURIComponent(this.member)
+			const { data } = await axios.post(generateUrl('contactsmenu/findOne'), `shareType=0&shareWith=${user}`)
+			this.displayName = data.fullName
+			this.loading = false
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.usergroup-member {
+	&__container {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px;
+		border-radius: var(--border-radius);
+		background-color: var(--color-background-soft);
+	}
+
+	&__info {
+		flex-grow: 1;
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
+	&__name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__role {
+		font-size: 0.75rem;
+		color: var(--color-text-maxcontrast);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+}
+</style>

--- a/src/mixins/RouterMixin.js
+++ b/src/mixins/RouterMixin.js
@@ -14,6 +14,9 @@ export default {
 		selectedCircle() {
 			return this.$route.params.selectedCircle
 		},
+		selectedUserGroup() {
+			return this.$route.params.selectedUserGroup
+		},
 		selectedChart() {
 			return this.$route.params.selectedChart
 		},

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -27,6 +27,7 @@ export const CHART_ALL_CONTACTS: DefaultChart = t('contacts', 'Organization char
 // Circle route, see vue-router conf
 export const ROUTE_CIRCLE = 'circle'
 export const ROUTE_CHART = 'chart'
+export const ROUTE_USER_GROUP = 'user_group'
 
 // Contact settings
 export const CONTACTS_SETTINGS: DefaultGroup = t('contacts', 'Contacts settings')

--- a/src/models/userGroup.ts
+++ b/src/models/userGroup.ts
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { ROUTE_USER_GROUP } from './constants'
+
+export default class UserGroup {
+
+	private _data: object
+	private _members: string[]
+
+	constructor(group: object) {
+		this._data = group
+		this._members = []
+	}
+
+	addMember(member: object) {
+		if (!this._members.includes(member)) {
+			this._members.push(member)
+		}
+	}
+
+	get id(): string {
+		return this._data.id
+	}
+
+	get displayName(): string {
+		return this._data.displayname
+	}
+
+	get population(): number {
+		return this._data.usercount
+	}
+
+	get canLeave(): boolean {
+		// users can't leave groups
+		return false
+	}
+
+	get isOwner(): boolean {
+		return false
+	}
+
+	get isMember(): boolean {
+		// Only the groups that a user has been added to will be visible to them
+		return true
+	}
+
+	get canManageMembers(): boolean {
+		return false
+	}
+
+	get canJoin(): boolean {
+		return false
+	}
+
+	get members(): string[] {
+		return this._members
+	}
+
+	get router(): object {
+		return {
+			name: 'user_group',
+			params: { selectedUserGroup: this.id, selectedGroup: ROUTE_USER_GROUP },
+		}
+	}
+
+	toString(): string {
+		return this.displayName
+	}
+
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,7 +6,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { generateUrl } from '@nextcloud/router'
 
-import { ROUTE_CIRCLE, ROUTE_CHART } from '../models/constants.ts'
+import { ROUTE_CIRCLE, ROUTE_CHART, ROUTE_USER_GROUP } from '../models/constants.ts'
 import Contacts from '../views/Contacts.vue'
 
 // if index.php is in the url AND we got this far, then it's working:
@@ -51,6 +51,11 @@ export default createRouter({
 				{
 					path: ':selectedGroup/:selectedContact',
 					name: 'contact',
+					component: Contacts,
+				},
+				{
+					path: `${ROUTE_USER_GROUP}/:selectedUserGroup`,
+					name: 'user_group',
 					component: Contacts,
 				},
 			],

--- a/src/services/userGroup.ts
+++ b/src/services/userGroup.ts
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+
+export const getUserGroups = async function(userId: string): string[] {
+	const response = await axios.get(generateOcsUrl('/cloud/users/{userId}/groups/details', { userId }))
+	return response.data.ocs.data.groups
+}
+
+export const getUserGroupMembers = async function(groupId: string): string[] {
+	const response = await axios.get(generateOcsUrl('/cloud/groups/{groupId}/users', { groupId }))
+	return response.data.ocs.data.users
+}

--- a/src/store/userGroup.ts
+++ b/src/store/userGroup.ts
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { getUserGroups, getUserGroupMembers } from '../services/userGroup.ts'
+import logger from '../services/logger.js'
+import UserGroup from '../models/userGroup.ts'
+
+import { defineStore } from 'pinia'
+
+export default defineStore('userGroup', {
+	state: () => ({
+		userGroups: {},
+	}),
+
+	getters: {
+		userGroupList: (state) => Object.values(state.userGroups),
+		getUserGroup: (state) => (groupId: string) => state.userGroups[groupId],
+	},
+
+	actions: {
+		async getUserGroups(userId: string): object[] {
+			const userGroups = await getUserGroups(userId)
+
+			userGroups.forEach(group => {
+				try {
+					const newUserGroup = new UserGroup(group)
+					this.userGroups[newUserGroup.id] = newUserGroup
+				} catch (error) {
+					logger.error('Failed to add group', { group, error })
+				}
+			})
+
+			return userGroups
+		},
+		async getUserGroupMembers(groupId: string): string[] {
+			const members = await getUserGroupMembers(groupId)
+
+			members.forEach(member => {
+				this.getUserGroup(groupId).addMember(member)
+			})
+
+			return members
+		},
+	},
+})


### PR DESCRIPTION
Allow a user to view their groups through the teams menu. Groups can only be viewed by its members.
Reference issue here https://github.com/nextcloud/circles/issues/1941

Requires https://github.com/nextcloud/server/pull/54691 to be merged first

<img width="1920" height="962" alt="image" src="https://github.com/user-attachments/assets/e8fce334-4924-4798-8f20-aa3c91a9948f" />
