### PR TITLE
feat: Create invitation links for join to team

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -10,6 +10,7 @@ return [
 		['name' => 'contacts#direct', 'url' => '/direct/contact/{contact}', 'verb' => 'GET'],
 		['name' => 'contacts#directcircle', 'url' => '/direct/circle/{singleId}', 'verb' => 'GET'],
 		['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
+		['name' => 'page#joinInvitation', 'url' => '/join/{invitationCode}', 'verb' => 'GET'],
 		['name' => 'page#index', 'url' => '/{group}', 'verb' => 'GET', 'postfix' => 'group'],
 		['name' => 'page#index', 'url' => '/{group}/{contact}', 'verb' => 'GET', 'postfix' => 'group.contact'],
 		['name' => 'social_api#update_contact',  'url' => '/api/v1/social/avatar/{network}/{addressbookId}/{contactId}', 'verb' => 'PUT'],

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -81,4 +81,17 @@ class PageController extends Controller {
 
 		return new TemplateResponse(Application::APP_ID, 'main');
 	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function joinInvitation(string $invitationCode): TemplateResponse {
+		$this->initialState->provideInitialState('invitationCode', $invitationCode);
+
+		Util::addStyle(Application::APP_ID, 'contacts-join-invitation');
+		Util::addScript(Application::APP_ID, 'contacts-join-invitation');
+
+		return new TemplateResponse(Application::APP_ID, 'join-invitation');
+	}
 }

--- a/src/components/CircleDetails/CircleConfigs.vue
+++ b/src/components/CircleDetails/CircleConfigs.vue
@@ -5,40 +5,26 @@
 
 <template>
 	<ul>
-		<li v-for="(configs, title) in PUBLIC_CIRCLE_CONFIG" :key="title" class="circle-config">
+		<li v-for="(config, title) in PUBLIC_CIRCLE_CONFIG" :key="title" class="circle-config">
 			<ContentHeading class="circle-config__title">
 				{{ title }}
 			</ContentHeading>
 
-			<ul class="circle-config__list">
-				<CheckboxRadioSwitch
-					v-for="(label, config) in configs"
-					:key="'circle-config' + config"
-					:model-value="isChecked(config)"
-					:loading="loading === config"
-					:disabled="loading !== false"
-					wrapper-element="li"
-					@update:model-value="onChange(config, $event)">
-					{{ label }}
-				</CheckboxRadioSwitch>
-			</ul>
+			<component :is="config.component" v-bind="config.props" :circle="circle" />
 		</li>
 	</ul>
 </template>
 
 <script>
-import { showError } from '@nextcloud/dialogs'
-import { NcCheckboxRadioSwitch as CheckboxRadioSwitch } from '@nextcloud/vue'
+import { markRaw } from 'vue'
 import ContentHeading from './ContentHeading.vue'
 import Circle from '../../models/circle.ts'
 import { PUBLIC_CIRCLE_CONFIG } from '../../models/constants.ts'
-import { CircleEdit, editCircle } from '../../services/circles.ts'
 
 export default {
 	name: 'CircleConfigs',
 
 	components: {
-		CheckboxRadioSwitch,
 		ContentHeading,
 	},
 
@@ -51,45 +37,8 @@ export default {
 
 	data() {
 		return {
-			PUBLIC_CIRCLE_CONFIG,
-
-			loading: false,
+			PUBLIC_CIRCLE_CONFIG: markRaw(PUBLIC_CIRCLE_CONFIG),
 		}
-	},
-
-	methods: {
-		isChecked(config) {
-			return (this.circle.config & config) !== 0
-		},
-
-		/**
-		 * On toggle, add or remove the config bitwise
-		 *
-		 * @param {CircleConfig} config the circle config to manage
-		 * @param {boolean} checked checked or not
-		 */
-		async onChange(config, checked) {
-			this.logger.debug(`Circle config ${config} is set to ${checked}`)
-
-			this.loading = config
-			const prevConfig = this.circle.config
-			if (checked) {
-				config = prevConfig | config
-			} else {
-				config = prevConfig & ~config
-			}
-
-			try {
-				const circleData = await editCircle(this.circle.id, CircleEdit.Config, config)
-				// eslint-disable-next-line vue/no-mutating-props
-				this.circle.config = circleData.config
-			} catch (error) {
-				console.error('Unable to edit circle config', prevConfig, config, error)
-				showError(t('contacts', 'An error happened during the config change'))
-			} finally {
-				this.loading = false
-			}
-		},
 	},
 }
 </script>

--- a/src/components/CircleDetails/CircleConfigs/CircleConfigCheckboxesList.vue
+++ b/src/components/CircleDetails/CircleConfigs/CircleConfigCheckboxesList.vue
@@ -1,0 +1,88 @@
+<!--
+  - SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<ul class="circle-config__list">
+		<NcCheckboxRadioSwitch
+			v-for="(label, config) in configs"
+			:key="'circle-config' + config"
+			:model-value="isChecked(config)"
+			:loading="loading === config"
+			:disabled="loading !== false"
+			wrapper-element="li"
+			@update:model-value="onChange(config, $event)">
+			{{ label }}
+		</NcCheckboxRadioSwitch>
+	</ul>
+</template>
+
+<script>
+import { showError } from '@nextcloud/dialogs'
+import { t } from '@nextcloud/l10n'
+import { NcCheckboxRadioSwitch } from '@nextcloud/vue'
+import Circle from '../../../models/circle.ts'
+import { CircleEdit, editCircle } from '../../../services/circles.ts'
+
+export default {
+	name: 'CircleConfigCheckboxesList',
+
+	components: {
+		NcCheckboxRadioSwitch,
+	},
+
+	props: {
+		circle: {
+			type: Circle,
+			required: true,
+		},
+
+		configs: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			loading: false,
+		}
+	},
+
+	methods: {
+		isChecked(config) {
+			return (this.circle.config & config) !== 0
+		},
+
+		/**
+		 * On toggle, add or remove the config bitwise
+		 *
+		 * @param {CircleConfig} config the circle config to manage
+		 * @param {boolean} checked checked or not
+		 */
+		async onChange(config, checked) {
+			this.logger.debug(`Circle config ${config} is set to ${checked}`)
+
+			this.loading = config
+			const prevConfig = this.circle.config
+			if (checked) {
+				config = prevConfig | config
+			} else {
+				config = prevConfig & ~config
+			}
+
+			try {
+				const circleData = await editCircle(this.circle.id, CircleEdit.Config, config)
+				// eslint-disable-next-line vue/no-mutating-props
+				this.circle.config = circleData.config
+			} catch (error) {
+				console.error('Unable to edit circle config', prevConfig, config, error)
+				showError(t('contacts', 'An error happened during the config change'))
+			} finally {
+				this.loading = false
+			}
+		},
+	},
+}
+</script>

--- a/src/components/CircleDetails/CircleConfigs/CircleConfigInvitationLink.vue
+++ b/src/components/CircleDetails/CircleConfigs/CircleConfigInvitationLink.vue
@@ -1,0 +1,119 @@
+<!--
+  - SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcActions :inline="3" force-name variant="tertiary">
+		<NcActionButton
+			v-if="!invitationUrl"
+			@click="createInvitationLink()">
+			<template #icon>
+				<LinkPlus :size="20" />
+			</template>
+			{{ t('contacts', 'Create link') }}
+		</NcActionButton>
+		<template v-else>
+			<NcActionLink
+				:href="invitationUrl"
+				:icon="copyLinkIcon"
+				@click.stop.prevent="copyToClipboard(invitationUrl)">
+				{{ copyButtonText }}
+			</NcActionLink>
+
+			<NcActionButton
+				@click="confirm(
+					t('contacts', 'This action will make it impossible to join the team using the current link. Do we really want to change the link?'),
+					() => createInvitationLink(),
+				)">
+				<template #icon>
+					<Autorenew :size="20" />
+				</template>
+				{{ t('contacts', 'Reset link') }}
+			</NcActionButton>
+
+			<NcActionButton
+				@click="confirm(
+					t('contacts', 'This action will make it impossible to join the team using the current link. Do we really want to delete the link?'),
+					() => revokeInvitationLink(),
+				)">
+				<template #icon>
+					<LinkOff :size="20" />
+				</template>
+				{{ t('contacts', 'Reject link') }}
+			</NcActionButton>
+		</template>
+	</NcActions>
+</template>
+
+<script>
+import { generateUrl, getBaseUrl } from '@nextcloud/router'
+import { NcActionButton, NcActionLink, NcActions } from '@nextcloud/vue'
+import Autorenew from 'vue-material-design-icons/Autorenew.vue'
+import LinkOff from 'vue-material-design-icons/LinkOff.vue'
+import LinkPlus from 'vue-material-design-icons/LinkPlus.vue'
+import CopyToClipboardMixin from '../../../mixins/CopyToClipboardMixin.js'
+import Circle from '../../../models/circle.ts'
+
+export default {
+	name: 'InvitationLink',
+	components: {
+		LinkOff,
+		Autorenew,
+		LinkPlus,
+		NcActions,
+		NcActionLink,
+		NcActionButton,
+	},
+
+	mixins: [CopyToClipboardMixin],
+	props: {
+		circle: {
+			type: Circle,
+			required: true,
+		},
+	},
+
+	computed: {
+		invitationUrl() {
+			if (!this.circle.invitationCode) {
+				return null
+			}
+
+			return getBaseUrl() + generateUrl(
+				'apps/contacts/join/{invitationCode}',
+				{ invitationCode: this.circle.invitationCode.match(/.{1,4}/g).join('-') },
+			)
+		},
+
+		copyButtonText() {
+			if (this.copied) {
+				return this.copySuccess
+					? t('contacts', 'Copied')
+					: t('contacts', 'Could not copy')
+			}
+			return t('contacts', 'Copy link')
+		},
+	},
+
+	methods: {
+		async createInvitationLink() {
+			const circleId = this.circle.id
+			await this.$store.dispatch('createInvitationLink', { circleId })
+
+			await this.copyToClipboard(this.invitationUrl)
+		},
+
+		async revokeInvitationLink() {
+			const circleId = this.circle.id
+			await this.$store.dispatch('revokeInvitationLink', { circleId })
+		},
+
+		confirm(message, action) {
+			if (window.confirm(message)) {
+				action()
+			}
+		},
+	},
+}
+</script>

