### PR TITLE
fix(teams): replace 'Team folder' create button with 'Folder' and add notice text

### DIFF
--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -131,6 +131,7 @@
 									:resource-type="resourceType"
 									:value="resourceInputs[resourceType.id] || ''"
 									:is-open="activePopover === resourceType.id"
+									:helper-text="resourceType.helperText"
 									@update:value="updateResourceInput(resourceType.id, $event)"
 									@update:is-open="setActivePopover(resourceType.id, $event)"
 									@create="handleResourceCreation">
@@ -400,9 +401,10 @@ export default {
 			return [
 				{
 					id: 'folder',
-					label: t('contacts', 'Team folder'),
-					inputLabel: t('contacts', 'New Team folder'),
+					label: t('contacts', 'Folder'),
+					inputLabel: t('contacts', 'New folder'),
 					placeholder: t('contacts', 'Folder name'),
+					helperText: t('contacts', 'This will create a regular folder shared with the team. To create a Team Folder, please contact your {productName} administrator', { productName: OC.theme.name }),
 					icon: 'FolderIcon',
 					apiPath: 'files',
 					enabled: enabledApps.files !== undefined,

--- a/src/components/CircleDetails/TeamResourceButton.vue
+++ b/src/components/CircleDetails/TeamResourceButton.vue
@@ -47,12 +47,17 @@
 					</NcButton>
 				</div>
 			</div>
+			<div v-if="resourceType.helperText" class="popover-helper-text">
+				<NcNoteCard type="info">
+					{{ resourceType.helperText }}
+				</NcNoteCard>
+			</div>
 		</div>
 	</NcPopover>
 </template>
 
 <script>
-import { NcButton, NcPopover, NcTextField } from '@nextcloud/vue'
+import { NcButton, NcNoteCard, NcPopover, NcTextField } from '@nextcloud/vue'
 import CheckOutlineIcon from 'vue-material-design-icons/Check.vue'
 import CloseOutlineIcon from 'vue-material-design-icons/Close.vue'
 
@@ -61,6 +66,7 @@ export default {
 
 	components: {
 		NcButton,
+		NcNoteCard,
 		NcPopover,
 		NcTextField,
 		CloseOutlineIcon,
@@ -174,6 +180,18 @@ export default {
 			display: flex;
 			gap: var(--default-grid-baseline);
 			align-items: center;
+		}
+	}
+
+	.popover-helper-text {
+		margin-top: calc(var(--default-grid-baseline) * 4);
+		margin-bottom: 0;
+		width: 0;
+		min-width: 100%;
+
+		:deep(.notecard) {
+			text-align: start;
+			margin: 0;
 		}
 	}
 }


### PR DESCRIPTION
* Resolves: nextcloud/circles#2265

## Summary

Changes the "Team folder" creation button label to "Folder" on the team/circle details page (accessed in the Contacts app). Also adds a notice informing users to contact their Nextcloud admin for team folders (groupfolders).

Although the issue was reported in the `nextcloud/circles` repository, the fix was implemented in `nextcloud/contacts`, as this is where the Team Details UI and resource creation buttons are located.

## Changes

- Changed button label from "Team folder" to "Folder" in resource creation shortcuts
- Added helper text in a `NcNoteCard` component within the folder creation popover
- Helper text appears only for the folder resource type

## Before

<img width="782" height="389" alt="before" src="https://github.com/user-attachments/assets/5d62b7f3-aece-484f-8d95-923793421755" />

## After

<img width="782" height="389" alt="after" src="https://github.com/user-attachments/assets/8bd979ea-24a5-49ba-8a23-3ccdc39926b4" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
