### PR TITLE
chore: drop support for stable8.6

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'stable8.3', 'stable8.6']
+        branches: ['main', 'stable8.3', 'stable8.7']
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/.tx/backport
+++ b/.tx/backport
@@ -1,2 +1,2 @@
 stable8.3
-stable8.6
+stable8.7

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@
 * 🙈 **We’re not reinventing the wheel!** Based on the great and open SabreDAV library.
 	</description>
 
-	<version>8.7.0-dev.0</version>
+	<version>8.8.0-dev.0</version>
 	<licence>AGPL-3.0-or-later</licence>
 
 	<author mail="hamza221@users.noreply.github.com">Hamza Mahjoubi</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contacts",
-  "version": "8.7.0-dev.0",
+  "version": "8.8.0-dev.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "contacts",
-      "version": "8.7.0-dev.0",
+      "version": "8.8.0-dev.0",
       "license": "agpl",
       "dependencies": {
         "@mattkrick/sanitize-svg": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contacts",
-  "version": "8.7.0-dev.0",
+  "version": "8.8.0-dev.0",
   "private": true,
   "description": "A contacts app for Nextcloud. Easily sync contacts from various devices, share and edit them online.",
   "keywords": [

--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
 	"ignoreUnstable": false,
 	"baseBranches": [
 		"main",
-		"stable8.6",
+		"stable8.7",
 		"stable8.3"
 	],
 	"enabledManagers": [


### PR DESCRIPTION
Due to a bug in release automation, v8.6.0 was skipped and v8.7.0 was released instead. 
* Dropping support for stable8.6 with this PR
* Branched of to stable8.7 from stable8.6 branch