### PR TITLE
fix(teams): always use populationInherited for population count

### DIFF
--- a/src/components/AppNavigation/CircleNavigationItem.vue
+++ b/src/components/AppNavigation/CircleNavigationItem.vue
@@ -126,14 +126,7 @@ export default {
 
 	computed: {
 		memberCount() {
-			const count = Object.keys(this.circle?.members || []).length
-
-			// If member list is empty, let's try the population initial count
-			if (count === 0 && this.circle.population > 0) {
-				return this.circle.population
-			}
-
-			return count
+			return this.circle.populationInherited || 0
 		},
 	},
 }

--- a/src/models/circle.d.ts
+++ b/src/models/circle.d.ts
@@ -46,9 +46,13 @@ export default class Circle {
 	 */
 	set description(text: string)
 	/**
-	 * Circle member count
+	 * Circle direct member count (excluding nested circles)
 	 */
 	get population(): any
+	/**
+	 * Circle total member count (direct + inherited from nested circles)
+	 */
+	get populationInherited(): any
 	/**
 	 * Circle ini_initiator the current
 	 * user info for this circle

--- a/src/models/circle.ts
+++ b/src/models/circle.ts
@@ -90,10 +90,17 @@ export default class Circle {
 	}
 
 	/**
-	 * Circle member count
+	 * Circle direct member count (excluding nested circles)
 	 */
 	get population() {
 		return this._data.population
+	}
+
+	/**
+	 * Circle total member count (direct + inherited from nested circles)
+	 */
+	get populationInherited() {
+		return this._data.populationInherited
 	}
 
 	// MEMBERSHIP -----------------------------------------

--- a/src/store/circles.js
+++ b/src/store/circles.js
@@ -91,6 +91,18 @@ const mutations = {
 	setCircleSettings(state, { circleId, settings }) {
 		state.circles[circleId]._data.settings = settings
 	},
+
+	/**
+	 * Update circle population count
+	 *
+	 * @param {object} state the store data
+	 * @param {object} data destructuring object
+	 * @param {string} data.circleId the circle to update the population
+	 * @param {number} data.populationInherited the inherited population count
+	 */
+	updateCirclePopulationCount(state, { circleId, populationInherited }) {
+		state.circles[circleId]._data.populationInherited = populationInherited
+	},
 }
 
 const getters = {
@@ -178,6 +190,7 @@ const actions = {
 			const circle = new Circle(response)
 			context.commit('addCircle', circle)
 			logger.debug('Created circle', { circleName, circle })
+			context.dispatch('updateCirclesPopulationCount')
 			return circle
 		} catch (error) {
 			console.error(error)
@@ -197,10 +210,27 @@ const actions = {
 			await deleteCircle(circleId)
 			context.commit('deleteCircle', circle)
 			logger.debug('Deleted circle', { circleId })
+			context.dispatch('updateCirclesPopulationCount')
 		} catch (error) {
 			console.error(error)
 			showError(t('contacts', 'Unable to delete team {circleId}', circleId))
 		}
+	},
+
+	/**
+	 * Update population count for all circles
+	 *
+	 * @param {object} context the store mutations Current context
+	 */
+	async updateCirclesPopulationCount(context) {
+		const circles = await getCircles()
+		circles.forEach((circle) => {
+			context.commit('updateCirclePopulationCount', {
+				circleId: circle.id,
+				populationInherited: circle.populationInherited,
+			})
+		})
+		logger.debug('Updated population count for all circles')
 	},
 
 	/**
@@ -217,8 +247,9 @@ const actions = {
 		const results = await addMembers(circleId, selection)
 		const members = results.map((member) => new Member(member, circle))
 
-		logger.debug('Added members to circle', { circle, members })
 		context.commit('appendMembersToCircle', members)
+		logger.debug('Added members to circle', { circle, members })
+		context.dispatch('updateCirclesPopulationCount')
 
 		return members
 	},
@@ -250,6 +281,7 @@ const actions = {
 		// success, let's remove from store
 		context.commit('deleteMemberFromCircle', member)
 		logger.debug('Deleted member', { circleId, memberId })
+		context.dispatch('updateCirclesPopulationCount')
 	},
 
 	/**
@@ -267,6 +299,7 @@ const actions = {
 		const member = new Member(result, circle)
 
 		await context.commit('addMemberToCircle', { circleId, member })
+		context.dispatch('updateCirclesPopulationCount')
 	},
 
 	async editCircleSetting(context, { circleId, setting }) {


### PR DESCRIPTION
* Related to: nextcloud/circles#2126

## Summary
Fixes team population counts to show values consistently across UI.
* This PR is the frontend follow-up of this backend implementation: https://github.com/nextcloud/circles/pull/2300

## Changes
- Always use `populationInherited` instead of alternating between `population` (on page load) and member list length (when clicking on a team)
- Update team population values when a member is added/removed or a team is removed
- Parent teams are now also updated correctly when a nested team changes, reflecting the updated population accordingly

## Before
[before.webm](https://github.com/user-attachments/assets/9325300c-18d5-43b2-afb4-fe4854c215be)

## After
[after.webm](https://github.com/user-attachments/assets/541bcfe6-eec0-4fae-9c39-1d7cb01b6568)

### Known Issue
#### Race condition flow
1. Frontend calls Backend `LocalController::membersAdd()` -> `MemberService::addMembers()`
3. `MemberService::addMembers()` triggers `FederatedEvent` which runs asynchronously
4. Backend returns response immediately (doesn't care if `updatePopulation()` completed or not)
5. Frontend receives response and calls `updateCirclesPopulationCount()`
6. Frontend fetches circles from DB (in some cases `updatePopulation()` did not complete yet)

With this approach, sometimes users might need to reload the page to see correct counts, specifically when adding multiple members at once or when updating a team that's also nested in other teams. This happens because `getCircles()` is called on the frontend before `updatePopulation()` in the backend has actually finished executing.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
