### PR TITLE
fix(contacts): handle line manager property creation

### DIFF
--- a/src/components/ContactDetails/ContactDetailsAddNewProp.vue
+++ b/src/components/ContactDetails/ContactDetailsAddNewProp.vue
@@ -74,6 +74,7 @@
 </template>
 
 <script>
+import { showWarning } from '@nextcloud/dialogs'
 import { NcActionButton as ActionButton, NcActions as Actions } from '@nextcloud/vue'
 import ICAL from 'ical.js'
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
@@ -207,12 +208,21 @@ export default {
 				return
 			}
 
+			let shouldFocusProp = true
 			if (id === 'x-managersname') {
 				const others = this.otherContacts(this.contact)
+				if (others.length === 0) {
+					showWarning(t('contacts', 'No other contacts available to select as line manager'))
+					this.moreActionsOpen = false
+					return
+				}
 				if (others.length === 1) {
 					// Pick the first and only other contact
-					await this.contact.vCard.addPropertyWithValue(id, others[0].key)
+					const manager = this.$store.getters.getContact(others[0].key)
+					const property = await this.contact.vCard.addPropertyWithValue(id, manager.displayName)
+					property.setParameter('uid', manager.uid)
 					await this.$store.dispatch('updateContact', this.contact)
+					shouldFocusProp = false
 				} else {
 					await this.contact.vCard.addPropertyWithValue(id, '')
 				}
@@ -233,7 +243,9 @@ export default {
 				}
 			}
 			this.moreActionsOpen = false
-			this.bus.emit('focus-prop', id)
+			if (shouldFocusProp) {
+				this.bus.emit('focus-prop', id)
+			}
 		},
 	},
 }

--- a/src/components/ContactDetails/ContactDetailsProperty.vue
+++ b/src/components/ContactDetails/ContactDetailsProperty.vue
@@ -307,7 +307,7 @@ export default {
 					// TODO: this only *shows* the display name but doesn't assign the missing UID
 					const displayName = this.property.getFirstValue()
 					const other = this.otherContacts(this.contact).find((contact) => contact.displayName === displayName)
-					return other?.key
+					return other?.key ?? ''
 				}
 				return this.property.getFirstValue()
 			},

--- a/src/components/Properties/PropertySelect.vue
+++ b/src/components/Properties/PropertySelect.vue
@@ -115,9 +115,12 @@ export default {
 		matchedOptions: {
 			get() {
 				const options = this.options || this.propModel.options
+				const localValueLowerCase = typeof this.localValue === 'string'
+					? this.localValue.toLowerCase()
+					: null
 				// match lowercase as well
 				let selected = options.find((option) => option.id === this.localValue
-					|| option.id === this.localValue.toLowerCase())
+					|| option.id === localValueLowerCase)
 
 				// if the model provided a custom match fallback, use it
 				if (!selected && this.propModel.greedyMatch) {


### PR DESCRIPTION
Adding the Line manager field created an empty x-managersname property and then immediately tried to focus the newly rendered editor. When the property had no matching contact value, the select received an undefined value and no focusable field was available.

This produced the following JavaScript errors:

- No focusable element found for property x-managersname
- TypeError: can't access property "toLowerCase", this.localValue is undefined

Keep empty manager properties represented as an empty string, guard select matching before lowercasing the local value, and store the only available manager using the vCard display name plus UID parameter instead of the internal contact key.

Fixes nextcloud/contacts#4454