### PR TITLE
fix(a11y): turn teams description into a list item

### DIFF
--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -172,9 +172,9 @@
 						@click="onToggleCircles" />
 				</template>
 
-				<p class="app-navigation__circle-desc">
+				<li class="app-navigation__circle-desc">
 					{{ CIRCLE_DESC }}
-				</p>
+				</li>
 			</template>
 		</template>
 


### PR DESCRIPTION
ref #4495
<img width="1307" height="582" alt="image" src="https://github.com/user-attachments/assets/03e3ad15-fbbb-4da3-a454-3f5cc87c06c7" />
