### PR TITLE
fix(proprety-text): only resize text area when the ref is defined

### DIFF
--- a/src/components/Properties/PropertyText.vue
+++ b/src/components/Properties/PropertyText.vue
@@ -209,7 +209,9 @@ export default {
 	},
 
 	mounted() {
-		this.resizeHeight()
+		if (this.propName === 'note') {
+			this.resizeHeight()
+		}
 	},
 
 	methods: {


### PR DESCRIPTION
`this.$refs.textarea` was called even when the `textarea` ref is undefined 