### PR TITLE
fix: wrong address book displayed on details view

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -676,7 +676,7 @@ export default defineComponent({
 		 * @return {string}
 		 */
 		addressbook() {
-			return this.lastUsedAddressBook?.id || this.contact.addressbook.id
+			return this.contact?.addressbook?.id || this.lastUsedAddressBook?.id
 		},
 
 		/**


### PR DESCRIPTION
### Summary
- Resolves: https://github.com/nextcloud/contacts/issues/4890
- Modified address book display logic to show the correct address book