### PR TITLE
fix: Icon button alignment

### DIFF
--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -550,6 +550,10 @@ $caption-padding: 22px;
 
 .contacts-settings {
 	padding: calc(var(--default-grid-baseline, 4px) * 2);
+
+	:deep(.button-vue__wrapper) {
+		justify-content: flex-start !important;
+	}
 }
 
 .contacts-settings-button {
@@ -557,7 +561,4 @@ $caption-padding: 22px;
 	justify-content: start !important;
 }
 
-:deep(.button-vue__wrapper){
-	justify-content: flex-start !important;
-}
 </style>


### PR DESCRIPTION
fix  #5001

| b | a |
|--------|--------|
|<img width="605" height="101" alt="image" src="https://github.com/user-attachments/assets/2a7b6764-267b-44bf-900a-6cdc73374924" /> | <img width="605" height="101" alt="image" src="https://github.com/user-attachments/assets/147c497e-9d6e-4140-bf8e-8603cf0da573" /> | 