### PR TITLE
feat: show confirmation when enabling team federation and remove team from parents

### DIFF
--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -73,7 +73,11 @@
 										</template>
 									</NcButton>
 								</template>
-								<CircleSettings :circle="circle" @leave="onLeave" @delete="onDelete" />
+								<CircleSettings
+									:circle="circle"
+									@leave="onLeave"
+									@delete="onDelete"
+									@close-settings-popover="onCloseSettingsPopover" />
 							</NcPopover>
 						</template>
 						<template v-else>
@@ -647,6 +651,10 @@ export default {
 		onDelete() {
 			this.isSettingsPopoverShown = false
 			this.confirmDeleteCircle()
+		},
+
+		onCloseSettingsPopover() {
+			this.isSettingsPopoverShown = false
 		},
 
 		startEditing() {

--- a/src/components/CircleDetails/CircleSettings.vue
+++ b/src/components/CircleDetails/CircleSettings.vue
@@ -19,7 +19,7 @@
 						:loading="loading === config"
 						:disabled="loading !== false"
 						wrapper-element="li"
-						@update:model-value="onChange(config, $event)">
+						@update:model-value="onChange(Number(config), $event)">
 						{{ label }}
 					</NcCheckboxRadioSwitch>
 				</ul>
@@ -63,7 +63,8 @@ import IconLogout from 'vue-material-design-icons/Logout.vue'
 import IconDelete from 'vue-material-design-icons/TrashCanOutline.vue'
 import CirclePasswordSettings from './CirclePasswordSettings.vue'
 import ContentHeading from './ContentHeading.vue'
-import { PUBLIC_CIRCLE_CONFIG } from '../../models/constants.ts'
+import CircleActionsMixin from '../../mixins/CircleActionsMixin.js'
+import { CircleConfigs, PUBLIC_CIRCLE_CONFIG } from '../../models/constants.ts'
 import { CircleEdit, editCircle } from '../../services/circles.ts'
 
 export default defineComponent({
@@ -77,6 +78,8 @@ export default defineComponent({
 		NcCheckboxRadioSwitch,
 	},
 
+	mixins: [CircleActionsMixin],
+
 	props: {
 		circle: {
 			type: Object,
@@ -84,7 +87,7 @@ export default defineComponent({
 		},
 	},
 
-	emits: ['leave', 'delete'],
+	emits: ['leave', 'delete', 'close-settings-popover'],
 	setup() {
 		return { t }
 	},
@@ -109,6 +112,14 @@ export default defineComponent({
 		 */
 		async onChange(config: number, checked: boolean) {
 			this.logger.debug(`Circle config ${config} is set to ${checked}`)
+
+			if (checked && config === CircleConfigs.FEDERATED) {
+				this.$emit('close-settings-popover')
+				const confirmed = await this.confirmEnableFederationForCircle()
+				if (!confirmed) {
+					return
+				}
+			}
 
 			this.loading = config
 			const prevConfig = this.circle.config

--- a/src/services/circles.d.ts
+++ b/src/services/circles.d.ts
@@ -48,6 +48,12 @@ export declare const createCircle: (name: string, personal: boolean, local: bool
  */
 export declare const deleteCircle: (circleId: string) => Promise<any>
 /**
+ * Remove a circle from all parent circles it belongs to
+ *
+ * @param {string} circleId the circle id
+ */
+export declare const removeCircleFromParentCircles: (circleId: string) => Promise<any>
+/**
  * Edit an existing circle
  *
  * @param {string} circleId the circle id

--- a/src/services/circles.ts
+++ b/src/services/circles.ts
@@ -76,6 +76,16 @@ export async function deleteCircle(circleId: string) {
 }
 
 /**
+ * Remove a circle from all parent circles it belongs to
+ *
+ * @param circleId the circle id
+ */
+export async function removeCircleFromParentCircles(circleId: string) {
+	const response = await axios.put(generateOcsUrl('apps/circles/circles/{circleId}/leave-parent-circles', { circleId }))
+	return response.data.ocs.data
+}
+
+/**
  * Edit an existing circle
  *
  * @param circleId the circle id

--- a/src/store/circles.js
+++ b/src/store/circles.js
@@ -17,6 +17,7 @@ import {
 	getCircleMembers,
 	getCircles,
 	leaveCircle,
+	removeCircleFromParentCircles,
 } from '../services/circles.ts'
 import logger from '../services/logger.js'
 
@@ -214,6 +215,23 @@ const actions = {
 		} catch (error) {
 			console.error(error)
 			showError(t('contacts', 'Unable to delete team {circleId}', circleId))
+		}
+	},
+
+	/**
+	 * Remove circle from all parent circles it belongs to
+	 *
+	 * @param {object} context the store mutations Current context
+	 * @param {string} circleId the circle id
+	 */
+	async removeCircleFromParentCircles(context, circleId) {
+		try {
+			await removeCircleFromParentCircles(circleId)
+			logger.debug('Removed circle from parent circles', { circleId })
+			context.dispatch('updateCirclesPopulationCount')
+		} catch (error) {
+			console.error(error)
+			throw error
 		}
 	},
 


### PR DESCRIPTION
* Related to: nextcloud/circles#2341
* Also related to this backend PR. nextcloud/circles#2352

## Summary
Shows confirmation modal when enabling federation for a team, and if confirmed triggers action to remove the team from all teams it belongs to

## Before
[before.webm](https://github.com/user-attachments/assets/3e6ead65-2563-45fb-885b-c08ff64289d6)

## After
[after.webm](https://github.com/user-attachments/assets/15ab980c-5497-4be6-b337-a48e10dec8cd)

## Checklist
- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
