### PR TITLE
feat(rfcProps): make notes a default prop

### DIFF
--- a/src/models/rfcProps.js
+++ b/src/models/rfcProps.js
@@ -63,7 +63,11 @@ const properties = {
 	note: {
 		readableName: t('contacts', 'Notes'),
 		icon: 'icon-note',
-		primary: false,
+		primary: true,
+		default: true,
+		defaultValue: {
+			value: '',
+		},
 	},
 	url: {
 		multiple: true,


### PR DESCRIPTION
Fix https://github.com/nextcloud/contacts/issues/4613

Now on contact creation notes is there by default.

<img width="709" height="1159" alt="image" src="https://github.com/user-attachments/assets/95f8c8df-c6e1-4677-9466-b367a57e56dd" />
