### PR TITLE
fix: do not allow to exclude system accounts from the bday calendar

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -695,9 +695,15 @@ export default {
 				: t('contacts', 'Exclude contact from Birthday Calendar')
 		},
 
+		/**
+		 * True if the contact can be excluded from (or added to) the user's birthday calendar
+		 *
+		 * @return {boolean}
+		 */
 		enableToggleBirthdayExclusion() {
-			return parseInt(window.OC.config.version.split('.')[0]) >= 26
-				&& this.localContact?.vCard // Wait until localContact was fetched
+			// Wait until localContact was fetched
+			const isFetched = !!this.localContact?.vCard
+			return isFetched && !this.isInSystemAddressBook
 		},
 
 		/**


### PR DESCRIPTION
Fix #4720 

| Before | After |
| --- | --- |
| <img width="884" height="421" alt="Screenshot_20250917_115915" src="https://github.com/user-attachments/assets/c76a9f18-10dd-4091-a7e9-2d369df7dc47" /> | <img width="826" height="337" alt="Screenshot_20250917_115845" src="https://github.com/user-attachments/assets/d777249b-2939-4dc2-b365-cfd037d244e7" /> |