### PR TITLE
fix: don't immediately update a vCard when changing the avatar

### DIFF
--- a/src/components/ContactDetails/ContactDetailsAvatar.vue
+++ b/src/components/ContactDetails/ContactDetailsAvatar.vue
@@ -384,8 +384,6 @@ export default {
 				this.contact.photo = `data:${type};base64,${data}`
 			}
 
-			await this.$store.dispatch('updateContact', this.contact)
-
 			await this.loadPhotoUrl()
 
 			await this.reloadBus.emit('reload-avatar', this.contact.key)
@@ -440,7 +438,6 @@ export default {
 		 */
 		removePhoto() {
 			this.contact.vCard.removeAllProperties('photo')
-			this.$store.dispatch('updateContact', this.contact)
 			// somehow the avatarUrl is not unavailable immediately, so we just set undefined
 			this.photoUrl = undefined
 			this.reloadBus.emit('delete-avatar', this.contact.key)


### PR DESCRIPTION
I think this is a leftover from when we allowed to edit the avatar outside of the edit-mode. Now, it is not possible so we don't need to update the contact immediately and can "debounce" the save until the user clicks on the save button.

## How to reproduce?

1. Create a new contact.
2. Add an avatar.
3. Click save

Saving will fail (due to a UID collision).

**After:** Saving works.