### PR TITLE
fix(ReadOnlyContactDetails): remove box shadow

### DIFF
--- a/src/views/ReadOnlyContactDetails.vue
+++ b/src/views/ReadOnlyContactDetails.vue
@@ -316,4 +316,8 @@ export default {
 .recipient-details-loading {
 	margin-top: 64px;
 }
+
+:deep(input) {
+	box-shadow: none !important;
+}
 </style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/contacts/issues/4987

Removes the shadow here (in mail):
<img width="396" height="743" alt="image" src="https://github.com/user-attachments/assets/d5611cec-4b9e-4c20-b194-093e3c091c70" />