--- a/src/components/CircleDetails/CircleSettings.vue
+++ b/src/components/CircleDetails/CircleSettings.vue
@@ -6,23 +6,12 @@
 <template>
 	<div class="circle-settings">
 		<ul>
-			<li v-for="(configs, title) in PUBLIC_CIRCLE_CONFIG" :key="title" class="circle-config">
+			<li v-for="(config, title) in PUBLIC_CIRCLE_CONFIG" :key="title" class="circle-config">
 				<ContentHeading class="circle-config__title">
 					{{ title }}
 				</ContentHeading>
 
-				<ul class="circle-config__list">
-					<NcCheckboxRadioSwitch
-						v-for="(label, config) in configs"
-						:key="'circle-config' + config"
-						:model-value="isChecked(config)"
-						:loading="loading === config"
-						:disabled="loading !== false"
-						wrapper-element="li"
-						@update:model-value="onChange(Number(config), $event)">
-						{{ label }}
-					</NcCheckboxRadioSwitch>
-				</ul>
+				<component :is="config.component" v-bind="config.props" :circle="circle" />
 			</li>
 		</ul>
 
@@ -54,18 +43,14 @@
 </template>
 
 <script lang="ts">
-import { showError } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
-import { defineComponent } from 'vue'
+import { defineComponent, markRaw } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
-import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import IconLogout from 'vue-material-design-icons/Logout.vue'
 import IconDelete from 'vue-material-design-icons/TrashCanOutline.vue'
 import CirclePasswordSettings from './CirclePasswordSettings.vue'
 import ContentHeading from './ContentHeading.vue'
