### PR TITLE
fix(l10n): Fix plural form

### DIFF
--- a/lib/Controller/ImportController.php
+++ b/lib/Controller/ImportController.php
@@ -172,13 +172,13 @@ class ImportController extends OCSController {
 
 		if ($skipped === 0) {
 			$message = $this->l10n->n(
-				'Imported 1 contact',
+				'Imported %n contact',
 				'Imported %n contacts',
 				count($imported),
 			);
 		} else {
 			$message = $this->l10n->n(
-				'Imported 1 contact (skipped %d)',
+				'Imported %n contact (skipped %d)',
 				'Imported %n contacts (skipped %d)',
 				count($imported),
 				[$skipped],


### PR DESCRIPTION
Reported at Transifex

Comment at Transifex:
"In Serbian, this plural form is used for 1, 21, 31, 101... So it is wrong to have it fixed only on 1. Here is the definition of the 3 plural forms for Serbian language: Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2); This issue holds true for all plural original strings that are fixed to 1, not only to this one."