### PR TITLE
feat(navigation): restore address book navigation in sidebar

### DIFF
--- a/src/components/AppContent/ContactsContent.vue
+++ b/src/components/AppContent/ContactsContent.vue
@@ -18,7 +18,7 @@
 				<IconContact :size="20" />
 			</template>
 			<template #description>
-				<NcButton variant="primary" @click="newContact">
+				<NcButton v-if="!isReadOnlyAddressbook" variant="primary" @click="newContact">
 					{{ t('contacts', 'Create contact') }}
 				</NcButton>
 			</template>
@@ -142,6 +142,16 @@ export default {
 			return this.contactsList.length === 0
 		},
 
+		/**
+		 * Is the selected address book read only
+		 *
+		 * @return {boolean}
+		 */
+		isReadOnlyAddressbook() {
+			return !!this.$store.getters.getAddressbooks
+				.find((addressbook) => addressbook.id === this.selectedAddressbook)?.readOnly
+		},
+
 		showDetails() {
 			return !!this.selectedContact
 		},
@@ -169,12 +179,7 @@ export default {
 		 */
 		hideDetails() {
 			// Reset the selected contact
-			this.$router.push({
-				name: 'group',
-				params: {
-					selectedGroup: this.selectedGroup,
-				},
-			})
+			this.$router.push(this.listRoute())
 		},
 	},
 }

--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -73,6 +73,37 @@
 				</template>
 			</AppNavigationItem>
 
+			<!-- Address books -->
+			<AppNavigationCaption :name="t('contacts', 'Address books')">
+				<template #actions>
+					<NcActionButton @click="$refs.newAddressbook.openModal()">
+						<template #icon>
+							<IconAdd :size="20" />
+						</template>
+						{{ t('contacts', 'Add address book') }}
+					</NcActionButton>
+				</template>
+			</AppNavigationCaption>
+			<AppNavigationItem
+				v-for="addressbook in enabledAddressbooks"
+				:key="addressbook.id"
+				:name="addressbook.displayName"
+				:to="{
+					name: ROUTE_ADDRESSBOOK,
+					params: { selectedAddressbook: addressbook.id },
+				}"
+				:active="routeState === `${ROUTE_ADDRESSBOOK}:${addressbook.id}`"
+				@click="updateRouteState(`${ROUTE_ADDRESSBOOK}:${addressbook.id}`)">
+				<template #icon>
+					<IconAddressBook :size="20" />
+				</template>
+				<template #counter>
+					<NcCounterBubble
+						v-if="addressbookContactCount(addressbook)"
+						:count="addressbookContactCount(addressbook)" />
+				</template>
+			</AppNavigationItem>
+
 			<!-- Recently contacted group -->
 			<AppNavigationItem
 				v-if="isContactsInteractionEnabled && recentlyContactedContacts && recentlyContactedContacts.contacts.length > 0"
@@ -195,6 +226,7 @@
 			</div>
 		</template>
 		<ContactsSettings v-model:open="showSettings" />
+		<SettingsNewAddressbook ref="newAddressbook" hide-button />
 	</AppNavigation>
 </template>
 
@@ -219,6 +251,7 @@ import IconContactFilled from 'vue-material-design-icons/AccountMultiple.vue'
 import IconContact from 'vue-material-design-icons/AccountMultipleOutline.vue'
 import IconUser from 'vue-material-design-icons/AccountOutline.vue'
 import IconError from 'vue-material-design-icons/AlertCircleOutline.vue'
+import IconAddressBook from 'vue-material-design-icons/BookAccountOutline.vue'
 import Cog from 'vue-material-design-icons/CogOutline.vue'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
 import NewCircleIntro from '../EntityPicker/NewCircleIntro.vue'
@@ -226,8 +259,9 @@ import IconRecentlyContacted from '../Icons/IconRecentlyContacted.vue'
 import CircleNavigationItem from './CircleNavigationItem.vue'
 import ContactsSettings from './ContactsSettings.vue'
 import GroupNavigationItem from './GroupNavigationItem.vue'
+import SettingsNewAddressbook from './Settings/SettingsNewAddressbook.vue'
 import RouterMixin from '../../mixins/RouterMixin.js'
-import { CHART_ALL_CONTACTS, CIRCLE_DESC, CONTACTS_SETTINGS, ELLIPSIS_COUNT, GROUP_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS, GROUP_RECENTLY_CONTACTED } from '../../models/constants.ts'
+import { CHART_ALL_CONTACTS, CIRCLE_DESC, CONTACTS_SETTINGS, ELLIPSIS_COUNT, GROUP_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS, GROUP_RECENTLY_CONTACTED, ROUTE_ADDRESSBOOK } from '../../models/constants.ts'
 import isCirclesEnabled from '../../services/isCirclesEnabled.js'
 import isContactsInteractionEnabled from '../../services/isContactsInteractionEnabled.js'
 import useUserGroupStore from '../../store/userGroup.ts'
