### PR TITLE
fix: make property labels accessible

### DIFF
--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -1245,7 +1245,7 @@ section.contact-details {
 
 :deep(.vs__selected) {
 	height: calc(var(--default-clickable-area) - var(--default-grid-baseline)) !important;
-	margin: calc(var(--default-grid-baseline) / 2);
+	margin: 0 !important;
 }
 
 #pick-addressbook-modal {
@@ -1318,6 +1318,14 @@ section.contact-details {
 
 :deep(.contact-details-wrapper-read-only  .input-field__input) {
 	box-shadow: none !important;
+}
+
+:deep(.vs__selected-options) {
+	max-height: 30px;
+}
+
+:deep(.v-select) {
+	margin-bottom: 0 !important;
 }
 
 .quick-actions {

--- a/src/components/Properties/PropertyDateTime.vue
+++ b/src/components/Properties/PropertyDateTime.vue
@@ -50,13 +50,14 @@
 					:first-day-of-week="firstDay"
 					:type="inputType"
 					:formatter="dateFormat"
+					:aria-label="propModel.readableName"
 					@update:model-value="debounceUpdateValue" />
 
-				<input
+				<NcTextField
 					v-else
 					:readonly="true"
-					:aria-label="propModel.readableName"
-					:value="formatDateTime()">
+					:model-value="formatDateTime()"
+					:label="propModel.readableName" />
 			</div>
 
 			<!-- props actions -->
@@ -77,6 +78,7 @@ import moment from '@nextcloud/moment'
 import {
 	NcDateTimePicker as DateTimePicker,
 	NcSelect,
+	NcTextField,
 } from '@nextcloud/vue'
 import debounce from 'debounce'
 import ICAL from 'ical.js'
@@ -90,6 +92,7 @@ export default {
 
 	components: {
 		NcSelect,
+		NcTextField,
 		DateTimePicker,
 		PropertyTitle,
 		PropertyActions,

--- a/src/components/Properties/PropertyMultipleText.vue
+++ b/src/components/Properties/PropertyMultipleText.vue
@@ -61,12 +61,13 @@
 				<p v-if="!property.isStructuredValue && isReadOnly">
 					{{ localValue[0] }}
 				</p>
-				<input
+				<NcTextField
 					v-else-if="!property.isStructuredValue"
-					v-model.trim="localValue[0]"
-					:aria-label="(localType && localType.name) || '' "
+					v-model:model-value="localValue[0]"
+					:label="propModel.readableName"
+					:readonly="isReadOnly"
 					type="text"
-					@input="updateValue">
+					@update:model-value="updateValue" />
 
 				<NcButton
 					v-if="!property.isStructuredValue && isReadOnly"
@@ -98,7 +99,7 @@
 				class="property__row">
 				<template v-if="(isReadOnly && localValue[index]) || !isReadOnly">
 					<div class="property__label">
-						<span>{{ propModel.readableValues[index] }}</span>
+						<span v-if="isReadOnly">{{ propModel.readableValues[index] }}</span>
 					</div>
 					<div class="property__value">
 						<p v-if="isReadOnly">
@@ -108,7 +109,6 @@
 							v-else
 							v-model:model-value="localValue[index]"
 							type="text"
-							:label-outside="true"
 							:aria-label="propModel.readableValues[index]"
 							:label="propModel.readableValues[index]"
 							@update:model-value="updateValue" />
@@ -143,7 +143,6 @@
 						<NcTextField
 							v-else
 							v-model:model-value="filteredValue[index]"
-							:label-outside="true"
 							:label="propModel.readableValues[index]"
 							type="text"
 							@update:model-value="updateValue" />

--- a/src/components/Properties/PropertyText.vue
+++ b/src/components/Properties/PropertyText.vue
@@ -48,12 +48,16 @@
 
 			<!-- textarea for note -->
 			<div class="property__value">
+				<p v-if="isReadOnly">
+					{{ localValue }}
+				</p>
+
 				<NcTextArea
-					v-if="propName === 'note'"
+					v-else-if="propName === 'note'"
 					id="textarea"
 					ref="textarea"
 					v-model:model-value="localValue"
-					:aria-label="t('contacts', 'note')"
+					:label="t('contacts', 'Notes')"
 					:inputmode="inputmode"
 					:readonly="isReadOnly"
 					@update:model-value="updateValueNoDebounce"
@@ -65,7 +69,7 @@
 					v-else-if="propName === 'email'"
 					ref="email"
 					v-model:model-value="localValue"
-					:aria-label="t('contacts', 'email')"
+					:label="propModel.readableName"
 					:class="{ 'property__value--with-ext': haveExtHandler }"
 					autocapitalize="none"
 					autocomplete="email"
@@ -73,18 +77,15 @@
 					:readonly="isReadOnly"
 					:error="!isEmailValid"
 					:helper-text="!emailHelpText || isReadonly ? '' : emailHelpText"
-					label-outside
 					:placeholder="placeholder"
 					type="email"
 					@update:model-value="updateEmailValue" />
 
 				<!-- OR default to input -->
-				<p v-else-if="isReadOnly">
-					{{ localValue }}
-				</p>
 				<NcTextField
 					v-else
 					v-model:model-value="localValue"
+					:label="propModel.readableName"
 					:inputmode="inputmode"
 					:aria-label="propName"
 					:class="{ 'property__value--with-ext': haveExtHandler }"

--- a/src/css/Properties/Properties.scss
+++ b/src/css/Properties/Properties.scss
@@ -25,7 +25,7 @@ $property-row-gap: $contact-details-row-gap;
 	&__row {
 		margin-top: var(--default-grid-baseline);
 		display: flex;
-		align-items: center;
+		align-items: end;
 		gap: $property-row-gap;
 
 		// fix default margin from server stylesheet causing slight misalignment
@@ -94,20 +94,6 @@ $property-row-gap: $contact-details-row-gap;
 		}
 	}
 
-	&__label,
-	&__value {
-		// Fix default multiselect styling
-		> .multiselect {
-			width: 100%;
-			min-width: unset;
-		}
-
-		// Fix default date time picker styling
-		> .mx-datepicker {
-			width: 100%;
-		}
-	}
-
 	// Mobile tweaks
 	@media (max-width: 1024px) {
 		// Left align labels on mobile
@@ -131,4 +117,8 @@ $property-row-gap: $contact-details-row-gap;
 		z-index: 10;
 		width: 44px;
 	}
+}
+
+.contact-details-wrapper-read-only .property__row {
+	align-items: center;
 }


### PR DESCRIPTION
Fix https://github.com/nextcloud/contacts/issues/5048

Final result:
<img width="584" height="613" alt="Screenshot From 2026-02-17 11-48-53" src="https://github.com/user-attachments/assets/01211eaa-6202-41d4-a9c8-88063a6a5a19" />
<img width="761" height="916" alt="Screenshot From 2026-02-17 11-48-36" src="https://github.com/user-attachments/assets/a0119158-3c7a-4d22-95d8-0b5345e2d199" />

Changes:
- Read only mode: gray label + `p` tags for text
- Edit mode: `NcInputField` with native label, aligned `NcSelect`

Getting `NcSelect` to be the same height and aligned with the input field took some nasty custom CSS seeing as one is 34px and the other 30px, but I'm hoping this will eventually be fixed by nextcloud vue