### PR TITLE
fix: restore address book navigation in the sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17272,6 +17272,21 @@
         }
       }
     },
+    "node_modules/rollup-plugin-license/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/rollup-plugin-node-externals": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-8.1.2.tgz",
@@ -32721,6 +32736,14 @@
           "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
           "dev": true,
           "requires": {}
+        },
+        "picomatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },

--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -94,6 +94,29 @@
 				</template>
 			</AppNavigationItem>
 
+			<!-- Address books section -->
+			<AppNavigationCaption
+				:name="t('contacts', 'Address books')" />
+			<AppNavigationItem
+				v-for="addressbook in enabledAddressbooks"
+				:key="addressbook.id"
+				:name="addressbook.displayName"
+				:to="{
+					name: 'addressbook',
+					params: { selectedAddressbook: addressbook.id },
+				}"
+				:active="routeState === `addressbook:${addressbook.id}`"
+				@click="updateRouteState(`addressbook:${addressbook.id}`)">
+				<template #icon>
+					<IconAddressBook :size="20" />
+				</template>
+				<template #counter>
+					<NcCounterBubble
+						v-if="addressbookContactCount(addressbook)"
+						:count="addressbookContactCount(addressbook)" />
+				</template>
+			</AppNavigationItem>
+
 			<AppNavigationCaption
 				id="newgroup"
 				v-model:menu-open="isNewGroupMenuOpen"
@@ -218,6 +241,7 @@ import IconUserFilled from 'vue-material-design-icons/Account.vue'
 import IconContactFilled from 'vue-material-design-icons/AccountMultiple.vue'
 import IconContact from 'vue-material-design-icons/AccountMultipleOutline.vue'
 import IconUser from 'vue-material-design-icons/AccountOutline.vue'
+import IconAddressBook from 'vue-material-design-icons/BookAccountOutline.vue'
 import IconError from 'vue-material-design-icons/AlertCircleOutline.vue'
 import Cog from 'vue-material-design-icons/CogOutline.vue'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
