### PR TITLE
fix: duplication of address books requests

### DIFF
--- a/src/store/addressbooks.js
+++ b/src/store/addressbooks.js
@@ -25,6 +25,7 @@ const addressbookModel = {
 
 const state = {
 	addressbooks: [],
+	addressbooksFetched: false,
 }
 
 /**
@@ -233,6 +234,10 @@ const actions = {
 	 * @return {object[]} the addressbooks
 	 */
 	async getAddressbooks(context) {
+		if (context.state.addressbooksFetched) {
+			return context.getters.getAddressbooks
+		}
+
 		const addressbooks = await client.addressBookHomes[0]
 			.findAllAddressBooks()
 			.then(addressbooks => {
@@ -245,6 +250,8 @@ const actions = {
 		addressbooks.forEach(addressbook => {
 			context.commit('addAddressbook', addressbook)
 		})
+
+		context.state.addressbooksFetched = true
 
 		return addressbooks
 	},


### PR DESCRIPTION
The problem:
The recipient info feature is causing many requests to the SAB.
It was tested with users who are actually in the SAB and artificial email addresses. Both always cause multiple requests.

When adding/removing recipients, then the component from contacts (in mail) is destroyed/mounted/destroyed/mounted and therefore the beforeMount method is called for each of re-rendering. This will dispatch getAddressbooks with the outcome of adding the same addressbook over and over again to the state.

Solution: Needs a bit of discussion because its not that easy to fix it