### PR TITLE
fix(PropertyText,PropertyMultipleText): make readonly inputs p for proper wrapping and a11y

### DIFF
--- a/src/components/Properties/PropertyMultipleText.vue
+++ b/src/components/Properties/PropertyMultipleText.vue
@@ -58,11 +58,13 @@
 
 			<div class="property__value">
 				<!-- show the first input if not a structured value -->
+				<p v-if="!property.isStructuredValue && isReadOnly">
+					{{ localValue[0] }}
+				</p>
 				<input
-					v-if="!property.isStructuredValue"
+					v-else-if="!property.isStructuredValue"
 					v-model.trim="localValue[0]"
 					:aria-label="(localType && localType.name) || '' "
-					:readonly="isReadOnly"
 					type="text"
 					@input="updateValue">
 			</div>
@@ -88,9 +90,12 @@
 						<span>{{ propModel.readableValues[index] }}</span>
 					</div>
 					<div class="property__value">
+						<p v-if="isReadOnly">
+							{{ localValue[index] }}
+						</p>
 						<NcTextField
+							v-else
 							v-model:model-value="localValue[index]"
-							:readonly="isReadOnly"
 							type="text"
 							:label-outside="true"
 							:aria-label="propModel.readableValues[index]"
@@ -111,9 +116,12 @@
 				<template v-if="(isReadOnly && filteredValue[index]) || !isReadOnly">
 					<div class="property__label" />
 					<div class="property__value">
+						<p v-if="isReadOnly">
+							{{ filteredValue[index] }}
+						</p>
 						<NcTextField
+							v-else
 							v-model:model-value="filteredValue[index]"
-							:readonly="isReadOnly"
 							:label-outside="true"
 							:label="propModel.readableValues[index]"
 							type="text"
@@ -180,3 +188,14 @@ export default {
 }
 
 </script>
+
+<style lang="scss" scoped>
+.property {
+	&__value {
+		p {
+			max-width: 100%;
+			overflow-wrap: break-word;
+		}
+	}
+}
+</style>

--- a/src/components/Properties/PropertyText.vue
+++ b/src/components/Properties/PropertyText.vue
@@ -79,11 +79,13 @@
 					@update:model-value="updateEmailValue" />
 
 				<!-- OR default to input -->
+				<p v-else-if="isReadOnly">
+					{{ localValue }}
+				</p>
 				<NcTextField
 					v-else
 					v-model:model-value="localValue"
 					:inputmode="inputmode"
-					:readonly="isReadOnly"
 					:aria-label="propName"
 					:class="{ 'property__value--with-ext': haveExtHandler }"
 					type="text"
@@ -268,6 +270,11 @@ export default {
 	&__value {
 		&--note {
 			white-space: pre-line;
+		}
+
+		p {
+			width: 100%;
+			overflow-wrap: break-word;
 		}
 	}
 }


### PR DESCRIPTION
Fix https://github.com/nextcloud/contacts/issues/5036

| Before | After |
| - | - |
| <img width="1002" height="1262" alt="image" src="https://github.com/user-attachments/assets/5c9ceb33-ef55-4329-982e-ecedec7947ce" /> | <img width="976" height="1249" alt="swappy-20260202_133802" src="https://github.com/user-attachments/assets/f6f47095-a0d5-45b4-be8a-31c229788d86" /> |
| <img width="423" height="91" alt="image" src="https://github.com/user-attachments/assets/856e5134-e280-44aa-9b7d-582b947be873" /> | <img width="405" height="162" alt="swappy-20260202_133817" src="https://github.com/user-attachments/assets/c03576bc-ac39-4038-a97f-3ca5331a595c" /> | 
