### PR TITLE
fix: translation for recently contacted not working

### DIFF
--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -19,7 +19,7 @@ export const LIST_SIZE = 60
 // Dynamic default groups
 export const GROUP_ALL_CONTACTS: DefaultGroup = t('contacts', 'All contacts')
 export const GROUP_NO_GROUP_CONTACTS: DefaultGroup = t('contacts', 'Not grouped')
-export const GROUP_RECENTLY_CONTACTED: DefaultGroup = t('contactsinteraction', 'Recently contacted')
+export const GROUP_RECENTLY_CONTACTED: DefaultGroup = t('contacts', 'Recently contacted')
 
 // Organization default chart for all contacts
 export const CHART_ALL_CONTACTS: DefaultChart = t('contacts', 'Organization chart')


### PR DESCRIPTION
I came across this issue while working on a related case with a user who was using Nextcloud in different languages.

The `contactsinteraction` translations are not loaded in the Contacts app, so the source string is never translated. It’s just a detail, but it would look nicer if the menu item were shown correctly.

**How to reproduce:**

* Use Nextcloud in a non-English language
* Share a file with `external-person@example.org`
* The "recently contacted" list is displayed as a contact list, but it should appear in the top navigation like it does in English

**Note:**

There will be a follow-up for contacts and server removing the translation, but this will take some more time.

| B | A |
| --- | --- |
| <img width="538" height="494" alt="Screenshot From 2025-08-28 22-26-29" src="https://github.com/user-attachments/assets/38a54ab2-dd1f-490f-a58e-bcacf40ed1e2" /> | <img width="538" height="494" alt="Screenshot From 2025-08-28 22-27-39" src="https://github.com/user-attachments/assets/b9e3fa84-68ef-4819-84cc-57558b0286f4" /> |


