### PR TITLE
feat: adds button to copy values

### DIFF
--- a/src/components/Properties/PropertyMultipleText.vue
+++ b/src/components/Properties/PropertyMultipleText.vue
@@ -67,6 +67,17 @@
 					:aria-label="(localType && localType.name) || '' "
 					type="text"
 					@input="updateValue">
+
+				<NcButton
+					v-if="!property.isStructuredValue && isReadOnly"
+					class="property__ext"
+					variant="tertiary-no-background"
+					:aria-label="t('contacts', 'copy')"
+					@click.stop.prevent="copyValueToClipboard(localValue[0])">
+					<template #icon>
+						<CopyIcon :size="20" />
+					</template>
+				</NcButton>
 			</div>
 
 			<!-- props actions -->
@@ -101,6 +112,16 @@
 							:aria-label="propModel.readableValues[index]"
 							:label="propModel.readableValues[index]"
 							@update:model-value="updateValue" />
+						<NcButton
+							v-if="isReadOnly"
+							class="property__ext"
+							variant="tertiary-no-background"
+							:aria-label="t('contacts', 'copy')"
+							@click.stop.prevent="copyValueToClipboard(localValue[index])">
+							<template #icon>
+								<CopyIcon :size="20" />
+							</template>
+						</NcButton>
 					</div>
 					<div class="property__actions" />
 				</template>
@@ -126,6 +147,16 @@
 							:label="propModel.readableValues[index]"
 							type="text"
 							@update:model-value="updateValue" />
+						<NcButton
+							v-if="isReadOnly"
+							class="property__ext"
+							variant="tertiary-no-background"
+							:aria-label="t('contacts', 'copy')"
+							@click.stop.prevent="copyValueToClipboard(filteredValue[index])">
+							<template #icon>
+								<CopyIcon :size="20" />
+							</template>
+						</NcButton>
 					</div>
 					<div class="property__actions" />
 				</template>
@@ -135,19 +166,23 @@
 </template>
 
 <script>
-import { NcSelect, NcTextField } from '@nextcloud/vue'
+import { NcButton, NcSelect, NcTextField } from '@nextcloud/vue'
+import CopyIcon from 'vue-material-design-icons/ContentCopy.vue'
 import PropertyActions from './PropertyActions.vue'
 import PropertyTitle from './PropertyTitle.vue'
 import PropertyMixin from '../../mixins/PropertyMixin.js'
+import { copyValueToClipboard } from '../../utils/clipboardUtils.js'
 
 export default {
 	name: 'PropertyMultipleText',
 
 	components: {
+		NcButton,
 		NcSelect,
 		NcTextField,
 		PropertyTitle,
 		PropertyActions,
+		CopyIcon,
 	},
 
 	mixins: [PropertyMixin],
@@ -185,6 +220,10 @@ export default {
 		},
 	},
 
+	methods: {
+		copyValueToClipboard,
+	},
+
 }
 
 </script>
