### PR TITLE
fix: Fix Teams description in nav

### DIFF
--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -536,7 +536,8 @@ $caption-padding: 22px;
 }
 
 .app-navigation__circle-desc {
-	margin: 0 $caption-padding;
+	margin: var(--default-grid-baseline, 4px) calc(var(--default-grid-baseline, 4px) * 2);
+	color: var(--color-text-maxcontrast);
 }
 
 .app-navigation__collapse :deep(a) {

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -51,7 +51,7 @@ const MEMBER_TYPE_MAIL: MemberType = 4
 const MEMBER_TYPE_CONTACT: MemberType = 8
 const MEMBER_TYPE_CIRCLE: MemberType = 16
 
-export const CIRCLE_DESC = t('contacts', 'Teams are groups of people that you can create yourself and with whom you can share data. They can be made up of other accounts or groups of accounts of the Nextcloud instance, but also of contacts from your address book or even external people by simply entering their e-mail addresses.')
+export const CIRCLE_DESC = t('contacts', 'Create your own groups for sharing. Add Nextcloud users, contacts, or anyone via email.')
 
 // Circles config flags
 


### PR DESCRIPTION
- Shorten text
- Fix alignment
- Improve text color

Before | After
-|-
<img width="690" height="1252" alt="Screenshot From 2026-04-20 15-54-20" src="https://github.com/user-attachments/assets/7ad44528-5733-411c-bd18-53a1c9d27041" />|<img width="690" height="1252" alt="Screenshot From 2026-04-20 15-53-41" src="https://github.com/user-attachments/assets/25000023-3fe1-41bf-9c87-413b7cd3a94d" />