@@ -247,6 +281,7 @@ export default {
 		Cog,
 		ContactsSettings,
 		GroupNavigationItem,
+		IconAddressBook,
 		IconContact,
 		IconContactFilled,
 		IconUser,
@@ -257,6 +292,7 @@ export default {
 		IconRecentlyContacted,
 		NewCircleIntro,
 		NcButton,
+		SettingsNewAddressbook,
 	},
 
 	mixins: [RouterMixin],
@@ -277,6 +313,7 @@ export default {
 			CHART_ALL_CONTACTS,
 			GROUP_NO_GROUP_CONTACTS,
 			GROUP_RECENTLY_CONTACTED,
+			ROUTE_ADDRESSBOOK,
 
 			// create group
 			isNewGroupMenuOpen: false,
@@ -301,6 +338,14 @@ export default {
 
 	computed: {
 		// store variables
+		addressbooks() {
+			return this.$store.getters.getAddressbooks
+		},
+
+		enabledAddressbooks() {
+			return this.addressbooks.filter((ab) => ab.enabled)
+		},
+
 		circles() {
 			return this.$store.getters.getCircles
 		},
@@ -426,6 +471,11 @@ export default {
 	},
 
 	methods: {
+		addressbookContactCount(addressbook) {
+			// contact groups are stored as contacts too, but never listed as such
+			return Object.values(addressbook.contacts || {}).filter((contact) => contact.kind !== 'group').length
+		},
+
 		toggleNewGroupMenu() {
 			this.isNewGroupMenuOpen = !this.isNewGroupMenuOpen
 		},

--- a/src/components/AppNavigation/Settings/SettingsNewAddressbook.vue
+++ b/src/components/AppNavigation/Settings/SettingsNewAddressbook.vue
@@ -5,7 +5,7 @@
 
 <template>
 	<div class="new-addressbook-entry">
-		<NcButton v-if="!modalOpen && !loading" @click="openModal">
+		<NcButton v-if="!hideButton && !modalOpen && !loading" @click="openModal">
 			<template #icon>
 				<IconAdd :size="20" />
 			</template>
@@ -52,6 +52,13 @@ export default {
 		IconLoading,
 		NcButton,
 		NcModal,
+	},
+
+	props: {
+		hideButton: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	data() {

--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -1024,13 +1024,23 @@ export default defineComponent({
 						addressbook,
 					})
 					// select the contact again
-					this.$router.push({
-						name: 'contact',
-						params: {
-							selectedGroup: this.$route.params.selectedGroup,
-							selectedContact: contact.key,
-						},
-					})
+					if (this.$route.params.selectedAddressbook) {
+						this.$router.push({
+							name: 'addressbook-contact',
+							params: {
+								selectedAddressbook: this.$route.params.selectedAddressbook,
+								selectedContact: contact.key,
+							},
+						})
+					} else {
+						this.$router.push({
+							name: 'contact',
+							params: {
+								selectedGroup: this.$route.params.selectedGroup,
+								selectedContact: contact.key,
+							},
+						})
+					}
 				} catch (error) {
 					console.error(error)
 					showError(t('contacts', 'An error occurred while trying to move the contact'))
@@ -1057,13 +1067,23 @@ export default defineComponent({
 						addressbook,
 					})
 					// select the contact again
-					this.$router.push({
-						name: 'contact',
-						params: {
-							selectedGroup: this.$route.params.selectedGroup,
-							selectedContact: contact.key,
-						},
-					})
+					if (this.$route.params.selectedAddressbook) {
+						this.$router.push({
+							name: 'addressbook-contact',
+							params: {
+								selectedAddressbook: this.$route.params.selectedAddressbook,
+								selectedContact: contact.key,
+							},
+						})
+					} else {
+						this.$router.push({
+							name: 'contact',
+							params: {
+								selectedGroup: this.$route.params.selectedGroup,
+								selectedContact: contact.key,
+							},
+						})
+					}
 				} catch (error) {
 					console.error(error)
 					showError(t('contacts', 'An error occurred while trying to copy the contact'))

--- a/src/components/ContactsList/ContactsListItem.vue
+++ b/src/components/ContactsList/ContactsListItem.vue
@@ -14,7 +14,7 @@
 			:key="source.key"
 			class="list-item-style envelope"
 			:name="source.displayName"
-			:to="isStatic ? undefined : { name: 'contact', params: { selectedGroup: selectedGroup, selectedContact: source.key } }">
+			:to="isStatic ? undefined : contactRoute(source.key)">
 			<!-- @slot Icon slot -->
 
 			<template #icon>
@@ -303,11 +303,7 @@ export default {
 			if (this.isStatic) {
 				return
 			}
-			// change url with router
-			this.$router.push({
-				name: 'contact',
-				params: { selectedGroup: this.selectedGroup, selectedContact: this.source.key },
-			})
+			this.$router.push(this.contactRoute(this.source.key))
 		},
 
 		onSelectMultiple() {

--- a/src/mixins/RouterMixin.js
+++ b/src/mixins/RouterMixin.js
@@ -20,5 +20,33 @@ export default {
 		selectedChart() {
 			return this.$route.params.selectedChart
 		},
+		selectedAddressbook() {
+			return this.$route.params.selectedAddressbook
+		},
+	},
+
+	methods: {
+		/**
+		 * Location of the current contacts list, address book or group
+		 *
+		 * @return {object} a vue-router location
+		 */
+		listRoute() {
+			return this.selectedAddressbook
+				? { name: 'addressbook', params: { selectedAddressbook: this.selectedAddressbook } }
+				: { name: 'group', params: { selectedGroup: this.selectedGroup } }
+		},
+
+		/**
+		 * Location of a contact within the current list, address book or group
+		 *
+		 * @param {string} selectedContact the key of the contact
+		 * @return {object} a vue-router location
+		 */
+		contactRoute(selectedContact) {
+			return this.selectedAddressbook
+				? { name: 'addressbook-contact', params: { selectedAddressbook: this.selectedAddressbook, selectedContact } }
+				: { name: 'contact', params: { selectedGroup: this.selectedGroup, selectedContact } }
+		},
 	},
 }

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -28,6 +28,7 @@ export const CHART_ALL_CONTACTS: DefaultChart = t('contacts', 'Organization char
 export const ROUTE_CIRCLE = 'circle'
 export const ROUTE_CHART = 'chart'
 export const ROUTE_USER_GROUP = 'user_group'
+export const ROUTE_ADDRESSBOOK = 'addressbook'
 
 // Contact settings
 export const CONTACTS_SETTINGS: DefaultGroup = t('contacts', 'Contacts settings')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,7 +6,7 @@
 import { generateUrl } from '@nextcloud/router'
 import { createRouter, createWebHistory } from 'vue-router'
 import Contacts from '../views/Contacts.vue'
-import { GROUP_ALL_CONTACTS, ROUTE_CHART, ROUTE_CIRCLE, ROUTE_USER_GROUP } from '../models/constants.ts'
+import { GROUP_ALL_CONTACTS, ROUTE_ADDRESSBOOK, ROUTE_CHART, ROUTE_CIRCLE, ROUTE_USER_GROUP } from '../models/constants.ts'
 import { generateContactKey } from '../models/contact.js'
 
 // if index.php is in the url AND we got this far, then it's working:
@@ -68,6 +68,16 @@ export default createRouter({
 							selectedContact: generateContactKey(to.params.userId, 'z-server-generated--system'),
 						},
 					}),
+				},
+				{
+					path: `${ROUTE_ADDRESSBOOK}/:selectedAddressbook`,
+					name: 'addressbook',
+					component: Contacts,
+				},
+				{
+					path: `${ROUTE_ADDRESSBOOK}/:selectedAddressbook/:selectedContact`,
+					name: 'addressbook-contact',
+					component: Contacts,
 				},
 			],
 		},

--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -187,6 +187,9 @@ export default {
 		 * @return {Array}
 		 */
 		contactsList() {
+			if (this.selectedAddressbook) {
+				return this.sortedContacts.filter((contact) => this.contacts[contact.key]?.addressbook.id === this.selectedAddressbook)
+			}
 			if (this.selectedGroup === GROUP_ALL_CONTACTS) {
 				return this.sortedContacts
 			} else if (this.selectedGroup === GROUP_NO_GROUP_CONTACTS) {
@@ -213,6 +216,13 @@ export default {
 	watch: {
 		// watch url change and group select
 		selectedGroup() {
+			if (!this.isMobile && !this.selectedChart) {
+				this.selectFirstContactIfNone()
+			}
+		},
+
+		// watch url change and address book select
+		selectedAddressbook() {
 			if (!this.isMobile && !this.selectedChart) {
 				this.selectFirstContactIfNone()
 			}
@@ -280,6 +290,11 @@ export default {
 				return
 			}
 
+			// fall back to the default address book if the selected one is not writeable
+			const targetAddressbook = this.selectedAddressbook
+				? this.addressbooks.find((ab) => ab.id === this.selectedAddressbook && !ab.readOnly) ?? this.defaultAddressbook
+				: this.defaultAddressbook
+
 			const contact = new Contact(
 				`
 				BEGIN:VCARD
@@ -287,7 +302,7 @@ export default {
 				PRODID:-//Nextcloud Contacts v${appVersion}
 				END:VCARD
 			`.trim().replace(/\t/gm, ''),
-				this.defaultAddressbook,
+				targetAddressbook,
 			)
 
 			contact.fullName = t('contacts', 'Name')
@@ -314,19 +329,22 @@ export default {
 
 			// set group if it's selected already
 			// BUT NOT if it's the _fake_ groups like all contacts and not grouped
-			if ([GROUP_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS].indexOf(this.selectedGroup) === -1) {
+			if (this.selectedGroup && [GROUP_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS].indexOf(this.selectedGroup) === -1) {
 				contact.groups = [this.selectedGroup]
 			}
 			try {
 				// this will trigger the proper commits to groups, contacts and addressbook
 				await this.$store.dispatch('addContact', contact)
-				await this.$router.push({
-					name: 'contact',
-					params: {
-						selectedGroup: this.selectedGroup,
-						selectedContact: contact.key,
-					},
-				})
+				// follow the address book the contact was actually created in, it might not be the selected one
+				await this.$router.push(this.selectedAddressbook
+					? {
+							name: 'addressbook-contact',
+							params: {
+								selectedAddressbook: targetAddressbook.id,
+								selectedContact: contact.key,
+							},
+						}
+					: this.contactRoute(contact.key))
 			} catch (error) {
 				showError(t('contacts', 'Unable to create the contact.'))
 				console.error(error)
@@ -378,17 +396,25 @@ export default {
 				// Unknown contact
 				if (this.selectedContact && !inList) {
 					showError(t('contacts', 'Contact not found'))
+					this.$router.push(this.listRoute())
+				}
+
+				// Unknown address book
+				if (this.selectedAddressbook
+					&& !this.addressbooks.find((addressbook) => addressbook.id === this.selectedAddressbook)) {
+					showError(t('contacts', 'Address book {addressbook} not found', { addressbook: this.selectedAddressbook }))
+					this.logger.error('Address book not found', this.selectedAddressbook)
+
 					this.$router.push({
-						name: 'group',
-						params: {
-							selectedGroup: this.selectedGroup,
-						},
+						name: 'root',
 					})
+					return
 				}
 
 				// Unknown group
 				if (!this.selectedCircle
 					&& !this.selectedUserGroup
+					&& !this.selectedAddressbook
 					&& !this.groups.find((group) => group.name === this.selectedGroup)
 					&& GROUP_ALL_CONTACTS !== this.selectedGroup
 					&& GROUP_NO_GROUP_CONTACTS !== this.selectedGroup
@@ -404,13 +430,7 @@ export default {
 				}
 
 				if (Object.keys(this.contactsList).length) {
-					this.$router.push({
-						name: 'contact',
-						params: {
-							selectedGroup: this.selectedGroup,
-							selectedContact: Object.values(this.contactsList)[0].key,
-						},
-					})
+					this.$router.push(this.contactRoute(Object.values(this.contactsList)[0].key))
 				}
 			}
 		},


### PR DESCRIPTION
Fixes #3647

## Summary

Address books used to be listed in the left sidebar (via the now-deleted `SettingsSection.vue`), allowing users to click on a book to filter their contacts. This was removed in bd536c0e when settings were migrated to a modal dialog, without any navigation replacement — making the "New address book" feature essentially invisible and unusable.

Changes:
- Add an **"Address books" section** in the sidebar listing all enabled address books with a contact counter
- Add `ROUTE_ADDRESSBOOK` constant and `addressbook/:selectedAddressbook` + `addressbook/:selectedAddressbook/:selectedContact` routes
- Add `selectedAddressbook` to `RouterMixin`
- Filter `contactsList` by the selected address book when on the addressbook route
- New contacts created while an address book is selected are saved into that address book (not always the default one)
- Fix `Missing required param "selectedGroup"` errors in `selectFirstContactIfNone()`, `ContactsListItem`, and `ContactDetails` (`moveContactToAddressbook` / `copyContactToAddressbook`) when navigating without a `selectedGroup` param

## Test plan

- [ ] Create a new address book via Settings → it appears immediately in the left sidebar
- [ ] Click an address book in the sidebar → only its contacts are shown
- [ ] Click a contact in the filtered list → contact detail opens correctly
- [ ] Click "New contact" while an address book is selected → contact is saved in that address book
- [ ] Move/copy a contact to another address book → no routing error
- [ ] Disabling an address book via Settings → it disappears from the sidebar
- [ ] Existing group / circle / chart navigation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)