### PR TITLE
Improve filtering contacts, especially for phone numbers

### DIFF
--- a/src/components/ContactsList.vue
+++ b/src/components/ContactsList.vue
@@ -311,7 +311,14 @@ export default {
 		 */
 		matchSearch(contact) {
 			if (this.query.trim() !== '') {
-				return contact.searchData.toString().toLowerCase().search(this.query.trim().toLowerCase()) !== -1
+				try {
+					return contact.searchData.toString().toLowerCase().search(this.query.trim().toLowerCase()) !== -1
+				} catch (e) {
+					if (e instanceof SyntaxError) {
+						// this.query likely is an invalid regex (i.e. just `+`)
+						return contact.searchData.toString().toLowerCase().includes(this.query.trim().toLowerCase())
+					}
+				}
 			}
 			return true
 		},

--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -28,8 +28,6 @@ export const MinimalContactProperties = [
 	'EMAIL', 'UID', 'TEL', 'CATEGORIES', 'FN', 'ORG', 'N', 'X-PHONETIC-FIRST-NAME', 'X-PHONETIC-LAST-NAME', 'X-MANAGERSNAME', 'TITLE', 'NOTE', 'RELATED',
 ].concat(ContactKindProperties)
 
-const SearchIgnoreProperties = ['version', 'prodid', 'uid', 'rev', 'fn']
-
 export default class Contact {
 	/**
 	 * Creates an instance of Contact
@@ -580,19 +578,6 @@ export default class Contact {
 	}
 
 	/**
-	 * Returns phone numbers normalized (i.e. everything but digits, '+' and '#' stripped) joined as string
-	 *
-	 * @return {string}
-	 */
-	get normalizedTels() {
-		if (this.vCard.hasProperty('tel')) {
-			return this.vCard.getAllProperties('tel')
-				.map((x) => x.jCal[3].replace(/[^0-9+#]/g, ''))
-		}
-		return ''
-	}
-
-	/**
 	 * Return an array of formatted properties for the search
 	 *
 	 * @readonly
@@ -600,12 +585,21 @@ export default class Contact {
 	 * @return {string[]}
 	 */
 	get searchData() {
+		const MinimalContactPropertiesLower = MinimalContactProperties.map((prop) => prop.toLowerCase())
 		const filtered = this.jCal[1]
-			.filter((x) => !SearchIgnoreProperties.includes(x[0]))
-			.map((x) => x[3])
-		const nomalizedTels = this.normalizedTels ? ',' + this.normalizedTels : ''
-		// Add normalized phone numbers to search data
-		return filtered + nomalizedTels
+			.filter((x) => MinimalContactPropertiesLower.includes(x[0].toLowerCase()))
+			.map((x) => {
+				if (x[0].toLowerCase() === 'tel') {
+					return this.normalizedTels(x[3])
+				}
+				return x[3].toString()
+			})
+		return filtered
+	}
+
+	// support numbers in weird formats for searching e.g. +49 (0) 123 456-789
+	normalizedTels(number) {
+		return number.replace(/[^0-9+#]/g, '')
 	}
 
 	/**


### PR DESCRIPTION
## Summary

* fix(contact): include phone numbers when getting contacts for address book (Fixes: #3112)
* fix(contact): don't add metadata properties and property names to searchData (Fixes: #1176)
* fix(contact): Add normalized phone numbers to searchData
* fix(ContactsList): don't choke when filtering for `+`

## Screenshots

Before | After
--- | ---
<img width="582" height="502" alt="image" src="https://github.com/user-attachments/assets/e8a8ab67-5674-4d92-a427-aa8d9f900ff1" /> | <img width="582" height="500" alt="image" src="https://github.com/user-attachments/assets/a70f2ca8-9d6e-4d07-8231-b0ad930d8499" />
<img width="582" height="502" alt="image" src="https://github.com/user-attachments/assets/4f14bb89-164c-4b83-b660-602512e11a41" /> | <img width="582" height="502" alt="image" src="https://github.com/user-attachments/assets/01debcb8-775a-4240-92a8-0a2745669e9c" />
<img width="582" height="500" alt="image" src="https://github.com/user-attachments/assets/c5fe0f99-2de8-4c2b-ab7c-4553e0b5c3d7" /> | <img width="582" height="500" alt="image" src="https://github.com/user-attachments/assets/9e98aee0-0d88-4dc2-9e56-d46256a8a92b" />
<img width="584" height="238" alt="image" src="https://github.com/user-attachments/assets/54ff2ee3-098d-4920-b5e1-ce745872be4c" /> | <img width="582" height="500" alt="image" src="https://github.com/user-attachments/assets/20fb6fff-24f0-42e9-bb14-05cc2bb2d2d8" />