### PR TITLE
[stable8.3] chore: Don't run test pipeline for stable8.3 against master

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         php-versions: ['8.2']
         databases: ['sqlite']
-        server-versions: ['master', 'stable32']
+        server-versions: ['stable32']
         include:
           - php-versions: '8.1'
             databases: 'sqlite'
@@ -94,7 +94,7 @@ jobs:
       matrix:
         php-versions: ['8.2', '8.3', '8.4']
         databases: ['mysql']
-        server-versions: ['master', 'stable32']
+        server-versions: ['stable32']
         include:
           - php-versions: '8.1'
             databases: 'mysql'
@@ -170,7 +170,7 @@ jobs:
       matrix:
         php-versions: ['8.2']
         databases: ['pgsql']
-        server-versions: ['master', 'stable32']
+        server-versions: ['stable32']
         include:
           - php-versions: '8.1'
             databases: 'pgsql'


### PR DESCRIPTION
`stable8.3` only supports Nextcloud 32. Anything else will break the pipeline and must therefore being removed to ensure backports can be merged smoothly.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