@@ -247,6 +271,7 @@ export default {
 		Cog,
 		ContactsSettings,
 		GroupNavigationItem,
+		IconAddressBook,
 		IconContact,
 		IconContactFilled,
 		IconUser,
@@ -301,6 +326,14 @@ export default {
 
 	computed: {
 		// store variables
+		addressbooks() {
+			return this.$store.getters.getAddressbooks
+		},
+
+		enabledAddressbooks() {
+			return this.addressbooks.filter((ab) => ab.enabled)
+		},
+
 		circles() {
 			return this.$store.getters.getCircles
 		},
@@ -426,6 +459,10 @@ export default {
 	},
 
 	methods: {
+		addressbookContactCount(addressbook) {
+			return Object.keys(addressbook.contacts || {}).length
+		},
+
 		toggleNewGroupMenu() {
 			this.isNewGroupMenuOpen = !this.isNewGroupMenuOpen
 		},

--- a/src/components/AppNavigation/Settings/SettingsAddressbook.vue
+++ b/src/components/AppNavigation/Settings/SettingsAddressbook.vue
@@ -245,7 +245,7 @@ export default {
 
 		principalUrl() {
 			const principalsStore = usePrincipalsStore()
-			return principalsStore.currentUserPrincipal?.url
+			return principalsStore.currentUserPrincipal.principalUrl
 		},
 
 		isSharedWithMe() {

--- a/src/components/AppNavigation/Settings/SettingsAddressbook.vue
+++ b/src/components/AppNavigation/Settings/SettingsAddressbook.vue
@@ -245,7 +245,7 @@ export default {
 
 		principalUrl() {
 			const principalsStore = usePrincipalsStore()
-			return principalsStore.currentUserPrincipal.principalUrl
+			return principalsStore.currentUserPrincipal?.url
 		},
 
 		isSharedWithMe() {

--- a/src/components/ContactsList/ContactsListItem.vue
+++ b/src/components/ContactsList/ContactsListItem.vue
@@ -13,7 +13,7 @@
 			:key="source.key"
 			class="list-item-style envelope"
 			:name="source.displayName"
-			:to="isStatic ? undefined : { name: 'contact', params: { selectedGroup: selectedGroup, selectedContact: source.key } }">
+			:to="isStatic ? undefined : contactRoute">
 			<!-- @slot Icon slot -->
 
 			<template #icon>
@@ -94,6 +94,7 @@ import CheckIcon from 'vue-material-design-icons/Check.vue'
 import StarIcon from 'vue-material-design-icons/Star.vue'
 import StarOutlineIcon from 'vue-material-design-icons/StarOutline.vue'
 import RouterMixin from '../../mixins/RouterMixin.js'
+import { GROUP_ALL_CONTACTS } from '../../models/constants.ts'
 
 export default {
 	name: 'ContactsListItem',
@@ -153,6 +154,25 @@ export default {
 	},
 
 	computed: {
+		contactRoute() {
+			if (this.selectedAddressbook) {
+				return {
+					name: 'contact',
+					params: {
+						selectedGroup: GROUP_ALL_CONTACTS,
+						selectedContact: this.source.key,
+					},
+				}
+			}
+			return {
+				name: 'contact',
+				params: {
+					selectedGroup: this.selectedGroup,
+					selectedContact: this.source.key,
+				},
+			}
+		},
+
 		isFavorite() {
 			return this.source.favorite
 		},
@@ -269,11 +289,7 @@ export default {
 			if (this.isStatic) {
 				return
 			}
-			// change url with router
-			this.$router.push({
-				name: 'contact',
-				params: { selectedGroup: this.selectedGroup, selectedContact: this.source.key },
-			})
+			this.$router.push(this.contactRoute)
 		},
 
 		onSelectMultiple() {

--- a/src/mixins/RouterMixin.js
+++ b/src/mixins/RouterMixin.js
@@ -20,5 +20,8 @@ export default {
 		selectedChart() {
 			return this.$route.params.selectedChart
 		},
+		selectedAddressbook() {
+			return this.$route.params.selectedAddressbook
+		},
 	},
 }

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -28,6 +28,7 @@ export const CHART_ALL_CONTACTS: DefaultChart = t('contacts', 'Organization char
 export const ROUTE_CIRCLE = 'circle'
 export const ROUTE_CHART = 'chart'
 export const ROUTE_USER_GROUP = 'user_group'
+export const ROUTE_ADDRESSBOOK = 'addressbook'
 
 // Contact settings
 export const CONTACTS_SETTINGS: DefaultGroup = t('contacts', 'Contacts settings')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,7 +6,7 @@
 import { generateUrl } from '@nextcloud/router'
 import { createRouter, createWebHistory } from 'vue-router'
 import Contacts from '../views/Contacts.vue'
-import { ROUTE_CHART, ROUTE_CIRCLE, ROUTE_USER_GROUP } from '../models/constants.ts'
+import { ROUTE_ADDRESSBOOK, ROUTE_CHART, ROUTE_CIRCLE, ROUTE_USER_GROUP } from '../models/constants.ts'
 
 // if index.php is in the url AND we got this far, then it's working:
 // let's keep using index.php in the url
@@ -55,6 +55,11 @@ export default createRouter({
 				{
 					path: `${ROUTE_USER_GROUP}/:selectedUserGroup`,
 					name: 'user_group',
+					component: Contacts,
+				},
+				{
+					path: `${ROUTE_ADDRESSBOOK}/:selectedAddressbook`,
+					name: 'addressbook',
 					component: Contacts,
 				},
 			],

--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -187,6 +187,14 @@ export default {
 		 * @return {Array}
 		 */
 		contactsList() {
+			if (this.selectedAddressbook) {
+				const addressbook = this.addressbooks.find((ab) => ab.id === this.selectedAddressbook)
+				if (addressbook) {
+					const keys = Object.keys(addressbook.contacts)
+					return this.sortedContacts.filter((contact) => keys.includes(contact.key))
+				}
+				return []
+			}
 			if (this.selectedGroup === GROUP_ALL_CONTACTS) {
 				return this.sortedContacts
 			} else if (this.selectedGroup === GROUP_NO_GROUP_CONTACTS) {

--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -190,8 +190,10 @@ export default {
 			if (this.selectedAddressbook) {
 				const addressbook = this.addressbooks.find((ab) => ab.id === this.selectedAddressbook)
 				if (addressbook) {
-					const keys = Object.keys(addressbook.contacts)
-					return this.sortedContacts.filter((contact) => keys.includes(contact.key))
+					const contactKeys = new Set(
+						Object.values(addressbook.contacts).map((c) => c.key),
+					)
+					return this.sortedContacts.filter((contact) => contactKeys.has(contact.key))
 				}
 				return []
 			}
@@ -288,6 +290,10 @@ export default {
 				return
 			}
 
+			const targetAddressbook = this.selectedAddressbook
+				? this.addressbooks.find((ab) => ab.id === this.selectedAddressbook) ?? this.defaultAddressbook
+				: this.defaultAddressbook
+
 			const contact = new Contact(
 				`
 				BEGIN:VCARD
@@ -295,7 +301,7 @@ export default {
 				PRODID:-//Nextcloud Contacts v${appVersion}
 				END:VCARD
 			`.trim().replace(/\t/gm, ''),
-				this.defaultAddressbook,
+				targetAddressbook,
 			)
 
 			contact.fullName = t('contacts', 'Name')
@@ -331,7 +337,7 @@ export default {
 				await this.$router.push({
 					name: 'contact',
 					params: {
-						selectedGroup: this.selectedGroup,
+						selectedGroup: this.selectedAddressbook ? GROUP_ALL_CONTACTS : this.selectedGroup,
 						selectedContact: contact.key,
 					},
 				})
@@ -376,8 +382,8 @@ export default {
 		 * if none are selected already
 		 */
 		selectFirstContactIfNone() {
-			// Do not redirect if pending import
-			if (this.$route.name === 'import') {
+			// Do not redirect if pending import or browsing an address book
+			if (this.$route.name === 'import' || this.$route.name === 'addressbook') {
 				return
 			}
 
@@ -397,6 +403,7 @@ export default {
 				// Unknown group
 				if (!this.selectedCircle
 					&& !this.selectedUserGroup
+					&& !this.selectedAddressbook
 					&& !this.groups.find((group) => group.name === this.selectedGroup)
 					&& GROUP_ALL_CONTACTS !== this.selectedGroup
 					&& GROUP_NO_GROUP_CONTACTS !== this.selectedGroup
@@ -411,7 +418,7 @@ export default {
 					return
 				}
 
-				if (Object.keys(this.contactsList).length) {
+				if (Object.keys(this.contactsList).length && !this.selectedAddressbook) {
 					this.$router.push({
 						name: 'contact',
 						params: {


### PR DESCRIPTION
## Summary

Address books used to be listed in the left sidebar (via the now-deleted `SettingsSection.vue`), allowing users to click on a book to filter contacts. This was lost in bd536c0e when the settings were migrated to a modal dialog — the address books moved into the modal but no navigation equivalent was added, making the "New address book" feature essentially invisible and useless.

This PR restores the feature:

- **New "Address books" section** in the sidebar (`RootNavigation.vue`), listing all enabled address books with a contact counter
- **New route** `addressbook/:selectedAddressbook` to navigate by address book
- **Contact filtering** by selected address book in `contactsList`
- **New contacts** created while an address book is selected are saved into that book (not always the default one)
- **Routing fixes** to prevent "Missing required param selectedGroup" errors when on the `addressbook` route (`selectFirstContactIfNone`, `ContactsListItem`)

## Test plan

- [ ] Create a new address book via Settings → it appears immediately in the left sidebar
- [ ] Click an address book in the sidebar → only its contacts are shown
- [ ] Click a contact in the filtered list → contact detail opens correctly
- [ ] Click "New contact" while an address book is selected → contact is created in that address book
- [ ] Disabling an address book via Settings → it disappears from the sidebar
- [ ] Existing group/circle/chart navigation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)