### PR TITLE
Issue #5244 Fix drag & drop to group for contacts without prior click

### DIFF
--- a/src/components/AppNavigation/GroupNavigationItem.vue
+++ b/src/components/AppNavigation/GroupNavigationItem.vue
@@ -163,19 +163,22 @@ export default {
 		async onDrop(event, group) {
 			try {
 				const contactFromDropData = JSON.parse(event.dataTransfer.getData('item'))
-				const contactFromStore = this.$store.getters.getContact(Buffer.from(`${contactFromDropData.uid}~${contactFromDropData.addressbookId}`, 'utf-8').toString('base64'))
-				if (contactFromStore && !this.isInGroup(contactFromStore.groups, group.id)) {
-					const contact = this.$store.getters.getContact(Buffer.from(`${contactFromDropData.uid}~${contactFromDropData.addressbookId}`, 'utf-8').toString('base64'))
+				const contactId = Buffer.from(`${contactFromDropData.uid}~${contactFromDropData.addressbookId}`, 'utf-8').toString('base64')
+				let contact = this.$store.getters.getContact(contactId)
+				if (!contact) {
+					return
+				} 
+
+				await this.$store.dispatch('fetchFullContact', { contact })
+				contact = this.$store.getters.getContact(contactId)
+
+				if (!this.isInGroup(contact.groups, group.id)) {
+					contact.groups = [...contact.groups, group.name]
 					await this.$store.dispatch('updateContactGroups', {
-						groupNames: [...contactFromStore.groups, group.name],
+						groupNames: contact.groups,
 						contact,
 					})
-					const localContact = Object.assign(
-						Object.create(Object.getPrototypeOf(contact)),
-						contact,
-					)
-					localContact.groups = [...contactFromStore.groups, group.name]
-					await this.$store.dispatch('updateContact', localContact)
+					await this.$store.dispatch('updateContact', contact)
 				}
 			} catch (e) {
 				console.error(e)

--- a/src/components/AppNavigation/GroupNavigationItem.vue
+++ b/src/components/AppNavigation/GroupNavigationItem.vue
@@ -167,7 +167,7 @@ export default {
 				let contact = this.$store.getters.getContact(contactId)
 				if (!contact) {
 					return
-				} 
+				}
 
 				await this.$store.dispatch('fetchFullContact', { contact })
 				contact = this.$store.getters.getContact(contactId)

--- a/tests/javascript/models/contact.test.js
+++ b/tests/javascript/models/contact.test.js
@@ -60,3 +60,37 @@ describe('Test stripping quotes from TYPE', () => {
 	})
 
 })
+
+describe('Test groups setter', () => {
+
+	let contact
+
+	beforeEach(() => {
+		contact = new Contact(
+			'BEGIN:VCARD\nVERSION:3.0\nUID:123456789-123465-123456-123456789\nFN:Test contact\nEND:VCARD',
+		)
+	})
+
+	test('groups setter updates jCal so the group is included in serialization', () => {
+		contact.groups = ['Friends']
+
+		expect(contact.groups).toEqual(['Friends'])
+		expect(contact.vCard.toString()).toContain('CATEGORIES:Friends')
+	})
+
+	test('groups setter replaces existing groups', () => {
+		contact.groups = ['OldGroup']
+		contact.groups = ['NewGroup']
+
+		expect(contact.groups).toEqual(['NewGroup'])
+	})
+
+	test('groups setter with empty array removes categories property', () => {
+		contact.groups = ['SomeGroup']
+		contact.groups = []
+
+		expect(contact.groups).toEqual([])
+		expect(contact.vCard.hasProperty('categories')).toBe(false)
+	})
+
+})


### PR DESCRIPTION
Fixes #5244

### What was broken

Dragging a contact into a group only worked if the contact had been clicked before. Without a prior click, no PUT request was sent and the group assignment was silently dropped.

### Root cause

Without a prior click (which triggers a full PROPFIND), the contact object is not set in a satisfactionary way — the contact is only hydrated from the initial listing. By loading the contact before adding the groups, the `updateContact` action now accepts the object, and no longer skipps silently.

### Fix

Call `fetchFullContact` in the drop handler before proceeding with the group assignment.

### Testing:
The `onDrop` handler is hard to unit test in isolation (async DAV calls, Vuex store, DOM events). I added unit tests for the `Contact.groups` setter which is at the core of the fix. Manual testing was done for the following scenarios — see video below:
* dragging without clicking from "All contacts" list
* dragging without clicking from "Ungrouped contacts" list
* dragging without clicking from any named list to another

https://drive.google.com/file/d/1jZ0OnXgLvYKriTLuYLomdrjkNBSkK17N/view?usp=sharing