### PR TITLE
fix: group multiple emails or phone numbers

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -76,40 +76,48 @@
 				</template>
 
 				<template #quick-actions>
-					<div v-if="!editMode && !loadingData">
+					<div v-if="!editMode && !loadingData" class="quick-actions">
+						<NcButton
+							v-if="isTalkEnabled && isInSystemAddressBook"
+							:aria-label="t('contacts', 'Go to talk conversation')"
+							:name="t('contacts', 'Go to talk conversation')"
+							class="icon-talk quick-action"
+							:href="callUrl" />
+						<NcButton
+							v-if="profilePageLink"
+							class="quick-action"
+							:aria-label="t('contacts', 'View profile')"
+							:name="t('contacts', 'View profile')"
+							:href="profilePageLink">
+							<template #icon>
+								<IconAccount :size="20" />
+							</template>
+						</NcButton>
 						<Actions
-							:inline="6"
+							class="quick-action"
 							variant="secondary">
-							<ActionButton
-								v-if="isTalkEnabled && isInSystemAddressBook"
-								:aria-label="t('contacts', 'Go to talk conversation')"
-								:name="t('contacts', 'Go to talk conversation')"
-								class="icon-talk quick-action"
-								:href="callUrl" />
-							<ActionButton
-								v-if="profilePageLink"
-								class="quick-action"
-								:aria-label="t('contacts', 'View profile')"
-								:name="t('contacts', 'View profile')"
-								:href="profilePageLink">
-								<template #icon>
-									<IconAccount :size="20" />
-								</template>
-							</ActionButton>
+							<template #icon>
+								<IconMail :size="20" />
+							</template>
 							<ActionLink
 								v-for="emailAddress in emailAddressList"
 								:key="emailAddress"
-								class="quick-action"
 								:href="'mailto:' + emailAddress">
 								<template #icon>
 									<IconMail :size="20" />
 								</template>
 								{{ emailAddress }}
 							</ActionLink>
+						</Actions>
+						<Actions
+							class="quick-action"
+							variant="secondary">
+							<template #icon>
+								<IconCall :size="20" />
+							</template>
 							<ActionLink
 								v-for="phoneNumber in phoneNumberList"
 								:key="phoneNumber"
-								class="quick-action"
 								:href="'tel:' + phoneNumber">
 								<template #icon>
 									<IconCall :size="20" />
@@ -1276,5 +1284,9 @@ section.contact-details {
 
 :deep(.contact-details-wrapper-read-only  .input-field__input) {
 	box-shadow: none !important;
+}
+
+.quick-actions {
+	display: flex;
 }
 </style>


### PR DESCRIPTION
Closes #4314

Shows only one button with a popover if there are more than one email addresses or phone numbers.

<img width="213" height="199" alt="image" src="https://github.com/user-attachments/assets/e5b8034e-ed89-427a-88d2-a287053dfaa7" />
<img width="199" height="197" alt="image" src="https://github.com/user-attachments/assets/711d9c85-9cb0-4171-a4e5-b9d46206e178" />
<img width="220" height="90" alt="image" src="https://github.com/user-attachments/assets/cf15fd8f-bbc5-48db-baec-dd6dc4956169" />
