### PR TITLE
fix: keyboard navigation

### DIFF
--- a/src/components/AppNavigation/CircleNavigationItem.vue
+++ b/src/components/AppNavigation/CircleNavigationItem.vue
@@ -6,7 +6,11 @@
 	<AppNavigationItem
 		:key="circle.key"
 		:name="circle.displayName"
-		:to="circle.router">
+		:to="circle.router"
+		:force-menu="true">
+		<!-- force-menu avoids a Tab-trap in NcAppNavigationItem/NcActions when only
+			one action (copy link) is available: their Tab handler focuses a menu
+			trigger button that isn't rendered in single-inline-action mode. -->
 		<template #icon>
 			<AccountStar v-if="circle.isOwner" :size="20" />
 			<AccountGroupOutline v-else :size="20" />

--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<AppContentDetails>
+	<AppContentDetails ref="detailsRoot" tabindex="-1">
 		<!-- nothing selected or contact not found -->
 		<EmptyContent
 			v-if="!contact"
@@ -871,6 +871,7 @@ export default defineComponent({
 
 		// capture ctrl+s
 		document.addEventListener('keydown', this.onCtrlSave)
+		this.reloadBus.on('focus-details', this.focusDetails)
 
 		this.lastUsedAddressBook = this.getLastUsedAddressBook()
 	},
@@ -878,9 +879,17 @@ export default defineComponent({
 	beforeUnmount() {
 		// unbind capture ctrl+s
 		document.removeEventListener('keydown', this.onCtrlSave)
+		this.reloadBus.off('focus-details', this.focusDetails)
 	},
 
 	methods: {
+		/**
+		 * Move focus into the details panel, used when navigating here from the contact list via keyboard
+		 */
+		focusDetails() {
+			this.$refs.detailsRoot?.$el?.focus()
+		},
+
 		updateGroups(value) {
 			this.newGroupsValue = value
 		},

--- a/src/components/ContactsList.vue
+++ b/src/components/ContactsList.vue
@@ -117,7 +117,8 @@
 				:index="index"
 				:source="item"
 				:reload-bus="reloadBus"
-				:on-select-multiple-from-parent="onSelectMultiple" />
+				:on-select-multiple-from-parent="onSelectMultiple"
+				:on-navigate-from-parent="onNavigateContact" />
 		</VList>
 	</AppContentList>
 </template>
@@ -144,6 +145,7 @@ import Batch from './ContactsList/Batch.vue'
 import ContactsListItem from './ContactsList/ContactsListItem.vue'
 import Merging from './ContactsList/Merging.vue'
 import RouterMixin from '../mixins/RouterMixin.js'
+import { getNextContactKey, getPreviousContactKey } from '../utils/contactNavigation.ts'
 
 export default {
 	name: 'ContactsList',
@@ -366,7 +368,7 @@ export default {
 
 			const scroller = this.$refs.scroller
 			const scrollerBoundingRect = scroller.$el.getBoundingClientRect()
-			const item = this.$el.querySelector('#' + key.slice(0, -2))
+			const item = document.getElementById(key.slice(0, -2))
 			const itemBoundingRect = item?.getBoundingClientRect()
 
 			// Try to scroll the item fully into view
@@ -443,6 +445,49 @@ export default {
 			this.multiSelectedContacts = newSelection
 
 			return true
+		},
+
+		/**
+		 * Move focus to the previous/next contact in the filtered list, scrolling it into view if necessary
+		 *
+		 * @param {number} index index of the contact the navigation started from
+		 * @param {'up'|'down'} direction direction to navigate to
+		 */
+		async onNavigateContact(index, direction) {
+			const currentKey = this.filteredList[index]?.key
+			if (!currentKey) {
+				return
+			}
+
+			const targetKey = direction === 'down'
+				? getNextContactKey(this.filteredList, currentKey)
+				: getPreviousContactKey(this.filteredList, currentKey)
+
+			if (!targetKey) {
+				return
+			}
+
+			this.scrollToContact(targetKey)
+			const anchor = await this.waitForContactAnchor(targetKey)
+			anchor?.focus()
+		},
+
+		/**
+		 * Wait for the given contact's anchor to be mounted by the virtual scroller
+		 *
+		 * @param {string} key the contact unique key
+		 * @return {Promise<HTMLElement|null>}
+		 */
+		async waitForContactAnchor(key) {
+			const id = key.slice(0, -2)
+			for (let attempt = 0; attempt < 5; attempt++) {
+				await this.$nextTick()
+				const anchor = document.getElementById(id)?.querySelector('a')
+				if (anchor) {
+					return anchor
+				}
+			}
+			return null
 		},
 
 		unselectAllMultiSelected() {

--- a/src/components/ContactsList/ContactsListItem.vue
+++ b/src/components/ContactsList/ContactsListItem.vue
@@ -7,7 +7,8 @@
 		class="contacts-list__item-wrapper"
 		:draggable="isDraggable"
 		@dragstart="startDrag($event, source)"
-		@click.shift.exact.prevent="onSelectMultipleRange">
+		@click.shift.exact.prevent="onSelectMultipleRange"
+		@keydown="onListKeydown">
 		<ListItem
 			:id="id"
 			:key="source.key"
@@ -19,7 +20,14 @@
 			<template #icon>
 				<div
 					class="contacts-list__item-icon"
+					:role="isStatic ? undefined : 'checkbox'"
+					:tabindex="isStatic ? undefined : 0"
+					:aria-checked="isStatic ? undefined : source.isMultiSelected"
+					:aria-label="isStatic ? undefined : selectAriaLabel"
 					@click.exact.prevent="onSelectMultiple"
+					@keydown.space.exact.prevent="onSelectMultiple"
+					@keydown.enter.exact.prevent="onSelectMultiple"
+					@keydown.shift.space.exact.prevent="onSelectMultipleRange"
 					@mouseenter="hoverAvatar(true)"
 					@mouseleave="hoverAvatar(false)">
 					<NcAvatar
@@ -132,6 +140,11 @@ export default {
 			default: () => {},
 		},
 
+		onNavigateFromParent: {
+			type: Function,
+			default: () => {},
+		},
+
 		isStatic: {
 			type: Boolean,
 			default: false,
@@ -169,6 +182,12 @@ export default {
 
 		getTel() {
 			return this.source.properties.find((property) => property.name === 'tel')?.getFirstValue()
+		},
+
+		selectAriaLabel() {
+			return this.source.isMultiSelected
+				? t('contacts', 'Unselect {name}', { name: this.source.displayName })
+				: t('contacts', 'Select {name}', { name: this.source.displayName })
 		},
 	},
 
@@ -289,6 +308,31 @@ export default {
 				return
 			}
 			this.onSelectMultipleFromParent(this.source, this.index, true)
+		},
+
+		/**
+		 * Handle arrow key navigation from this contact:
+		 * - right moves focus into the contact details
+		 * - up/down moves focus to the previous/next contact in the list
+		 *
+		 * @param {KeyboardEvent} event the keydown event
+		 */
+		onListKeydown(event) {
+			if (this.isStatic) {
+				return
+			}
+
+			if (event.key === 'ArrowRight') {
+				event.preventDefault()
+				this.selectContact()
+				this.reloadBus.emit('focus-details')
+			} else if (event.key === 'ArrowDown') {
+				event.preventDefault()
+				this.onNavigateFromParent(this.index, 'down')
+			} else if (event.key === 'ArrowUp') {
+				event.preventDefault()
+				this.onNavigateFromParent(this.index, 'up')
+			}
 		},
 
 		hoverAvatar(newState) {

--- a/src/utils/contactNavigation.ts
+++ b/src/utils/contactNavigation.ts
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+interface ContactListEntry {
+	key: string
+}
+
+/**
+ * Return the key of the previous contact in the list, or null if already at the first.
+ *
+ * @param filteredList Ordered array of contact objects with a `key` property
+ * @param selectedKey Key of the currently selected contact
+ */
+export function getPreviousContactKey(filteredList: ContactListEntry[], selectedKey: string): string | null {
+	const currentIndex = filteredList.findIndex((c) => c.key === selectedKey)
+	if (currentIndex > 0) {
+		return filteredList[currentIndex - 1].key
+	}
+	return null
+}
+
+/**
+ * Return the key of the next contact in the list, or null if already at the last.
+ *
+ * @param filteredList Ordered array of contact objects with a `key` property
+ * @param selectedKey Key of the currently selected contact
+ */
+export function getNextContactKey(filteredList: ContactListEntry[], selectedKey: string): string | null {
+	const currentIndex = filteredList.findIndex((c) => c.key === selectedKey)
+	if (currentIndex !== -1 && currentIndex < filteredList.length - 1) {
+		return filteredList[currentIndex + 1].key
+	}
+	return null
+}

--- a/tests/javascript/utils/contactNavigation.test.ts
+++ b/tests/javascript/utils/contactNavigation.test.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { getNextContactKey, getPreviousContactKey } from '../../../src/utils/contactNavigation'
+
+const list = [
+	{ key: 'alice' },
+	{ key: 'bob' },
+	{ key: 'charlie' },
+]
+
+describe('getPreviousContactKey', () => {
+	test('returns the key of the preceding contact', () => {
+		expect(getPreviousContactKey(list, 'bob')).toBe('alice')
+		expect(getPreviousContactKey(list, 'charlie')).toBe('bob')
+	})
+
+	test('returns null when the selected contact is first', () => {
+		expect(getPreviousContactKey(list, 'alice')).toBeNull()
+	})
+
+	test('returns null when the selected contact is not in the list', () => {
+		expect(getPreviousContactKey(list, 'unknown')).toBeNull()
+	})
+
+	test('returns null for an empty list', () => {
+		expect(getPreviousContactKey([], 'alice')).toBeNull()
+	})
+})
+
+describe('getNextContactKey', () => {
+	test('returns the key of the following contact', () => {
+		expect(getNextContactKey(list, 'alice')).toBe('bob')
+		expect(getNextContactKey(list, 'bob')).toBe('charlie')
+	})
+
+	test('returns null when the selected contact is last', () => {
+		expect(getNextContactKey(list, 'charlie')).toBeNull()
+	})
+
+	test('returns null when the selected contact is not in the list', () => {
+		expect(getNextContactKey(list, 'unknown')).toBeNull()
+	})
+
+	test('returns null for an empty list', () => {
+		expect(getNextContactKey([], 'alice')).toBeNull()
+	})
+})


### PR DESCRIPTION
Fix https://github.com/nextcloud/contacts/issues/5050

Fixes:
- Keyboard navigation getting stuck in shared teams
- Having to scroll all through the contact list to get to the details, with this u can use right arrow
- Multiselecting with keyboard navigation

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
