### PR TITLE
fix: use untranslated category for grouping contacts

### DIFF
--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -69,7 +69,7 @@
 			<AppNavigationItem
 				v-if="isContactsInteractionEnabled && recentlyContactedContacts && recentlyContactedContacts.contacts.length > 0"
 				id="recentlycontacted"
-				:name="GROUP_RECENTLY_CONTACTED"
+				:name="t('contacts', 'Recently contacted')"
 				:to="{
 					name: 'group',
 					params: { selectedGroup: GROUP_RECENTLY_CONTACTED },

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -19,7 +19,7 @@ export const LIST_SIZE = 60
 // Dynamic default groups
 export const GROUP_ALL_CONTACTS: DefaultGroup = t('contacts', 'All contacts')
 export const GROUP_NO_GROUP_CONTACTS: DefaultGroup = t('contacts', 'Not grouped')
-export const GROUP_RECENTLY_CONTACTED: DefaultGroup = t('contacts', 'Recently contacted')
+export const GROUP_RECENTLY_CONTACTED: DefaultGroup = 'Recently contacted'
 
 // Organization default chart for all contacts
 export const CHART_ALL_CONTACTS: DefaultChart = t('contacts', 'Organization chart')


### PR DESCRIPTION
See https://github.com/nextcloud/contacts/issues/4663 for additional context and steps to reproduce. 

The grouping in contacts is done by the categories attribute. The cards created for recently contacted are using a translated string for the category. This leads to a weird state when a user switched languages inbetween. 

<img width="760" height="322" alt="image" src="https://github.com/user-attachments/assets/5a13527c-1e62-4b8b-b8da-b7f7d087a38c" />


The notable difference in contacts is that the category name is translated, but we are always using "Recently contacted" in the url. 

