### PR TITLE
Fix checkbox radio switch in circle details

### DIFF
--- a/src/components/CircleDetails/CircleSettings.vue
+++ b/src/components/CircleDetails/CircleSettings.vue
@@ -15,11 +15,11 @@
 					<NcCheckboxRadioSwitch
 						v-for="(label, config) in configs"
 						:key="'circle-config' + config"
-						:checked="isChecked(config)"
+						:model-value="isChecked(config)"
 						:loading="loading === config"
 						:disabled="loading !== false"
 						wrapper-element="li"
-						@update:checked="onChange(config, $event)">
+						@update:model-value="onChange(config, $event)">
 						{{ label }}
 					</NcCheckboxRadioSwitch>
 				</ul>


### PR DESCRIPTION
This change adapts the events for CheckboxRadioSwitch from @nextcloud/vue in version 9.x.x. I'm not sure if all broken interfaces are fixed, but at least the checkboxes in the CircleDetails component work again.

This fixes https://github.com/nextcloud/contacts/issues/4854.