### PR TITLE
fix(teams): circular Talk previews, border-radius-small for Files previews

### DIFF
--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -210,7 +210,11 @@
 				</template>
 
 				<section v-else>
-					<div v-for="(group, providerId) in groupedResources" :key="providerId" class="circle-details-section">
+					<div
+						v-for="(group, providerId) in groupedResources"
+						:key="providerId"
+						class="circle-details-section"
+						:class="`circle-details-section--${providerId}`">
 						<div class="section-header">
 							<ContentHeading>{{ group.name }}</ContentHeading>
 						</div>
@@ -1156,6 +1160,15 @@ export default {
 					height: 32px;
 				}
 			}
+
+		}
+
+		&.circle-details-section--talk .item-list :deep(img.resource__icon) {
+			border-radius: var(--border-radius-pill);
+		}
+
+		&.circle-details-section--files .item-list :deep(img.resource__icon) {
+			border-radius: var(--border-radius-small);
 		}
 
 		.avatar-list {


### PR DESCRIPTION
Fixes the previews in Teams not looking correct. Together with https://github.com/nextcloud/circles/pull/2494

Previews in Teams are currently square.
Previews for Files should have border-radius-small. The previews in "Talk conversations" should be circular.

Before | After
-|-
<img width="1450" height="860" alt="Screenshot From 2026-05-27 14-02-23" src="https://github.com/user-attachments/assets/1874e112-60d0-4a81-b5c1-5a3e47158988" />|<img width="1450" height="860" alt="Screenshot From 2026-05-27 13-56-28" src="https://github.com/user-attachments/assets/401b5a0e-dc37-41b4-92f0-a347ca016641" />



## Summary

- Adds a provider-based CSS class (`circle-details-section--{providerId}`) to each resource section so styles can be scoped by provider
- Talk conversation images get `border-radius-pill` (circular)
- Files image previews get `border-radius-small` (slightly rounded corners)

## Test plan

- Open Contacts, navigate to a Team/Circle that has both shared Talk conversations and shared files
- Confirm Talk conversation avatars are circular
- Confirm Files image previews have small rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)