### PR TITLE
fix(orgchart): revive node highlighting

### DIFF
--- a/src/components/OrgChart.vue
+++ b/src/components/OrgChart.vue
@@ -159,9 +159,9 @@ export default {
 					}
 				})
 				.onNodeClick((d) => {
-					if (!this.chartReference.data().filter((item) => item.nodeId === d)[0]._upToTheRootHighlighted) {
+					if (!this.chartReference.data().filter((item) => item.nodeId === d.id)[0]?._upToTheRootHighlighted) {
 						this.chartReference.clearHighlighting()
-						this.chartReference.setUpToTheRootHighlighted(d).render()
+						this.chartReference.setUpToTheRootHighlighted(d.id).render()
 					} else {
 						this.chartReference.clearHighlighting()
 					}


### PR DESCRIPTION
How to test: 
1. checkout main 
2. open org chart 
3. click on a node 
4. see console 
5. checkout this branch 
6. test again 
<img width="675" height="832" alt="image" src="https://github.com/user-attachments/assets/b4ee5833-8f41-4d6a-9113-fa6aeb730096" />
