### PR TITLE
fix: allow users to unshare group-shared address books for themselves

### DIFF
--- a/src/components/AppNavigation/Settings/SettingsAddressbook.vue
+++ b/src/components/AppNavigation/Settings/SettingsAddressbook.vue
@@ -307,7 +307,7 @@ export default {
 			window.OC.dialogs.confirm(
 				t('contacts', 'This will unshare the address book and every contacts within it'),
 				t('contacts', 'Unshare {addressbook}?', { addressbook: this.addressbook.displayName }),
-				this.deleteAddressbook,
+				this.unshareFromMe,
 				true,
 			)
 		},
@@ -324,6 +324,22 @@ export default {
 					showError(t('contacts', 'Deletion of address book was not successful.'))
 				} finally {
 					// stop loading status regardless of outcome
+					this.deleteAddressbookLoading = false
+				}
+			}
+		},
+
+		async unshareFromMe(confirm) {
+			if (confirm) {
+				this.deleteAddressbookLoading = true
+				try {
+					const principalsStore = usePrincipalsStore()
+					const uri = principalsStore.currentUserPrincipal.principalScheme
+					await this.$store.dispatch('unshareAddressbookFromMe', { addressbook: this.addressbook, uri })
+				} catch (err) {
+					console.error(err)
+					showError(t('contacts', 'Unsharing of address book was not successful.'))
+				} finally {
 					this.deleteAddressbookLoading = false
 				}
 			}

--- a/src/store/addressbooks.js
+++ b/src/store/addressbooks.js
@@ -475,6 +475,28 @@ const actions = {
 	},
 
 	/**
+	 * Unshare an addressbook from the current user
+	 * This is used when a user wants to remove a shared addressbook
+	 * from their own account, including group-shared addressbooks
+	 *
+	 * @param {object} context the store mutations Current context
+	 * @param {object} data destructuring object
+	 * @param {object} data.addressbook the addressbook to unshare
+	 * @param {string} data.uri the current user's principal scheme uri
+	 */
+	async unshareAddressbookFromMe(context, { addressbook, uri }) {
+		try {
+			await addressbook.dav.unshare(uri)
+			Object.values(addressbook.contacts)
+				.forEach((contact) => context.commit('deleteContact', contact))
+			context.commit('deleteAddressbook', addressbook)
+		} catch (error) {
+			console.error(error)
+			throw error
+		}
+	},
+
+	/**
 	 * Remove sharee from Addressbook
 	 *
 	 * @param {object} context the store mutations Current context


### PR DESCRIPTION
Fixes #5000

Find the unshare/decline endpoint in the backend and update the permission check to allow group members to remove a group share from their own account, similar to how user-direct shares handle decline