### PR TITLE
chore: re-sync appstore-build-publish workflow with org template (Node 20)

### DIFF
--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get appinfo data
         id: appinfo
-        uses: skjnldsv/xpath-action@d813024a13948950fd8d23b580254feeb4883d3c # master
+        uses: skjnldsv/xpath-action@f5b036e9d973f42c86324833fd00be90665fbf77 # v1.0.0
         with:
           filename: ${{ env.APP_NAME }}/appinfo/info.xml
           expression: "//info//dependencies//nextcloud/@min-version"
@@ -56,7 +56,7 @@ jobs:
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
         # Skip if no package.json
         if: ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ steps.versions.outputs.nodeVersion }}
 
@@ -67,12 +67,12 @@ jobs:
 
       - name: Get php version
         id: php-versions
-        uses: icewind1991/nextcloud-version-matrix@58becf3b4bb6dc6cef677b15e2fd8e7d48c0908f # v1.3.1
+        uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
         with:
           filename: ${{ env.APP_NAME }}/appinfo/info.xml
 
       - name: Set up php ${{ steps.php-versions.outputs.php-min }}
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
           php-version: ${{ steps.php-versions.outputs.php-min }}
           coverage: none
@@ -81,7 +81,7 @@ jobs:
 
       - name: Check composer.json
         id: check_composer
-        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: "${{ env.APP_NAME }}/composer.json"
 
@@ -103,7 +103,7 @@ jobs:
 
       - name: Check Krankerl config
         id: krankerl
-        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: ${{ env.APP_NAME }}/krankerl.toml
 


### PR DESCRIPTION
Hello,

The `appstore-build-publish` workflow run for v8.4.6 brings two deprecation warnings on `ubuntu-latest`:

- **Node.js 20 actions are deprecated** and are forced to move up to Node 24 after 2026-06-02 and should be entirely removed by 2026-09-16.
- **`set-output` command was deprecated** in 2022.

`nextcloud/.github/workflow-templates/appstore-build-publish.yml` already pins newer versions that address 5 of the 7 listed GitHub actions. This PR re-syncs `nextcloud/contacts` with the upstream Nextcloud template.

## Edits

5 bumps in `.github/workflows/appstore-build-publish.yml`:

| Action | From | To |
|---|---|---|
| `actions/setup-node` | v6.2.0 | v6.4.0 |
| `andstor/file-existence-action` | v3.0.0 | v3.1.0 |
| `icewind1991/nextcloud-version-matrix` | v1.3.1 | v1.3.2 |
| `shivammathur/setup-php` | 2.36.0 | 2.37.0 |
| `skjnldsv/xpath-action` | `@master` | v1.0.0 |

## Still needs attention

Two actions stay on Node 20 because they have no newer release:

- `skjnldsv/check-actor-permission` : last tag v3.0 (2024-02)
- `skjnldsv/read-package-engines-version-actions` : last tag v3 (2024-02)
