### PR TITLE
[stable8.2] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16028,21 +16028,6 @@
         }
       }
     },
-    "node_modules/rollup-plugin-license/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/rollup-plugin-node-externals": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-8.0.1.tgz",
@@ -18256,9 +18241,9 @@
       "dev": true
     },
     "node_modules/validator": {
-      "version": "13.15.20",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
-      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw==",
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -30151,14 +30136,6 @@
           "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
           "dev": true,
           "requires": {}
-        },
-        "picomatch": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-          "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         }
       }
     },
@@ -31675,9 +31652,9 @@
       }
     },
     "validator": {
-      "version": "13.15.20",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
-      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw=="
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw=="
     },
     "vfile": {
       "version": "6.0.3",


### PR DESCRIPTION
# Audit report

This audit fix resolves 1 of the total 1 vulnerabilities found in your project.

## Updated dependencies
* [validator](#user-content-validator)
## Fixed vulnerabilities

### `validator` <a href="#user-content-validator" id="validator">#</a>
* Validator is Vulnerable to Incomplete Filtering of One or More Instances of Special Elements
* Severity: **high** (CVSS 7.5)
* Reference: [https://github.com/advisories/GHSA-vghf-hv5q-vc2g](https://github.com/advisories/GHSA-vghf-hv5q-vc2g)
* Affected versions: <13.15.22
* Package usage:
  * `node_modules/validator`