### PR TITLE
Feat: Make Federated Cloud ID by default visible in Contacts Card

### DIFF
--- a/src/models/rfcProps.js
+++ b/src/models/rfcProps.js
@@ -91,7 +91,7 @@ const properties = {
 		force: 'text',
 		default: true,
 		defaultValue: {
-			value: [''],
+			value: '',
 			type: [defaultProfileState],
 		},
 		options: [

--- a/src/models/rfcProps.js
+++ b/src/models/rfcProps.js
@@ -89,6 +89,7 @@ const properties = {
 		icon: 'icon-federated-cloud-id',
 		readableName: t('contacts', 'Federated Cloud ID'),
 		force: 'text',
+		default: true,
 		defaultValue: {
 			value: [''],
 			type: [defaultProfileState],
@@ -98,7 +99,7 @@ const properties = {
 			{ id: 'WORK', name: t('contacts', 'Work') },
 			{ id: 'OTHER', name: t('contacts', 'Other') },
 		],
-		primary: false,
+		primary: true,
 	},
 	adr: {
 		multiple: true,
@@ -403,6 +404,7 @@ const fieldOrder = [
 	// primary fields
 	'tel',
 	'email',
+	'cloud',
 	'adr',
 	'bday',
 	'url',
@@ -419,7 +421,6 @@ const fieldOrder = [
 	'x-phonetic-first-name',
 	'x-phonetic-last-name',
 	'gender',
-	'cloud',
 	'impp',
 	'geo',
 	'note',


### PR DESCRIPTION
# Summary

Make Federated Cloud ID by default visible in Contacts Card.
This simplifies federated sharing, as the field is visible by default, making it easier to add contacts along with their federated cloud ID.

<img width="1019" height="835" alt="FedCloudID by default visible" src="https://github.com/user-attachments/assets/cff20e0f-5e87-4e0a-852f-f263b2c72fe5" />
