### PR TITLE
feat(teams): add confirmation popup when enabling federation for a team

### DIFF
--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -73,7 +73,11 @@
 										</template>
 									</NcButton>
 								</template>
-								<CircleSettings :circle="circle" @leave="onLeave" @delete="onDelete" />
+								<CircleSettings
+									:circle="circle"
+									@leave="onLeave"
+									@delete="onDelete"
+									@close-settings-popover="onCloseSettingsPopover" />
 							</NcPopover>
 						</template>
 						<template v-else>
@@ -647,6 +651,10 @@ export default {
 		onDelete() {
 			this.isSettingsPopoverShown = false
 			this.confirmDeleteCircle()
+		},
+
+		onCloseSettingsPopover() {
+			this.isSettingsPopoverShown = false
 		},
 
 		startEditing() {

--- a/src/components/CircleDetails/CircleSettings.vue
+++ b/src/components/CircleDetails/CircleSettings.vue
@@ -19,7 +19,7 @@
 						:loading="loading === config"
 						:disabled="loading !== false"
 						wrapper-element="li"
-						@update:model-value="onChange(config, $event)">
+						@update:model-value="onChange(Number(config), $event)">
 						{{ label }}
 					</NcCheckboxRadioSwitch>
 				</ul>
@@ -63,7 +63,8 @@ import IconLogout from 'vue-material-design-icons/Logout.vue'
 import IconDelete from 'vue-material-design-icons/TrashCanOutline.vue'
 import CirclePasswordSettings from './CirclePasswordSettings.vue'
 import ContentHeading from './ContentHeading.vue'
-import { PUBLIC_CIRCLE_CONFIG } from '../../models/constants.ts'
+import CircleActionsMixin from '../../mixins/CircleActionsMixin.js'
+import { CircleConfigs, PUBLIC_CIRCLE_CONFIG } from '../../models/constants.ts'
 import { CircleEdit, editCircle } from '../../services/circles.ts'
 
 export default defineComponent({
@@ -77,6 +78,8 @@ export default defineComponent({
 		NcCheckboxRadioSwitch,
 	},
 
+	mixins: [CircleActionsMixin],
+
 	props: {
 		circle: {
 			type: Object,
@@ -84,7 +87,7 @@ export default defineComponent({
 		},
 	},
 
-	emits: ['leave', 'delete'],
+	emits: ['leave', 'delete', 'close-settings-popover'],
 	setup() {
 		return { t }
 	},
@@ -109,6 +112,14 @@ export default defineComponent({
 		 */
 		async onChange(config: number, checked: boolean) {
 			this.logger.debug(`Circle config ${config} is set to ${checked}`)
+
+			if (checked && config === CircleConfigs.FEDERATED) {
+				this.$emit('close-settings-popover')
+				const confirmed = await this.confirmEnableFederationForCircle()
+				if (!confirmed) {
+					return
+				}
+			}
 
 			this.loading = config
 			const prevConfig = this.circle.config

--- a/src/mixins/CircleActionsMixin.js
+++ b/src/mixins/CircleActionsMixin.js
@@ -1,4 +1,4 @@
-import { showError } from '@nextcloud/dialogs'
+import { showConfirmation, showError, showSuccess } from '@nextcloud/dialogs'
 /**
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -132,6 +132,23 @@ export default {
 			} finally {
 				this.loadingAction = false
 			}
+		},
+
+		async confirmEnableFederationForCircle() {
+			const confirmed = await showConfirmation({
+				name: t('contacts', 'Confirm enabling federation'),
+				text: t('contacts', 'Enabling this will prevent {circle} from being a member of other teams.\nAre you sure?', {
+					circle: this.circle.displayName,
+				}),
+				labelConfirm: t('contacts', 'Enable federation'),
+				labelReject: t('contacts', 'Cancel'),
+				severity: 'warning',
+			})
+			if (!confirmed) {
+				this.logger.debug('Enable federation cancelled')
+				return false
+			}
+			return true
 		},
 
 		/**


### PR DESCRIPTION
* Related to https://github.com/nextcloud/circles/issues/2341

This PR is a "simpler" alternative to these two:
* https://github.com/nextcloud/circles/pull/2352
* https://github.com/nextcloud/contacts/pull/5103

Instead of calling an endpoint to remove a team from all parent teams when enabling federation, this PR simply adds a confirmation modal when the user attempts to enable federation.

The contacts PR (#5103) also included a confirmation modal, but additionally called the endpoint created in the circles PR ([#2352](https://github.com/nextcloud/circles/pull/2352)). This PR only implements the modal without the endpoint call.