### PR TITLE
chore(renovate): remove custom commit message templates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,9 +15,6 @@
 		"dependencies",
 		"3. to review"
 	],
-	"commitMessageAction": "Bump",
-	"commitMessageTopic": "{{depName}}",
-	"commitMessageExtra": "from {{currentVersion}} to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
 	"rangeStrategy": "bump",
 	"rebaseWhen": "conflicted",
 	"ignoreUnstable": false,


### PR DESCRIPTION
They are not used anyway since we use the :semanticCommit preset anyway.