### PR TITLE
Bug: Federated Cloud ID shown as array object

### DIFF
--- a/src/models/rfcProps.js
+++ b/src/models/rfcProps.js
@@ -90,7 +90,7 @@ const properties = {
 		readableName: t('contacts', 'Federated Cloud ID'),
 		force: 'text',
 		defaultValue: {
-			value: [''],
+			value: '',
 			type: [defaultProfileState],
 		},
 		options: [


### PR DESCRIPTION
# Summary
When an empty Federated Cloud ID is added, the record is shown as empty array.
Also returns a JSON error in de browser console.

# Fix
Make not an array but string object.

<img width="1534" height="577" alt="FedCloudID" src="https://github.com/user-attachments/assets/36d1d117-908e-4b39-a4cc-0d438a59b59e" />
