### PR TITLE
fix: rev timestamp on contact update

### DIFF
--- a/src/store/contacts.js
+++ b/src/store/contacts.js
@@ -326,7 +326,6 @@ const actions = {
 		if (contact.version === '3.0') {
 			contact.rev = ICAL.VCardTime.fromDateAndOrTimeString(new Date().toISOString(), 'date-time')
 		}
-		contact.rev = ICAL.VCardTime.now().convertToZone(ICAL.Timezone.utcTimezone)
 
 		const vData = contact.toStringStripQuotes()
 


### PR DESCRIPTION
### Summary
- Resolves https://github.com/nextcloud/contacts/issues/4726
- Resolves https://github.com/nextcloud/contacts/issues/4678
- Adjusted the timestamp logic on card update