### PR TITLE
fix(a11y): switch contacts settings to a button and preserve styling

### DIFF
--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -182,14 +182,16 @@
 
 		<template #footer>
 			<div class="contacts-settings">
-				<AppNavigationItem
+				<NcButton
 					:aria-label="t('contacts', 'Open the contacts app settings')"
-					:name="CONTACTS_SETTINGS"
+					variant="tertiary"
+					:wide="true"
 					@click="showContactsSettings">
 					<template #icon>
 						<Cog :size="20" />
 					</template>
-				</AppNavigationItem>
+					{{ CONTACTS_SETTINGS }}
+				</NcButton>
 			</div>
 		</template>
 		<ContactsSettings v-model:open="showSettings" />
@@ -207,6 +209,7 @@ import {
 	NcAppNavigationItem as AppNavigationItem,
 	NcLoadingIcon as IconLoading,
 	NcActionButton,
+	NcButton,
 	NcCounterBubble,
 } from '@nextcloud/vue'
 import { mapStores } from 'pinia'
@@ -253,6 +256,7 @@ export default {
 		IconLoading,
 		IconRecentlyContacted,
 		NewCircleIntro,
+		NcButton,
 	},
 
 	mixins: [RouterMixin],
@@ -551,5 +555,9 @@ $caption-padding: 22px;
 .contacts-settings-button {
 	width: 100%;
 	justify-content: start !important;
+}
+
+:deep(.button-vue__wrapper){
+	justify-content: flex-start !important;
 }
 </style>


### PR DESCRIPTION
ref #4495
the button is not an `AppNavigationItem`as it's a footer item, aka not inside the 'AppNavigation' 's `ul` 
the change also aligns with the given sample [here](https://nextcloud-vue-components.netlify.app/#/Components/App%20containers/NcAppContent?id=ncappnavigation)
<img width="1307" height="454" alt="image" src="https://github.com/user-attachments/assets/28e1e0a2-43f6-4ea2-bf24-efffeae9f348" />