@@ -193,7 +232,7 @@ export default {
 .property {
 	&__value {
 		p {
-			max-width: 100%;
+			width: 100%;
 			overflow-wrap: break-word;
 		}
 	}

--- a/src/components/Properties/PropertyText.vue
+++ b/src/components/Properties/PropertyText.vue
@@ -92,15 +92,33 @@
 					:placeholder="placeholder"
 					@update:model-value="updateValue" />
 
-				<!-- external link -->
-				<a
-					v-if="haveExtHandler && isReadOnly"
-					:href="externalHandler"
-					class="property__ext"
-					:aria-label="t('mail', 'send an email')"
-					target="_blank">
-					<OpenInNewIcon :size="20" />
-				</a>
+				<NcActions
+					v-if="isReadOnly"
+					:inline="2"
+					variant="tertiary-no-background">
+					<!-- copy button -->
+					<NcActionButton
+						class="property__ext"
+						variant="tertiary-no-background"
+						:aria-label="t('contacts', 'copy')"
+						@click.stop.prevent="copyValueToClipboard(localValue)">
+						<template #icon>
+							<CopyIcon :size="20" />
+						</template>
+					</NcActionButton>
+
+					<!-- external link -->
+					<NcActionLink
+						v-if="haveExtHandler"
+						class="property__ext"
+						:href="externalHandler"
+						:aria-label="t('mail', 'send an email')"
+						target="_blank">
+						<template #icon>
+							<OpenInNewIcon :size="20" />
+						</template>
+					</NcActionLink>
+				</NcActions>
 			</div>
 
 			<!-- props actions -->
@@ -116,13 +134,15 @@
 </template>
 
 <script>
-import { NcSelect, NcTextArea, NcTextField } from '@nextcloud/vue'
+import { NcActionButton, NcActionLink, NcActions, NcSelect, NcTextArea, NcTextField } from '@nextcloud/vue'
 import debounce from 'debounce'
 import isEmail from 'validator/lib/isEmail.js'
+import CopyIcon from 'vue-material-design-icons/ContentCopy.vue'
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import PropertyActions from './PropertyActions.vue'
 import PropertyTitle from './PropertyTitle.vue'
 import PropertyMixin from '../../mixins/PropertyMixin.js'
+import { copyValueToClipboard } from '../../utils/clipboardUtils.js'
 
 export default {
 	name: 'PropertyText',
@@ -134,6 +154,10 @@ export default {
 		PropertyTitle,
 		PropertyActions,
 		OpenInNewIcon,
+		CopyIcon,
+		NcActions,
+		NcActionButton,
+		NcActionLink,
 	},
 
 	mixins: [PropertyMixin],
@@ -261,6 +285,8 @@ export default {
 			this.resizeHeight(e)
 			this.updateValue(e)
 		},
+
+		copyValueToClipboard,
 	},
 }
 </script>

--- a/src/css/Properties/Properties.scss
+++ b/src/css/Properties/Properties.scss
@@ -32,6 +32,13 @@ $property-row-gap: $contact-details-row-gap;
 		input {
 			margin-inline-end: 0;
 		}
+
+		// Show ext buttons on full row hover
+		&:hover {
+			.property__ext {
+				opacity: .7;
+			}
+		}
 	}
 
 	// property label or multiselect within row
@@ -106,13 +113,6 @@ $property-row-gap: $contact-details-row-gap;
 		// Left align labels on mobile
 		&__label {
 			justify-content: flex-start;
-		}
-	}
-
-	// Show ext buttons on full row hover
-	&:hover {
-		.property__ext {
-			opacity: .7;
 		}
 	}
 

--- a/src/utils/clipboardUtils.js
+++ b/src/utils/clipboardUtils.js
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { showError, showSuccess } from '@nextcloud/dialogs'
+
+async function copyValueToClipboard(value) {
+	try {
+		await navigator.clipboard.writeText(value)
+		showSuccess(t('contacts', 'Value copied to the clipboard'))
+	} catch (error) {
+		showError(t('contacts', 'Could not copy value to the clipboard.'))
+	}
+}
+
+export { copyValueToClipboard }


### PR DESCRIPTION
Adds a button to copy values to `Propertytext` and `PropertyMultipleText`, which is part of this issue: #4629.

<img width="398" height="80" alt="Screenshot at 2026-01-30 15-09-52" src="https://github.com/user-attachments/assets/c0e01f90-77e4-423e-8a7d-9539f1521e50" />

<img width="393" height="159" alt="Screenshot at 2026-01-30 15-15-14" src="https://github.com/user-attachments/assets/75b05ef6-2f59-4dda-a8fe-435ad7816507" />

<img width="323" height="97" alt="image" src="https://github.com/user-attachments/assets/a9dc09c7-57ac-4b0d-9e67-1f9ea3dcae38" />
