### PR TITLE
feat: adds edit profile button on own contact

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -152,6 +152,17 @@
 						class="header-icon header-icon--pulse icon-up"
 						@click="updateContact" />
 
+					<!-- edit button for own contact -->
+					<NcButton
+						v-if="isOwnContact"
+						:href="profileSettingsUrl"
+						:variant="isMobile ? 'secondary' : 'tertiary'">
+						<template #icon>
+							<PencilIcon :size="20" />
+						</template>
+						{{ t('contacts', 'Edit profile') }}
+					</NcButton>
+
 					<!-- edit and save buttons -->
 					<template v-if="canModifyCard">
 						<NcButton
@@ -395,6 +406,7 @@
 </template>
 
 <script>
+import { getCurrentUser } from '@nextcloud/auth'
 import { getBuilder } from '@nextcloud/browser-storage'
 import { showError } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
@@ -596,6 +608,9 @@ export default defineComponent({
 		 * @return {object | boolean}
 		 */
 		warning() {
+			if (this.isOwnContact === true) {
+				return false
+			}
 			if (this.canModifyCard === false) {
 				return {
 					icon: EyeCircleIcon,
@@ -818,6 +833,14 @@ export default defineComponent({
 
 		nextcloudVersionAtLeast28() {
 			return parseInt(window.OC.config.version.split('.')[0]) >= 28
+		},
+
+		isOwnContact() {
+			return this.isInSystemAddressBook && this.contact.uid === getCurrentUser().uid
+		},
+
+		profileSettingsUrl() {
+			return generateUrl('settings/user')
 		},
 	},
 


### PR DESCRIPTION
Closes #3405

Adds a button to own contact that links to the profile settings.
The read-only warning will not be shown in this case.

<img width="591" height="97" alt="image" src="https://github.com/user-attachments/assets/bd005e1f-cca7-4c1d-820d-181cf01330f3" />
