### PR TITLE
feat(teams): add swtich to enable/disable federation on team settings

### DIFF
--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -103,11 +103,11 @@ export const PUBLIC_CIRCLE_CONFIG = {
 		// [CIRCLE_CONFIG_CIRCLE_INVITE]: t('contacts', 'Team must confirm when invited in another circle'),
 		[CIRCLE_CONFIG_ROOT]: t('contacts', 'Prevent teams from being a member of another team'),
 	},
-	
+
 	[t('contacts', 'Federation')]: {
 		[CIRCLE_CONFIG_FEDERATED]: t('contacts', 'Allow federated members'),
 	},
-	
+
 	[t('contacts', 'Privacy')]: {
 		[CIRCLE_CONFIG_VISIBLE]: t('contacts', 'Visible to everyone'),
 	},


### PR DESCRIPTION
* Resolves: nextcloud/circles#2333

## Summary
Adds a switch to enable/disable federation for a given team from the contacts app (team settings). This implementation also changes the config value on backend (`oc_circles_circle` table).

| Before | After |
|--------|--------|
| <img width="551" height="747" alt="image" src="https://github.com/user-attachments/assets/35ba1e4e-8a4e-4d39-b978-b2a7a2e8e76b" /> | <img width="551" height="747" alt="image" src="https://github.com/user-attachments/assets/1c5dc6f2-c31a-4b1e-a6ed-7aca3662e481" /> |

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
