### PR TITLE
[stable 7.3] fix(settings): add label for sorting

### DIFF
--- a/src/components/AppNavigation/Settings/SettingsSortContacts.vue
+++ b/src/components/AppNavigation/Settings/SettingsSortContacts.vue
@@ -11,7 +11,7 @@
 			:searchable="false"
 			:allow-empty="false"
 			:options="options"
-			:custom-label="formatSortByLabel"
+			:input-label="t('contacts', 'Sort contacts by')"
 			track-by="key"
 			label="label"
 			@input="sortContacts" />
@@ -74,9 +74,6 @@ export default {
 			this.$store.commit('setOrder', key)
 			this.$store.commit('sortContacts')
 			localStorage.setItem('orderKey', key)
-		},
-		formatSortByLabel(option) {
-			return t('contacts', 'Sort by {sorting}', { sorting: option.label })
 		},
 	},
 }


### PR DESCRIPTION
ref #4884

| b | a |
|--------|--------|
|<img width="909" height="816" alt="image" src="https://github.com/user-attachments/assets/97b19cdf-9afc-4d08-8174-ee29031939cb" /> | <img width="909" height="816" alt="image" src="https://github.com/user-attachments/assets/3e98ae9d-4672-4024-96d3-d5863965eb3a" /> | 