### PR TITLE
ci(actions): Thin out PHPUnit runs

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,19 +2,51 @@
 # SPDX-License-Identifier: MIT
 name: PHPUnit
 
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-      - stable*
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: phpunit-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 env:
   APP_NAME: contacts
 
 jobs:
-  php:
+  changes:
+    runs-on: ubuntu-latest-low
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      src: ${{ steps.changes.outputs.src}}
+
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            src:
+              - '.github/workflows/**'
+              - 'appinfo/**'
+              - 'lib/**'
+              - 'templates/**'
+              - 'tests/**'
+              - 'vendor/**'
+              - 'vendor-bin/**'
+              - '.php-cs-fixer.dist.php'
+              - 'composer.json'
+              - 'composer.lock'
+
+  phpunit-sqlite:
     runs-on: ubuntu-latest
+
+    needs: [ changes ]
+    if: needs.changes.outputs.src != 'false'
 
     strategy:
       # do not stop on another job's failure
@@ -22,10 +54,7 @@ jobs:
       matrix:
         php-versions: ['8.2', '8.3', '8.4', '8.5']
         databases: ['sqlite']
-        server-versions: ['master', 'stable33', 'stable32']
-        exclude:
-          - php-versions: '8.5'
-            server-versions: 'stable32'
+        server-versions: ['master']
         include:
           - php-versions: '8.1'
             databases: 'sqlite'
@@ -37,6 +66,7 @@ jobs:
       - name: Checkout server
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           repository: nextcloud/server
           ref: ${{ matrix.server-versions }}
           submodules: true
@@ -44,6 +74,7 @@ jobs:
       - name: Checkout app
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           path: apps/${{ env.APP_NAME }}
 
       - name: Set up php ${{ matrix.php-versions }}
@@ -88,23 +119,19 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash)
 
-  mysql:
+  phpunit-mariadb:
     runs-on: ubuntu-latest
+
+    needs: [ changes ]
+    if: needs.changes.outputs.src != 'false'
 
     strategy:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.4']
         databases: ['mysql']
-        server-versions: ['master', 'stable33','stable32']
-        exclude:
-          - php-versions: '8.5'
-            server-versions: 'stable32'
-        include:
-          - php-versions: '8.1'
-            databases: 'mysql'
-            server-versions: 'stable32'
+        server-versions: ['master', 'stable33', 'stable32']
 
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
@@ -121,6 +148,7 @@ jobs:
       - name: Checkout server
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           repository: nextcloud/server
           ref: ${{ matrix.server-versions }}
           submodules: true
@@ -128,6 +156,7 @@ jobs:
       - name: Checkout app
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           path: apps/${{ env.APP_NAME }}
 
       - name: Patch for nightly PHP
@@ -167,14 +196,17 @@ jobs:
       #   working-directory: apps/${{ env.APP_NAME }}
       #   run:  composer run test:integration
 
-  pgsql:
+  phpunit-pgsql:
     runs-on: ubuntu-latest
+
+    needs: [ changes ]
+    if: needs.changes.outputs.src != 'false'
 
     strategy:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.5']
         databases: ['pgsql']
         server-versions: ['master', 'stable33', 'stable32']
         exclude:
@@ -184,6 +216,7 @@ jobs:
           - php-versions: '8.1'
             databases: 'pgsql'
             server-versions: 'stable32'
+
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
     services:
@@ -201,6 +234,7 @@ jobs:
       - name: Checkout server
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           repository: nextcloud/server
           ref: ${{ matrix.server-versions }}
           submodules: true
@@ -208,6 +242,7 @@ jobs:
       - name: Checkout app
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           path: apps/${{ env.APP_NAME }}
 
       - name: Set up php ${{ matrix.php-versions }}
@@ -243,11 +278,13 @@ jobs:
 
   summary:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-low
+
     needs:
-      - php
-      - mysql
-      - pgsql
+      - changes
+      - phpunit-sqlite
+      - phpunit-mariadb
+      - phpunit-pgsql
 
     if: always()
 
@@ -255,8 +292,8 @@ jobs:
 
     steps:
       - name : Sqlite test status
-        run: if ${{ needs.php.result != 'success' && needs.php.result != 'skipped' }}; then exit 1; fi
-      - name : Mysql test status
-        run: if ${{ needs.mysql.result != 'success' && needs.mysql.result != 'skipped' }}; then exit 1; fi
+        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-sqlite.result != 'success' }}; then exit 1; fi
+      - name : MariaDB test status
+        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-mariadb.result != 'success' }}; then exit 1; fi
       - name : Pgsql test status
-        run: if ${{ needs.pgsql.result != 'success' && needs.pgsql.result != 'skipped' }}; then exit 1; fi
+        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-pgsql.result != 'success' }}; then exit 1; fi


### PR DESCRIPTION
- :hot_face: Before: 4 phps * 3 servers * 3 dbs = 36 runs
  https://github.com/nextcloud/contacts/actions/runs/24841235705
  <img width="1485" height="868" alt="grafik" src="https://github.com/user-attachments/assets/72d068f1-f3cd-4d52-b0e3-67839ca6c06d" />
  parallel runs for the same PR
  <img width="1655" height="925" alt="grafik" src="https://github.com/user-attachments/assets/fcfb046d-c35c-4ea4-9f92-5d42fe51c2d6" />


- :deciduous_tree: After: 2 dbs * 3 servers + 1 db * 5 phps = 11 runs
  - SQLite against all PHP versions with master + 8.1 with stable32
  - MariaDB + Postgres against all supported servers with php 8.4 or 8.1/8.5 respectively
  - Cancel on repushing the same PR (concurrency)
  - Check if a PHP or relevant file changed