### PR TITLE
chore(eol): stable 7.3 ⚰️

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'stable7.3', 'stable8.3', 'stable8.4']
+        branches: ['main', 'stable8.3', 'stable8.4']
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/.tx/backport
+++ b/.tx/backport
@@ -1,3 +1,2 @@
-stable7.3
 stable8.3
 stable8.4

--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,9 @@
 	"rebaseWhen": "conflicted",
 	"ignoreUnstable": false,
 	"baseBranches": [
-		"main"
+		"main",
+		"stable8.4",
+		"stable8.3"
 	],
 	"enabledManagers": [
 		"composer",


### PR DESCRIPTION
As Nextcloud 31 reached end of life this month, we're also dropping support for stable7.3 , last maintenance release was triggered this afternoon. 
Current maintained versions are 
- 8.3 -> Nextcloud 32 and 33 (stable)
- 8.4 -> Nextcloud 33 (nightly) 
