### PR TITLE
fix(collaborationAutocompletion): replace legacy SHARE_TYPE with ShareType

### DIFF
--- a/src/services/collaborationAutocompletion.js
+++ b/src/services/collaborationAutocompletion.js
@@ -124,7 +124,7 @@ function formatResults(result) {
 		label: result.label,
 		id: `${type}-${result.value.shareWith}`,
 		// If this is a user, set as user for avatar display by UserBubble
-		user: [window.OC.Share.SHARE_TYPE_USER, window.OC.Share.SHARE_TYPE_REMOTE].indexOf(result.value.shareType) > -1
+		user: [ShareType.User, ShareType.Remote].indexOf(result.value.shareType) > -1
 			? result.value.shareWith
 			: null,
 		type,


### PR DESCRIPTION
Inside the Contacts app I could not add members to teams as no users could be found, although they existed.

Claude pointed me to that bug in `collaborationAutocompletion.js` where `window.OC.Share.SHARE_TYPE_USER` was still being used instead of `ShareType.User` and `window.OC.Share.SHARE_TYPE_REMOTE` instead of `ShareType.Remote`. 

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
