### PR TITLE
[stable8.0] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "contacts",
-      "version": "8.0.4",
+      "version": "8.0.5",
       "license": "agpl",
       "dependencies": {
         "@mattkrick/sanitize-svg": "^0.4.1",
@@ -19084,9 +19084,9 @@
       "dev": true
     },
     "node_modules/validator": {
-      "version": "13.15.15",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
-      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "version": "13.15.20",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
+      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -33674,9 +33674,9 @@
       }
     },
     "validator": {
-      "version": "13.15.15",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
-      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A=="
+      "version": "13.15.20",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
+      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw=="
     },
     "vfile": {
       "version": "6.0.3",


### PR DESCRIPTION
# Audit report

This audit fix resolves 1 of the total 3 vulnerabilities found in your project.

## Updated dependencies
* [validator](#user-content-validator)
## Fixed vulnerabilities

### `validator` <a href="#user-content-validator" id="validator">#</a>
* validator.js has a URL validation bypass vulnerability in its isURL function
* Severity: **moderate** (CVSS 6.1)
* Reference: [https://github.com/advisories/GHSA-9965-vmph-33xx](https://github.com/advisories/GHSA-9965-vmph-33xx)
* Affected versions: <13.15.20
* Package usage:
  * `node_modules/validator`