### PR TITLE
Fix: Prevent contact count label from truncating (#4269)

### DIFF
--- a/src/css/contacts.scss
+++ b/src/css/contacts.scss
@@ -37,4 +37,9 @@ $grid-input-height-with-margin: $grid-height-unit - $grid-input-margin * 2;
 		// Cancel scrolling
 		overflow: visible;
 	}
+
+	// Fix for contact count label being truncated (#4269)
+	.app-navigation-entry__counter-wrapper {
+		flex-shrink: 0;
+	}
 }


### PR DESCRIPTION
Fixes #4269. The flex-shrink property allows the contact counter wrapper to shrink below its intrinsic width when the sidebar is constrained, causing the counter to truncate its contents. Added flex-shrink: 0 to prevent the truncation.