### PR TITLE
fix: show address book in read only mode

### DIFF
--- a/src/components/Properties/PropertySelect.vue
+++ b/src/components/Properties/PropertySelect.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<div v-if="propModel && showProperty && !isSingleOption" class="property">
+	<div v-if="propModel && showProperty && (!isSingleOption || isReadOnly)" class="property">
 		<!-- title if first element -->
 		<PropertyTitle
 			v-if="isFirstProperty && propModel.icon"


### PR DESCRIPTION
### Issue
- When you have a personal address book and a system address book there is no way to know which address book the contact is in because the address book property is not visible

### Resolution
- Always show which address book the contact is in, when is ready only view and hide it in edit mode if there is only one usable address book