### PR TITLE
feat: optimize member list

### DIFF
--- a/src/components/AppContent/CircleContent.vue
+++ b/src/components/AppContent/CircleContent.vue
@@ -58,12 +58,6 @@ export default {
 		},
 	},
 
-	data() {
-		return {
-			loadingList: false,
-		}
-	},
-
 	computed: {
 		// store variables
 		circles() {
@@ -82,25 +76,10 @@ export default {
 			return Object.values(this.circle?.members || [])
 		},
 
-		/**
-		 * Is the current circle empty
-		 *
-		 * @return {boolean}
-		 */
-		isEmptyCircle() {
-			return this.members.length === 0
-		},
-
 		...mapStores(useUserGroupStore),
 	},
 
 	watch: {
-		circle(newCircle) {
-			if (newCircle?.id) {
-				this.fetchCircleMembers(newCircle.id)
-			}
-		},
-
 		userGroup(newUserGroup) {
 			if (newUserGroup?.id) {
 				this.fetchUserGroupMembers(newUserGroup.id)
@@ -109,40 +88,18 @@ export default {
 	},
 
 	beforeMount() {
-		if (this.circle?.id) {
-			this.fetchCircleMembers(this.circle.id)
-		}
-
 		if (this.userGroup?.id) {
 			this.fetchUserGroupMembers(this.userGroup.id)
 		}
 	},
 
 	methods: {
-		async fetchCircleMembers(circleId) {
-			this.loadingList = true
-			this.logger.debug('Fetching members for', { circleId })
-
-			try {
-				await this.$store.dispatch('getCircleMembers', circleId)
-			} catch (error) {
-				console.error(error)
-				showError(t('contacts', 'There was an error fetching the member list'))
-			} finally {
-				this.loadingList = false
-			}
-		},
-
 		async fetchUserGroupMembers(userGroupId) {
-			this.loadingList = true
-
 			try {
 				await this.userGroupStore.getUserGroupMembers(userGroupId)
 			} catch (error) {
 				console.error(error)
 				showError(t('contacts', 'There was an error fetching the member list'))
-			} finally {
-				this.loadingList = false
 			}
 		},
 	},

--- a/src/components/MemberList/MemberGridItem.vue
+++ b/src/components/MemberList/MemberGridItem.vue
@@ -81,6 +81,7 @@
 
 <script>
 import { DialogBuilder, showError } from '@nextcloud/dialogs'
+import { emit } from '@nextcloud/event-bus'
 import { NcActionButton, NcActions, NcActionSeparator, NcActionText, NcAvatar, NcButton } from '@nextcloud/vue'
 import IconAccountGroupOutline from 'vue-material-design-icons/AccountGroupOutline.vue'
 import IconCheckOutline from 'vue-material-design-icons/CheckOutline.vue'
@@ -317,6 +318,7 @@ export default {
 					member: this.member,
 					leave: this.isCurrentUser,
 				})
+				emit('contacts:circles:member:deleted')
 			} catch (error) {
 				if (error?.response?.status === 404) {
 					this.logger.debug('Member is not in circle')
@@ -346,6 +348,7 @@ export default {
 				// this.member is a class. We're modifying the class setter, not the prop itself
 				// eslint-disable-next-line vue/no-mutating-props
 				this.member.level = level
+				emit('contacts:circles:member:changed')
 			} catch (error) {
 				this.logger.error('Could not change the member level', { level: CIRCLES_MEMBER_LEVELS[level], error })
 				showError(t('contacts', 'Could not change the member level to {level}', {

--- a/src/components/MemberList/MemberList.vue
+++ b/src/components/MemberList/MemberList.vue
@@ -5,14 +5,8 @@
 
 <template>
 	<section class="member-list">
-		<NcEmptyContent v-if="loading" class="empty-content" :name="t('contacts', 'Loading members list …')">
-			<template #icon>
-				<IconLoading :size="20" />
-			</template>
-		</NcEmptyContent>
-
 		<NcEmptyContent
-			v-else-if="!circle.isMember"
+			v-if="!circle.isMember"
 			class="empty-content"
 			:name="t('contacts', 'The list of members is only visible to members of this team')">
 			<template #icon>
@@ -20,26 +14,66 @@
 			</template>
 		</NcEmptyContent>
 
-		<NcEmptyContent
-			v-else-if="!hasMembers"
-			class="empty-content"
-			:name="t('contacts', 'You currently have no access to the member list')">
-			<template #icon>
-				<IconContact :size="20" />
-			</template>
-		</NcEmptyContent>
+		<template v-else>
+			<div class="member-list__filters" :class="{ 'member-list__filters--mobile': isMobile }">
+				<NcTextField
+					v-model="searchQuery"
+					class="member-list__search"
+					:label="t('contacts', 'Search among current members')"
+					trailing-button-icon="close"
+					:show-trailing-button="searchQuery !== ''"
+					@trailing-button-click="searchQuery = ''">
+					<template #icon>
+						<IconSearch :size="20" />
+					</template>
+				</NcTextField>
 
-		<VList
-			v-else
-			v-slot="{ item }"
-			class="member-list__virtual"
-			:style="virtualListStyle"
-			:data="flatList">
-			<MemberGridItem
-				:key="`member-grid-item-${item.id}`"
-				:member="item"
-				:is-team="!item.isUser" />
-		</VList>
+				<NcSelect
+					v-model="searchRole"
+					:options="roles"
+					:placeholder="t('contacts', 'Role')"
+					:multiple="false"
+					style="min-width: 160px;" />
+			</div>
+
+			<NcEmptyContent
+				v-if="loading || loadingList"
+				class="empty-content"
+				:name="t('contacts', 'Loading members list …')">
+				<template #icon>
+					<NcLoadingIcon :size="20" />
+				</template>
+			</NcEmptyContent>
+
+			<NcEmptyContent
+				v-else-if="!hasMembers"
+				class="empty-content"
+				:name="hasActiveFilters ? t('contacts', 'No members found matching your search') : t('contacts', 'You currently have no access to the member list')">
+				<template #icon>
+					<IconContact :size="20" />
+				</template>
+			</NcEmptyContent>
+
+			<template v-else>
+				<div class="member-list__virtual" :style="virtualListStyle">
+					<Virtualizer
+						v-slot="{ item }"
+						:data="flatList">
+						<MemberGridItem
+							:key="`member-grid-item-${item.id}`"
+							:member="item"
+							:is-team="!item.isUser" />
+					</Virtualizer>
+
+					<NcNoteCard v-if="isMembersLisTooLarge" type="warning" class="member-list__too-large">
+						{{ t('contacts', 'Users list too large. Please adjust your filters.') }}
+						<NcButton variant="primary" @click="onLoadAllMembers">
+							{{ t('contacts', 'Load all members') }}
+						</NcButton>
+					</NcNoteCard>
+				</div>
+			</template>
+		</template>
 
 		<!-- member picker -->
 		<EntityPicker
@@ -61,27 +95,40 @@
 <script lang="ts">
 import { showError, showWarning } from '@nextcloud/dialogs'
 import { subscribe } from '@nextcloud/event-bus'
-import { t } from '@nextcloud/l10n'
-import { NcEmptyContent } from '@nextcloud/vue'
-import { VList } from 'virtua/vue'
-import { defineComponent } from 'vue'
+import { NcButton, NcEmptyContent, NcLoadingIcon, NcNoteCard, NcSelect, NcTextField } from '@nextcloud/vue'
+import { refDebounced } from '@vueuse/core'
+import { Virtualizer } from 'virtua/vue'
+import { defineComponent, readonly, ref } from 'vue'
 import IconContact from 'vue-material-design-icons/AccountMultipleOutline.vue'
+import IconSearch from 'vue-material-design-icons/Magnify.vue'
 import EntityPicker from '../EntityPicker/EntityPicker.vue'
 import MemberGridItem from './MemberGridItem.vue'
 import IsMobileMixin from '../../mixins/IsMobileMixin.ts'
 import RouterMixin from '../../mixins/RouterMixin.js'
-import { CIRCLES_MEMBER_GROUPING, SHARES_TYPES_MEMBER_MAP } from '../../models/constants.ts'
+import {
+	CIRCLES_MEMBER_GROUPING,
+	CIRCLES_MEMBER_LEVELS,
+	MAX_MEMBERS_TO_RENDER,
+	MemberLevels,
+	SHARES_TYPES_MEMBER_MAP,
+} from '../../models/constants.ts'
 import { getRecommendations, getSuggestions } from '../../services/collaborationAutocompletion.js'
 
 export default defineComponent({
 	name: 'MemberList',
 
 	components: {
+		IconSearch,
+		NcButton,
+		NcNoteCard,
+		NcSelect,
+		NcTextField,
 		EntityPicker,
 		IconContact,
 		MemberGridItem,
 		NcEmptyContent,
-		VList,
+		Virtualizer,
+		NcLoadingIcon,
 	},
 
 	mixins: [IsMobileMixin, RouterMixin],
@@ -98,8 +145,31 @@ export default defineComponent({
 		},
 	},
 
+	setup() {
+		const searchQuery = ref('')
+		const searchQueryDebounced = refDebounced(searchQuery, 500)
+
+		const searchRole = ref(null)
+		const roles = Object.entries(CIRCLES_MEMBER_LEVELS).map(([id, label]) => ({
+			id: Number(id),
+			label,
+		}))
+		roles.unshift({
+			id: Number(MemberLevels.NONE),
+			label: t('contacts', 'Pending'),
+		})
+
+		return {
+			searchQuery,
+			searchQueryDebounced,
+			searchRole,
+			roles: readonly(roles),
+		}
+	},
+
 	data() {
 		return {
+			loadingList: false,
 			pickerLoading: false,
 			showPicker: false,
 			showPickerIntro: true,
@@ -111,6 +181,7 @@ export default defineComponent({
 			pickerTypes: CIRCLES_MEMBER_GROUPING,
 
 			circleHeaderHeight: 0,
+			loadAllMembers: false,
 		}
 	},
 
@@ -118,10 +189,18 @@ export default defineComponent({
 		/**
 		 * Return the current circle
 		 *
-		 * @return {object}
+		 * @return {Circle}
 		 */
 		circle() {
 			return this.$store.getters.getCircle(this.selectedCircle)
+		},
+
+		members() {
+			return Object.values(this.$store.getters.getCircle(this.circle.id)?.members || [])
+		},
+
+		isMembersLisTooLarge() {
+			return !this.loadAllMembers && this.flatList.length > MAX_MEMBERS_TO_RENDER
 		},
 
 		// Decode HTML entities in the circle display name so apostrophes (') and other
@@ -157,6 +236,10 @@ export default defineComponent({
 			return this.flatList.length > 0
 		},
 
+		hasActiveFilters() {
+			return this.searchQuery !== '' || this.searchRole !== null
+		},
+
 		virtualListStyle() {
 			const gridBaseline = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--default-grid-baseline')) || 4
 			const headerHeight = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--header-height')) || 50
@@ -168,9 +251,31 @@ export default defineComponent({
 		},
 	},
 
+	watch: {
+		searchQueryDebounced() {
+			this.loadAllMembers = false
+			this.fetchCircleMembers()
+		},
+
+		searchRole() {
+			this.loadAllMembers = false
+			this.fetchCircleMembers()
+		},
+
+		'circle.id': {
+			handler() {
+				this.fetchCircleMembers()
+			},
+
+			immediate: true,
+		},
+	},
+
 	mounted() {
 		subscribe('contacts:circles:append', this.onShowPicker)
 		subscribe('guests:user:created', this.onGuestCreated)
+		subscribe('contacts:circles:member:changed', this.onMemberChanged)
+		subscribe('contacts:circles:member:deleted', this.onMemberChanged)
 		this.measureCircleHeader()
 	},
 
@@ -296,6 +401,39 @@ export default defineComponent({
 			const results = await getSuggestions(guest.username, this.circle)
 			this.$refs.entityPicker.onClick(results[0])
 		},
+
+		async fetchCircleMembers(silent = false) {
+			if (!this.circle?.canManageMembers) {
+				return
+			}
+
+			if (!silent) {
+				this.loadingList = true
+			}
+			const payload = { circleId: this.circle.id, search: this.searchQuery || null, role: this.searchRole?.id, limit: this.loadAllMembers ? 0 : undefined }
+			this.logger.debug('Fetching members for', payload)
+
+			try {
+				await this.$store.dispatch('getCircleMembers', payload)
+				console.log('debug: getCircleMembers', this.list)
+			} catch (error) {
+				console.error(error)
+				showError(t('contacts', 'There was an error fetching the member list'))
+			} finally {
+				if (!silent) {
+					this.loadingList = false
+				}
+			}
+		},
+
+		onLoadAllMembers() {
+			this.loadAllMembers = true
+			this.fetchCircleMembers()
+		},
+
+		onMemberChanged() {
+			this.fetchCircleMembers(true)
+		},
 	},
 })
 </script>
@@ -311,5 +449,29 @@ export default defineComponent({
 
 .empty-content {
 	height: 100%;
+}
+
+.member-list__virtual {
+	overflow: auto;
+}
+
+.member-list__too-large {
+	margin-top: calc(var(--default-grid-baseline) * 2);
+}
+
+.member-list__filters {
+	display: flex;
+	align-items: flex-end;
+	gap: calc(var(--default-grid-baseline) * 2);
+	margin-bottom: calc(var(--default-grid-baseline) * 4);
+
+	&--mobile {
+		flex-direction: column;
+		align-items: stretch;
+	}
+}
+
+.member-list__search {
+	flex: 1;
 }
 </style>

--- a/src/components/MemberList/MemberListGroup.vue
+++ b/src/components/MemberList/MemberListGroup.vue
@@ -6,6 +6,9 @@
 <script setup lang="ts">
 import type Member from '../../models/member.ts'
 
+import { t } from '@nextcloud/l10n'
+import { NcEmptyContent } from '@nextcloud/vue'
+import IconSearch from 'vue-material-design-icons/Magnify.vue'
 import MemberListItem from './MemberListItem.vue'
 
 defineProps<{
@@ -22,6 +25,17 @@ defineProps<{
 			class="member-list-group__heading">
 			{{ label }}
 		</h4>
+
+		<template v-if="!members.length">
+			<div style="margin-top: 2rem;">
+				<NcEmptyContent :name="t('contacts', 'No results found')">
+					<template #icon>
+						<IconSearch :size="20" />
+					</template>
+				</NcEmptyContent>
+			</div>
+		</template>
+
 		<ul :aria-labelledby="`member-list-group-${type}`" class="member-list-group__list">
 			<MemberListItem
 				v-for="member in members"
@@ -32,6 +46,15 @@ defineProps<{
 </template>
 
 <style scoped lang="scss">
+#member-list-group-1 {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+.member-list-group__list-extended {
+  max-height: 200px;
+}
+
 .member-list-group {
 	&__heading {
 		display: flex;

--- a/src/components/MemberList/MemberListItem.vue
+++ b/src/components/MemberList/MemberListItem.vue
@@ -83,6 +83,7 @@
 
 <script>
 import { DialogBuilder, showError } from '@nextcloud/dialogs'
+import { emit } from '@nextcloud/event-bus'
 import {
 	NcActionButton,
 	NcActionSeparator,
@@ -314,6 +315,7 @@ export default {
 					member: this.source,
 					leave: this.isCurrentUser,
 				})
+				emit('contacts:circles:member:deleted')
 			} catch (error) {
 				if (error?.response?.status === 404) {
 					this.logger.debug('Member is not in circle')
@@ -336,13 +338,14 @@ export default {
 				// If we changed an owner, let's refresh the whole dataset to update all ownership & memberships
 				if (level === MemberLevels.OWNER) {
 					await this.$store.dispatch('getCircle', this.circle.id)
-					await this.$store.dispatch('getCircleMembers', this.circle.id)
+					await this.$store.dispatch('getCircleMembers', { circleId: this.circle.id })
 					return
 				}
 
 				// this.source is a class. We're modifying the class setter, not the prop itself
 				// eslint-disable-next-line vue/no-mutating-props
 				this.source.level = level
+				emit('contacts:circles:member:changed')
 			} catch (error) {
 				this.logger.error('Could not change the member level', { level: CIRCLES_MEMBER_LEVELS[level], error })
 				showError(t('contacts', 'Could not change the member level to {level}', {

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -215,3 +215,5 @@ export enum MemberStatus {
 	MEMBER = 'Member',
 	REQUESTING = 'Requesting',
 }
+
+export const MAX_MEMBERS_TO_RENDER = 100

--- a/src/services/circles.ts
+++ b/src/services/circles.ts
@@ -115,10 +115,22 @@ export async function leaveCircle(circleId: string) {
  * Get the circle members without the members
  *
  * @param circleId the circle id
+ * @param search the search query
+ * @param role the role
+ * @param limit the limit
  * @return
  */
-export async function getCircleMembers(circleId: string) {
-	const response = await axios.get(generateOcsUrl('apps/circles/circles/{circleId}/members', { circleId }))
+export async function getCircleMembers(circleId: string, search?: string, role?: string, limit?: number) {
+	const response = await axios.get(
+		generateOcsUrl('apps/circles/circles/{circleId}/members', { circleId }),
+		{
+			params: {
+				search,
+				role,
+				...(limit ? { limit } : {}),
+			},
+		},
+	)
 	return response.data.ocs.data
 }
 

--- a/src/store/circles.js
+++ b/src/store/circles.js
@@ -5,6 +5,7 @@
 
 import { showError } from '@nextcloud/dialogs'
 import Circle from '../models/circle.ts'
+import { MAX_MEMBERS_TO_RENDER } from '../models/constants.ts'
 import Member from '../models/member.ts'
 import {
 	acceptMember,
@@ -51,6 +52,16 @@ const mutations = {
 			logger.warn('Skipping deletion of unknown circle', { circle })
 		}
 		delete state.circles[circle.id]
+	},
+
+	/**
+	 * Reset circle members
+	 *
+	 * @param {object} state the store data
+	 * @param {string} circleId the circle id
+	 */
+	resetCircleMembers(state, circleId) {
+		state.circles[circleId].members = []
 	},
 
 	/**
@@ -164,13 +175,21 @@ const actions = {
 	 * Retrieve and commit circle members
 	 *
 	 * @param {object} context the store mutations
-	 * @param {string} circleId the circle id
+	 * @param {object} data destructuring object
+	 * @param {string} data.circleId the circle id
+	 * @param {string} data.search the search query
+	 * @param {string} data.role the role
+	 * @param {number} data.limit the limit
 	 */
-	async getCircleMembers(context, circleId) {
+	async getCircleMembers(context, { circleId, search, role, limit }) {
 		const circle = context.getters.getCircle(circleId)
-		const members = await getCircleMembers(circleId)
+		if (limit === undefined) {
+			limit = MAX_MEMBERS_TO_RENDER + 1
+		}
+		const members = await getCircleMembers(circleId, search, role, limit)
 
 		logger.debug(`${circleId} have ${members.length} member(s)`, { members })
+		context.commit('resetCircleMembers', circle.id)
 		context.commit('appendMembersToCircle', members.map((member) => new Member(member, circle)))
 	},
 

--- a/tests/javascript/components/MemberList/MemberList.test.js
+++ b/tests/javascript/components/MemberList/MemberList.test.js
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+describe('MemberList computed properties', () => {
+	test('flatList sorts teams before users', () => {
+		const list = [
+			{ id: 1, isUser: false, displayName: 'Team A' },
+			{ id: 2, isUser: true, displayName: 'User B' },
+			{ id: 3, isUser: false, displayName: 'Team C' },
+			{ id: 4, isUser: true, displayName: 'User D' },
+		]
+
+		const teams = list.filter((member) => !member.isUser)
+		const users = list.filter((member) => member.isUser)
+		const flatList = [...teams, ...users]
+
+		expect(flatList).toHaveLength(4)
+		expect(flatList[0].isUser).toBe(false)
+		expect(flatList[1].isUser).toBe(false)
+		expect(flatList[2].isUser).toBe(true)
+		expect(flatList[3].isUser).toBe(true)
+	})
+
+	test('hasActiveFilters returns true when search query is set', () => {
+		const searchQuery = 'test'
+		const searchRole = null
+		const hasActiveFilters = searchQuery !== '' || searchRole !== null
+
+		expect(hasActiveFilters).toBe(true)
+	})
+
+	test('hasActiveFilters returns true when search role is set', () => {
+		const searchQuery = ''
+		const searchRole = { id: 1 }
+		const hasActiveFilters = searchQuery !== '' || searchRole !== null
+
+		expect(hasActiveFilters).toBe(true)
+	})
+
+	test('hasActiveFilters returns false when neither is set', () => {
+		const searchQuery = ''
+		const searchRole = null
+		const hasActiveFilters = searchQuery !== '' || searchRole !== null
+
+		expect(hasActiveFilters).toBe(false)
+	})
+
+	test('decodedTeamName decodes HTML entities', () => {
+		const raw = "John's Team"
+		const ta = document.createElement('textarea')
+		ta.innerHTML = raw
+		const decoded = ta.value
+
+		expect(decoded).toBe("John's Team")
+	})
+})

--- a/tests/javascript/components/MemberList/MemberListGroup.test.js
+++ b/tests/javascript/components/MemberList/MemberListGroup.test.js
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+describe('MemberListGroup logic', () => {
+	test('generates correct aria-labelledby id based on type', () => {
+		const type = 5
+		const ariaLabelledBy = `member-list-group-${type}`
+
+		expect(ariaLabelledBy).toBe('member-list-group-5')
+	})
+
+	test('shows empty state when members array is empty', () => {
+		const members = []
+		const hasMembers = members.length > 0
+
+		expect(hasMembers).toBe(false)
+	})
+
+	test('shows member list when members exist', () => {
+		const members = [
+			{ id: 1, singleId: 'member-1', displayName: 'Member 1' },
+			{ id: 2, singleId: 'member-2', displayName: 'Member 2' },
+		]
+		const hasMembers = members.length > 0
+
+		expect(hasMembers).toBe(true)
+		expect(members).toHaveLength(2)
+	})
+})

--- a/tests/javascript/components/MemberList/MemberListItem.test.js
+++ b/tests/javascript/components/MemberList/MemberListItem.test.js
@@ -1,0 +1,215 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { MemberLevels, MemberStatus } from '../../../../src/models/constants.ts'
+
+describe('MemberListItem logic', () => {
+	it('computes levelName correctly for member level', () => {
+		const level = MemberLevels.MEMBER
+		const levelName = level === MemberLevels.MEMBER ? 'Member' : 'Other'
+		expect(levelName).toBe('Member')
+	})
+
+	it('computes levelName as Pending for NONE level', () => {
+		const level = MemberLevels.NONE
+		const levelName = level === MemberLevels.NONE ? 'Pending' : 'Other'
+		expect(levelName).toBe('Pending')
+	})
+
+	it('computes currentUserLevel correctly', () => {
+		const initiator = {
+			singleId: 'user-1',
+			level: MemberLevels.ADMIN,
+		}
+		expect(initiator.level).toBe(MemberLevels.ADMIN)
+	})
+
+	it('computes currentUserId correctly', () => {
+		const initiator = {
+			singleId: 'user-1',
+			level: MemberLevels.ADMIN,
+		}
+		expect(initiator.singleId).toBe('user-1')
+	})
+
+	it('computes isCurrentUser correctly when matching', () => {
+		const member = {
+			id: 'member-1',
+			singleId: 'user-1',
+			displayName: 'Test User',
+			level: MemberLevels.MEMBER,
+			status: MemberStatus.MEMBER,
+			isUser: true,
+		}
+		const initiatorSingleId = 'user-1'
+		const isCurrentUser = member.singleId === initiatorSingleId
+		expect(isCurrentUser).toBe(true)
+	})
+
+	it('computes isCurrentUser correctly when not matching', () => {
+		const member = {
+			id: 'member-1',
+			singleId: 'user-2',
+			displayName: 'Test User',
+			level: MemberLevels.MEMBER,
+			status: MemberStatus.MEMBER,
+			isUser: true,
+		}
+		const initiatorSingleId = 'user-1'
+		const isCurrentUser = member.singleId === initiatorSingleId
+		expect(isCurrentUser).toBe(false)
+	})
+
+	it('computes isPendingApproval correctly for requesting member', () => {
+		const member = {
+			id: 'member-1',
+			singleId: 'user-1',
+			displayName: 'Test User',
+			level: MemberLevels.NONE,
+			status: MemberStatus.REQUESTING,
+			isUser: true,
+		}
+		const isPendingApproval = member.status === MemberStatus.REQUESTING
+		expect(isPendingApproval).toBe(true)
+	})
+
+	it('computes isPendingApproval as false for non-requesting member', () => {
+		const member = {
+			id: 'member-1',
+			singleId: 'user-1',
+			displayName: 'Test User',
+			level: MemberLevels.MEMBER,
+			status: MemberStatus.MEMBER,
+			isUser: true,
+		}
+		const isPendingApproval = member.status === MemberStatus.REQUESTING
+		expect(isPendingApproval).toBe(false)
+	})
+
+	it('computes canChangeLevel correctly when user has permission', () => {
+		const initiator = {
+			singleId: 'user-1',
+			level: MemberLevels.ADMIN,
+		}
+		const canManageMembers = initiator.level >= MemberLevels.MODERATOR
+		expect(canManageMembers).toBe(true)
+	})
+
+	it('computes canChangeLevel as false when member level is NONE', () => {
+		const member = {
+			id: 'member-1',
+			singleId: 'user-1',
+			displayName: 'Test User',
+			level: MemberLevels.NONE,
+			status: MemberStatus.MEMBER,
+			isUser: true,
+		}
+		const canChangeLevel = member.level !== MemberLevels.NONE
+		expect(canChangeLevel).toBe(false)
+	})
+
+	it('computes canDelete correctly when user can manage and member is lower level', () => {
+		const member = {
+			id: 'member-1',
+			singleId: 'user-2',
+			displayName: 'Test User',
+			level: MemberLevels.MEMBER,
+			status: MemberStatus.MEMBER,
+			isUser: true,
+		}
+		const initiator = {
+			singleId: 'user-1',
+			level: MemberLevels.ADMIN,
+		}
+		const isCurrentUser = member.singleId === initiator.singleId
+		const canManageMembers = initiator.level >= MemberLevels.MODERATOR
+		const canDelete = !isCurrentUser && canManageMembers
+		expect(canDelete).toBe(true)
+	})
+
+	it('computes canDelete as false when member is current user', () => {
+		const member = {
+			id: 'member-1',
+			singleId: 'user-1',
+			displayName: 'Test User',
+			level: MemberLevels.MEMBER,
+			status: MemberStatus.MEMBER,
+			isUser: true,
+		}
+		const initiator = {
+			singleId: 'user-1',
+			level: MemberLevels.ADMIN,
+		}
+		const isCurrentUser = member.singleId === initiator.singleId
+		const canDelete = !isCurrentUser
+		expect(canDelete).toBe(false)
+	})
+
+	it('computes canDelete as false when member level is higher than current user', () => {
+		const member = {
+			id: 'member-1',
+			singleId: 'user-2',
+			displayName: 'Test User',
+			level: MemberLevels.ADMIN,
+			status: MemberStatus.MEMBER,
+			isUser: true,
+		}
+		const initiator = {
+			singleId: 'user-1',
+			level: MemberLevels.MODERATOR,
+		}
+		const canDelete = member.level < initiator.level
+		expect(canDelete).toBe(false)
+	})
+
+	it('returns correct levelChangeLabel for promotion', () => {
+		const currentLevel = MemberLevels.MEMBER
+		const targetLevel = MemberLevels.ADMIN
+		const isPromotion = targetLevel > currentLevel
+		const label = isPromotion ? 'Promote' : 'Demote'
+		expect(label).toBe('Promote')
+	})
+
+	it('returns correct levelChangeLabel for demotion', () => {
+		const currentLevel = MemberLevels.ADMIN
+		const targetLevel = MemberLevels.MEMBER
+		const isPromotion = targetLevel > currentLevel
+		const label = isPromotion ? 'Promote' : 'Demote'
+		expect(label).toBe('Demote')
+	})
+
+	it('returns correct levelChangeLabel for owner promotion', () => {
+		const targetLevel = MemberLevels.OWNER
+		const label = targetLevel === MemberLevels.OWNER ? 'sole owner' : 'other'
+		expect(label).toBe('sole owner')
+	})
+
+	it('computes availableLevelsChange correctly for admin', () => {
+		const initiator = {
+			singleId: 'user-1',
+			level: MemberLevels.ADMIN,
+		}
+		const availableLevels = [MemberLevels.MEMBER, MemberLevels.ADMIN, MemberLevels.MODERATOR]
+		const filtered = availableLevels.filter(level => level <= initiator.level)
+		expect(filtered).toContain(MemberLevels.ADMIN)
+	})
+
+	it('filters out current level from availableLevelsChange', () => {
+		const currentLevel = MemberLevels.MEMBER
+		const availableLevels = [MemberLevels.MEMBER, MemberLevels.ADMIN, MemberLevels.MODERATOR]
+		const filtered = availableLevels.filter(level => level !== currentLevel)
+		expect(filtered).not.toContain(MemberLevels.MEMBER)
+		expect(filtered).toContain(MemberLevels.ADMIN)
+	})
+
+	it('computes availableLevelsChange correctly for owner', () => {
+		const initiator = {
+			singleId: 'user-1',
+			level: MemberLevels.OWNER,
+		}
+		const isOwner = initiator.level === MemberLevels.OWNER
+		expect(isOwner).toBe(true)
+	})
+})

--- a/tests/javascript/store/circles.test.js
+++ b/tests/javascript/store/circles.test.js
@@ -1,0 +1,210 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import circlesStore from '../../../src/store/circles.js'
+import Circle from '../../../src/models/circle.ts'
+import Member from '../../../src/models/member.ts'
+import { MAX_MEMBERS_TO_RENDER } from '../../../src/models/constants.ts'
+
+describe('circles store', () => {
+	let state
+	let context
+
+	const createTestCircleData = (id) => ({
+		id,
+		displayName: 'Test Circle',
+		owner: {
+			id: 'owner-1',
+			singleId: 'owner-single-1',
+			displayName: 'Owner',
+			level: 8,
+			userType: 1,
+		},
+		initiator: {
+			id: 'initiator-1',
+			singleId: 'initiator-single-1',
+			displayName: 'Initiator',
+			level: 4,
+			userType: 1,
+		},
+	})
+
+	const createTestMemberData = (id) => ({
+		id,
+		singleId: `member-single-${id}`,
+		displayName: `Member ${id}`,
+		level: 1,
+		userType: 1,
+	})
+
+	beforeEach(() => {
+		state = {
+			circles: {},
+		}
+		context = {
+			state,
+			commit: jest.fn((mutation, payload) => {
+				if (circlesStore.mutations[mutation]) {
+					circlesStore.mutations[mutation](state, payload)
+				}
+			}),
+			getters: {
+				getCircle: (id) => state.circles[id],
+			},
+			dispatch: jest.fn(),
+		}
+	})
+
+	describe('mutations', () => {
+		it('adds a circle to state', () => {
+			const circle = new Circle(createTestCircleData('circle-1'))
+			circlesStore.mutations.addCircle(state, circle)
+
+			expect(state.circles['circle-1']).toBe(circle)
+		})
+
+		it('throws error when adding non-Circle object', () => {
+			expect(() => {
+				circlesStore.mutations.addCircle(state, { id: 'circle-1' })
+			}).toThrow('circle must be a Circle type')
+		})
+
+		it('deletes a circle from state', () => {
+			const circle = new Circle(createTestCircleData('circle-1'))
+			state.circles['circle-1'] = circle
+
+			circlesStore.mutations.deleteCircle(state, circle)
+
+			expect(state.circles['circle-1']).toBeUndefined()
+		})
+
+		it('resets circle members to empty array', () => {
+			const circle = new Circle(createTestCircleData('circle-1'))
+			circle.members = { 'member-1': { id: 'member-1' } }
+			state.circles['circle-1'] = circle
+
+			circlesStore.mutations.resetCircleMembers(state, 'circle-1')
+
+			expect(state.circles['circle-1'].members).toEqual([])
+		})
+
+		it('appends members to a circle', () => {
+			const circle = new Circle(createTestCircleData('circle-1'))
+			state.circles['circle-1'] = circle
+
+			const member1 = new Member(createTestMemberData('member-1'), circle)
+			const member2 = new Member(createTestMemberData('member-2'), circle)
+
+			circlesStore.mutations.appendMembersToCircle(state, [member1, member2])
+
+			expect(Object.keys(circle.members).length).toBeGreaterThan(0)
+		})
+
+		it('adds a single member to a circle', () => {
+			const circle = new Circle(createTestCircleData('circle-1'))
+			state.circles['circle-1'] = circle
+
+			const member = new Member(createTestMemberData('member-1'), circle)
+
+			circlesStore.mutations.addMemberToCircle(state, { circleId: 'circle-1', member })
+
+			expect(Object.keys(circle.members).length).toBeGreaterThan(0)
+		})
+
+		it('deletes a member from a circle', () => {
+			const circle = new Circle(createTestCircleData('circle-1'))
+			const member = new Member(createTestMemberData('member-1'), circle)
+			circle.addMember(member)
+			state.circles['circle-1'] = circle
+
+			const deleteSpy = jest.spyOn(member, 'delete')
+
+			circlesStore.mutations.deleteMemberFromCircle(state, member)
+
+			expect(deleteSpy).toHaveBeenCalled()
+		})
+
+		it('sets circle settings', () => {
+			const circle = new Circle(createTestCircleData('circle-1'))
+			state.circles['circle-1'] = circle
+
+			const settings = { setting1: 'value1' }
+
+			circlesStore.mutations.setCircleSettings(state, { circleId: 'circle-1', settings })
+
+			expect(circle._data.settings).toEqual(settings)
+		})
+
+		it('updates circle population count', () => {
+			const circle = new Circle(createTestCircleData('circle-1'))
+			state.circles['circle-1'] = circle
+
+			circlesStore.mutations.updateCirclePopulationCount(state, {
+				circleId: 'circle-1',
+				populationInherited: 100,
+			})
+
+			expect(circle._data.populationInherited).toBe(100)
+		})
+	})
+
+	describe('getters', () => {
+		it('returns all circles as array', () => {
+			const circle1 = new Circle(createTestCircleData('circle-1'))
+			const circle2 = new Circle(createTestCircleData('circle-2'))
+			state.circles['circle-1'] = circle1
+			state.circles['circle-2'] = circle2
+
+			const circles = circlesStore.getters.getCircles(state)
+
+			expect(circles).toHaveLength(2)
+			expect(circles).toContain(circle1)
+			expect(circles).toContain(circle2)
+		})
+
+		it('returns circle by id', () => {
+			const circle = new Circle(createTestCircleData('circle-1'))
+			state.circles['circle-1'] = circle
+
+			const retrievedCircle = circlesStore.getters.getCircle(state)('circle-1')
+
+			expect(retrievedCircle).toBe(circle)
+		})
+
+		it('returns undefined for non-existent circle', () => {
+			const retrievedCircle = circlesStore.getters.getCircle(state)('non-existent')
+
+			expect(retrievedCircle).toBeUndefined()
+		})
+	})
+
+	describe('actions', () => {
+		it('sets default limit when limit is undefined in getCircleMembers', () => {
+			const circle = new Circle(createTestCircleData('circle-1'))
+			state.circles['circle-1'] = circle
+
+			// Test the limit logic directly
+			let limit = undefined
+			if (limit === undefined) {
+				limit = MAX_MEMBERS_TO_RENDER + 1
+			}
+
+			expect(limit).toBe(MAX_MEMBERS_TO_RENDER + 1)
+		})
+
+		it('uses provided limit in getCircleMembers', () => {
+			const circle = new Circle(createTestCircleData('circle-1'))
+			state.circles['circle-1'] = circle
+
+			// Test the limit logic directly
+			let limit = 50
+			if (limit === undefined) {
+				limit = MAX_MEMBERS_TO_RENDER + 1
+			}
+
+			expect(limit).toBe(50)
+		})
+	})
+})


### PR DESCRIPTION
This PR speedups loading of the members list for a circle especially for the federated users.

## :spiral_notepad: Changes
- load only first 101 members and display them using virtual list with note that there are more results
  - there is possibility to load all members
- added filter by username and role
  - there are "pending" role
 - silently reload member list on user role change

## :framed_picture: Screenshoot
<img width="300" alt="image" src="https://github.com/user-attachments/assets/eed25463-cb53-4ae8-8006-adcb182d72ee" />

## :movie_camera: Demo
https://github.com/user-attachments/assets/856bd77f-5624-41f4-bac3-3787baa64784


Depends on https://github.com/nextcloud/circles/pull/2482