-import CircleActionsMixin from '../../mixins/CircleActionsMixin.js'
-import { CircleConfigs, PUBLIC_CIRCLE_CONFIG } from '../../models/constants.ts'
-import { CircleEdit, editCircle } from '../../services/circles.ts'
+import { PUBLIC_CIRCLE_CONFIG } from '../../models/constants.ts'
 
 export default defineComponent({
 	name: 'CircleSettings',
@@ -75,10 +60,7 @@ export default defineComponent({
 		IconDelete,
 		IconLogout,
 		NcButton,
-		NcCheckboxRadioSwitch,
 	},
-
-	mixins: [CircleActionsMixin],
 
 	props: {
 		circle: {
@@ -87,60 +69,17 @@ export default defineComponent({
 		},
 	},
 
-	emits: ['leave', 'delete', 'close-settings-popover'],
+	emits: ['leave', 'delete'],
 	setup() {
 		return { t }
 	},
 
 	data() {
 		return {
-			PUBLIC_CIRCLE_CONFIG,
-			loading: false,
+			PUBLIC_CIRCLE_CONFIG: markRaw(PUBLIC_CIRCLE_CONFIG),
 		}
 	},
 
-	methods: {
-		isChecked(config) {
-			return (this.circle.config & config) !== 0
-		},
-
-		/**
-		 * On toggle, add or remove the config bitwise
-		 *
-		 * @param config - The circle config to manage
-		 * @param checked - Checked or not
-		 */
-		async onChange(config: number, checked: boolean) {
-			this.logger.debug(`Circle config ${config} is set to ${checked}`)
-
-			if (checked && config === CircleConfigs.FEDERATED) {
-				this.$emit('close-settings-popover')
-				const confirmed = await this.confirmEnableFederationForCircle()
-				if (!confirmed) {
-					return
-				}
-			}
-
-			this.loading = config
-			const prevConfig = this.circle.config
-			if (checked) {
-				config = prevConfig | config
-			} else {
-				config = prevConfig & ~config
-			}
-
-			try {
-				const circleData = await editCircle(this.circle.id, CircleEdit.Config, config)
-				// eslint-disable-next-line vue/no-mutating-props
-				this.circle.config = circleData.config
-			} catch (error) {
-				this.logger.error('Unable to edit circle config', { prevConfig, config, error })
-				showError(t('contacts', 'An error happened during the config change'))
-			} finally {
-				this.loading = false
-			}
-		},
-	},
 })
 </script>
 
@@ -150,7 +89,7 @@ export default defineComponent({
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
-	max-width: 320px;
+	max-width: 400px;
 }
 
 .circle-config {

--- a/src/components/JoinInvitation.vue
+++ b/src/components/JoinInvitation.vue
@@ -1,0 +1,144 @@
+<!--
+  - SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="wrapper">
+		<NcEmptyContent v-if="membershipStatus === 'LOADING'" :name="t('contacts', 'Loading')">
+			<template #icon>
+				<NcLoadingIcon />
+			</template>
+		</NcEmptyContent>
+
+		<NcEmptyContent
+			v-else-if="membershipStatus === 'MEMBER'"
+			:name="t('contacts', 'Invitation to the circle')">
+			<template #description>
+				<div
+					v-html="t('contacts', 'You are already a member of the circle <b>{circleName}</b>.', { circleName })" />
+			</template>
+			<template #action>
+				<NcButton :href="circleUrl">
+					{{ t('contacts', 'Go to circle page') }}
+				</NcButton>
+			</template>
+		</NcEmptyContent>
+
+		<NcEmptyContent
+			v-else-if="membershipStatus === 'REQUESTED_MEMBERSHIP'"
+			:name="t('contacts', 'Invitation to the circle')">
+			<template #description>
+				<div
+					v-html="t('contacts', 'You are already requested join to the circle <b>{circleName}</b>.', { circleName })" />
+			</template>
+			<template #action>
+				<NcButton :href="homeUrl">
+					{{ t('contacts', 'Go back') }}
+				</NcButton>
+			</template>
+		</NcEmptyContent>
+
+		<NcEmptyContent
+			v-else-if="membershipStatus === 'NOT_A_MEMBER'"
+			:name="t('contacts', 'Invitation to the circle')">
+			<template #description>
+				<div
+					v-html="t('contacts', 'Do you want to join to the circle <b>{circleName}</b>?', { circleName })" />
+			</template>
+			<template #action>
+				<NcButton variant="primary" @click="acceptInvitation">
+					{{ t('contacts', 'Join') }}
+				</NcButton>
+				<NcButton :href="homeUrl">
+					{{ t('contacts', 'Go back') }}
+				</NcButton>
+			</template>
+		</NcEmptyContent>
+
+		<NcEmptyContent
+			v-else-if="membershipStatus === 'INVALID'"
+			:name="t('contacts', 'Invalid invitation link')">
+			<template #description>
+				{{ t('contacts', 'This invitation link is not valid or has expired.') }}
+			</template>
+			<template #action>
+				<NcButton :href="homeUrl">
+					{{ t('contacts', 'Go back') }}
+				</NcButton>
+			</template>
+		</NcEmptyContent>
+	</div>
+</template>
+
+<script>
+import { showSuccess } from '@nextcloud/dialogs'
+import { loadState } from '@nextcloud/initial-state'
+import { t } from '@nextcloud/l10n'
+import { generateUrl, getBaseUrl } from '@nextcloud/router'
+import { NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import { getInvitation, joinInvitation } from '../services/circles.ts'
+
+export default {
+	name: 'JoinInvitation',
+	components: { NcButton, NcEmptyContent, NcLoadingIcon },
+	data() {
+		const invitationCode = loadState('contacts', 'invitationCode')
+
+		return {
+			invitationCode,
+			circleId: '',
+			circleName: '',
+			membershipStatus: 'LOADING',
+			homeUrl: generateUrl('/apps/contacts'),
+		}
+	},
+
+	computed: {
+		circleUrl() {
+			return generateUrl('/apps/contacts/circle/{circleId}', { circleId: this.circleId })
+		},
+	},
+
+	async mounted() {
+		try {
+			const invitation = await getInvitation(this.invitationCode)
+
+			this.circleId = invitation.circleId
+			this.circleName = invitation.circleName
+			this.membershipStatus = invitation.membershipStatus
+		} catch (error) {
+			this.membershipStatus = 'INVALID'
+		}
+	},
+
+	methods: {
+		t,
+
+		async acceptInvitation() {
+			await joinInvitation(this.invitationCode)
+
+			showSuccess(t('contacts', 'You have joined to the circle {circleName}.', { circleName: this.circleName }))
+
+			window.setTimeout(() => {
+				document.location.href = this.circleUrl
+			}, 500)
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.wrapper {
+	background-color: var(--color-main-background);
+	margin: 100px auto;
+	width: fit-content;
+	padding: 20px;
+}
+
+:deep(.empty-content__action) {
+	display: flex;
+	align-items: center;
+	gap: calc(var(--default-grid-baseline) * 2);
+}
+</style>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare module '*.vue' {
+	import type { DefineComponent } from 'vue'
+	const component: DefineComponent<object, object, any>
+	export default component
+}

--- a/src/join-invitation.js
+++ b/src/join-invitation.js
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createApp } from 'vue'
+import JoinInvitation from './components/JoinInvitation.vue'
+import LegacyGlobalMixin from './mixins/LegacyGlobalMixin.js'
+
+import 'vite/modulepreload-polyfill'
+
+document.addEventListener('DOMContentLoaded', main)
+
+function main() {
+	const app = createApp(JoinInvitation)
+	app.mixin(LegacyGlobalMixin)
+	app.mount('#join-invitation')
+}

--- a/src/models/circle.ts
+++ b/src/models/circle.ts
@@ -299,6 +299,14 @@ export default class Circle {
 		|| (this.config & CircleConfigs.FRIEND) !== 0
 	}
 
+	get invitationCode() {
+		return this._data.invitationCode
+	}
+
+	set invitationCode(invitationCode: string) {
+		this._data.invitationCode = invitationCode
+	}
+
 	// PARAMS ---------------------------------------------
 	/**
 	 * Vue router param

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -6,6 +6,8 @@
 
 import { translate as t } from '@nextcloud/l10n'
 import { ShareType } from '@nextcloud/sharing'
+import CircleConfigCheckboxesList from '../components/CircleDetails/CircleConfigs/CircleConfigCheckboxesList.vue'
+import CircleConfigInvitationLink from '../components/CircleDetails/CircleConfigs/CircleConfigInvitationLink.vue'
 
 export type DefaultGroup = string
 export type DefaultChart = string
@@ -92,16 +94,32 @@ export const CIRCLES_MEMBER_LEVELS = {
 // Available circle configs in the circle details view
 export const PUBLIC_CIRCLE_CONFIG = {
 	[t('contacts', 'Invites')]: {
-		[CIRCLE_CONFIG_OPEN]: t('contacts', 'Anyone can request membership'),
-		[CIRCLE_CONFIG_INVITE]: t('contacts', 'Members need to accept invitation'),
-		[CIRCLE_CONFIG_REQUEST]: t('contacts', 'Memberships must be confirmed/accepted by a Moderator (requires "Anyone can request membership")'),
-		[CIRCLE_CONFIG_FRIEND]: t('contacts', 'Members can also invite'),
+		component: CircleConfigCheckboxesList,
+		props: {
+			configs: {
+				[CIRCLE_CONFIG_OPEN]: t('contacts', 'Anyone can request membership'),
+				[CIRCLE_CONFIG_INVITE]: t('contacts', 'Members need to accept invitation'),
+				[CIRCLE_CONFIG_REQUEST]: t('contacts', 'Memberships must be confirmed/accepted by a Moderator (requires "Anyone can request membership")'),
+				[CIRCLE_CONFIG_FRIEND]: t('contacts', 'Members can also invite'),
+			},
+		},
+	},
+
+	[t('contacts', 'Invitation links')]: {
+		component: CircleConfigInvitationLink,
+		props: {},
 	},
 
 	[t('contacts', 'Membership')]: {
-		// TODO: implement backend
-		// [CIRCLE_CONFIG_CIRCLE_INVITE]: t('contacts', 'Team must confirm when invited in another circle'),
-		[CIRCLE_CONFIG_ROOT]: t('contacts', 'Prevent teams from being a member of another team'),
+		component: CircleConfigCheckboxesList,
+		props: {
+			configs: {
+
+				// TODO: implement backend
+				// [CIRCLE_CONFIG_CIRCLE_INVITE]: t('contacts', 'Team must confirm when invited in another circle'),
+				[CIRCLE_CONFIG_ROOT]: t('contacts', 'Prevent teams from being a member of another team'),
+			},
+		},
 	},
 
 	[t('contacts', 'Federation')]: {
@@ -109,7 +127,12 @@ export const PUBLIC_CIRCLE_CONFIG = {
 	},
 
 	[t('contacts', 'Privacy')]: {
-		[CIRCLE_CONFIG_VISIBLE]: t('contacts', 'Visible to everyone'),
+		component: CircleConfigCheckboxesList,
+		props: {
+			configs: {
+				[CIRCLE_CONFIG_VISIBLE]: t('contacts', 'Visible to everyone'),
+			},
+		},
 	},
 }
 

--- a/src/services/circles.ts
+++ b/src/services/circles.ts
@@ -48,6 +48,28 @@ export async function getCircle(circleId: string) {
 }
 
 /**
+ * Get a specific invitation
+ *
+ * @param invitationCode
+ * @return
+ */
+export async function getInvitation(invitationCode: string) {
+	const response = await axios.get(generateOcsUrl('apps/circles/invitations/{invitationCode}', { invitationCode }))
+	return response.data.ocs.data
+}
+
+/**
+ * Join to a circle using an invitation
+ *
+ * @param invitationCode
+ * @return
+ */
+export async function joinInvitation(invitationCode: string) {
+	const response = await axios.post(generateOcsUrl('apps/circles/invitations/{invitationCode}', { invitationCode }))
+	return response.data.ocs.data
+}
+
+/**
  * Create a new circle
  *
  * @param name the circle name
@@ -195,5 +217,14 @@ export async function editCircleSetting(circleId: string, setting: CircleSetting
 		generateOcsUrl('apps/circles/circles/{circleId}/setting', { circleId }),
 		setting,
 	)
+	return response.data.ocs.data
+}
+
+export async function createInvitationLink(circleId: string) {
+	const response = await axios.put(generateOcsUrl('apps/circles/circles/{circleId}/invitation', { circleId }))
+	return response.data.ocs.data
+}
+export async function revokeInvitationLink(circleId: string) {
+	const response = await axios.delete(generateOcsUrl('apps/circles/circles/{circleId}/invitation', { circleId }))
 	return response.data.ocs.data
 }

--- a/src/store/circles.js
+++ b/src/store/circles.js
@@ -10,6 +10,7 @@ import {
 	acceptMember,
 	addMembers,
 	createCircle,
+	createInvitationLink,
 	deleteCircle,
 	deleteMember,
 	editCircleSetting,
@@ -17,6 +18,7 @@ import {
 	getCircleMembers,
 	getCircles,
 	leaveCircle,
+	revokeInvitationLink,
 } from '../services/circles.ts'
 import logger from '../services/logger.js'
 
@@ -90,6 +92,10 @@ const mutations = {
 
 	setCircleSettings(state, { circleId, settings }) {
 		state.circles[circleId]._data.settings = settings
+	},
+
+	setInvitationCode(state, { circleId, invitationCode }) {
+		state.circles[circleId]._data.invitationCode = invitationCode
 	},
 
 	/**
@@ -310,6 +316,21 @@ const actions = {
 		})
 	},
 
+	async createInvitationLink(context, { circleId }) {
+		const { invitationCode } = await createInvitationLink(circleId)
+		await context.commit('setInvitationCode', {
+			circleId,
+			invitationCode,
+		})
+	},
+
+	async revokeInvitationLink(context, { circleId }) {
+		const { invitationCode } = await revokeInvitationLink(circleId)
+		await context.commit('setInvitationCode', {
+			circleId,
+			invitationCode,
+		})
+	},
 }
 
 export default { state, mutations, getters, actions }

--- a/templates/join-invitation.php
+++ b/templates/join-invitation.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2015-2016 ownCloud, Inc.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+?>
+
+<div id="join-invitation" style="width: 100%;"></div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,7 @@ export default createAppConfig({
 	'main': path.join(__dirname, 'src', 'main.js'),
 	'files-action': path.join(__dirname, 'src', 'files-action.js'),
 	'admin-settings': path.join(__dirname, 'src', 'admin-settings.js'),
+	'join-invitation': path.join(__dirname, 'src', 'join-invitation.js'),
 	'oca': path.join(__dirname, 'src', 'oca.ts'),
 }, {
 	inlineCSS: false,


### PR DESCRIPTION
This PR adds possibility to generate invitation link (even for completely hidden/closed Circles). Any user is able to join to the Circle by opening this link.

## Preview
### Invitation link management
<img width="300" alt="image" src="https://github.com/user-attachments/assets/860774d8-ba2d-40ab-8e25-11d2a2c6ac7f" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/26f9e642-c772-4a9c-ad48-cf2d687c1335" />

### Invitation link opened
<img width="300" alt="image" src="https://github.com/user-attachments/assets/43a9b082-a5fc-443a-a951-78c5edba79af" />

### Invitation link opened when user already joined to a Circle
<img width="300" alt="image" src="https://github.com/user-attachments/assets/06a5f1e7-483d-44ef-97f2-6a8e5724b652" />

### Invitation link opened when user already requested join to a Circle
<img width="300" alt="image" src="https://github.com/user-attachments/assets/fd85f40d-18d6-4874-8bf2-96d2c0c5597a" />


## Dependencies
- has to be merged after https://github.com/nextcloud/circles/pull/2254
