### PR TITLE
fix(SettingsAddressbook): prevent sharing an addressbook that has been shared with you

### DIFF
--- a/src/components/AppNavigation/Settings/SettingsAddressbook.vue
+++ b/src/components/AppNavigation/Settings/SettingsAddressbook.vue
@@ -23,7 +23,7 @@
 			</div>
 
 			<!-- sharing button -->
-			<Button v-if="!addressbook.readOnly"
+			<Button v-if="!addressbook.readOnly && !isSharedWithMe"
 				v-tooltip.top="sharedWithTooltip"
 				:class="{'addressbook__share--shared': hasShares}"
 				:name="sharedWithTooltip"
@@ -231,9 +231,14 @@ export default {
 		groupsCount() {
 			return this.groups.length
 		},
+
 		principalUrl() {
 			const principalsStore = usePrincipalsStore()
 			return principalsStore.currentUserPrincipal.principalUrl
+		},
+
+		isSharedWithMe() {
+			return this.addressbook.owner !== this.principalUrl
 		},
 	},
 	watch: {


### PR DESCRIPTION
Error that this fixes:

- User A shares addressbook with User B
- User A gives User B write permissions on addressbook
- User B sees a "share" button in the addressbook settings
- User B is not supposed to have that button, and when they click it they get errors