### PR TITLE
fix: improve expand button visibility in OrgChart dark mode

### DIFF
--- a/src/components/OrgChart.vue
+++ b/src/components/OrgChart.vue
@@ -194,10 +194,7 @@ export default {
 
 	.node-button-div {
 		filter: var(--background-invert-if-dark);
-
-		& > div > div {
-			filter: var(--background-invert-if-dark);
-		}
+		background-color: var(--color-main-background) !important;
 	}
 }
 </style>


### PR DESCRIPTION
## Description

**Summary of Changes**
- Updated styles for the expand/collapse button in `OrgChart.vue`.
- Applied `var(--color-main-background)` to ensure proper visibility in dark mode.
- Removed `& div > div` which was causing double inversion of background color.

**Related Issue**
Closes #4755 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] Code follows the project's coding standards
- [x] UI verified in dark mode
- [x] No breaking changes introduced
