### PR TITLE
Security: Potential denial of service from unbounded image decoding

### DIFF
--- a/lib/Service/ImageResizer.php
+++ b/lib/Service/ImageResizer.php
@@ -14,14 +14,28 @@ use OCP\Image;
 class ImageResizer {
 	public const RESIZE_MAX_X = 256;
 	public const RESIZE_MAX_Y = 256;
+	public const MAX_INPUT_BYTES = 5 * 1024 * 1024;
+	public const MAX_INPUT_PIXELS = 4096 * 4096;
 
 	/**
 	 * @param string $socialData
 	 * @return null|string
 	 */
 	public function resizeImage(string $socialData) {
-		$image = new Image();
+		if ($socialData === '' || strlen($socialData) > self::MAX_INPUT_BYTES) {
+			return null;
+		}
 
+		$size = @getimagesizefromstring($socialData);
+		if ($size === false || !isset($size[0], $size[1])) {
+			return null;
+		}
+
+		if ($size[0] <= 0 || $size[1] <= 0 || ($size[0] * $size[1]) > self::MAX_INPUT_PIXELS) {
+			return null;
+		}
+
+		$image = new Image();
 		$image->loadFromData($socialData);
 
 		if ($image->valid()) {


### PR DESCRIPTION
## Summary

Security: Potential denial of service from unbounded image decoding

## Problem

**Severity**: `Medium` | **File**: `lib/Service/ImageResizer.php:L22`

`resizeImage()` loads arbitrary image bytes into memory and decodes them without checking input size or dimensions first. If attacker-controlled or remote-fetched image data is very large or crafted, this may cause excessive memory/CPU consumption and degrade service availability.

## Solution

Validate input size before decoding (e.g., maximum bytes), enforce pixel/dimension limits, and fail fast on oversized payloads. Prefer safe decoding paths with resource limits and consider rejecting unsupported/complex image formats.

## Changes

- `lib/Service/ImageResizer.php` (modified)