### PR TITLE
perf: Don't fetch full group information

### DIFF
--- a/lib/Service/GroupSharingService.php
+++ b/lib/Service/GroupSharingService.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace OCA\Contacts\Service;
 
 use OCP\IConfig;
-use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\Share\IManager as IShareManager;
@@ -29,8 +28,7 @@ class GroupSharingService {
 			return false;
 		}
 
-		$userGroups = $this->groupManager->getUserGroups($user);
-		$userGroupNames = array_map(static fn (IGroup $group) => $group->getGID(), $userGroups);
+		$userGroupIds = $this->groupManager->getUserGroupIds($user);
 
 		$excludeGroupList = json_decode($this->config->getAppValue('core', 'shareapi_exclude_groups_list', '[]'), true);
 		$excludeGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups');
@@ -39,8 +37,8 @@ class GroupSharingService {
 		// "yes"   => Exclude listed groups from sharing
 		// "allow" => Limit sharing to listed groups
 		return match ($excludeGroups) {
-			'yes' => count(array_intersect($userGroupNames, $excludeGroupList)) === 0,
-			'allow' => count(array_intersect($userGroupNames, $excludeGroupList)) > 0,
+			'yes' => count(array_intersect($userGroupIds, $excludeGroupList)) === 0,
+			'allow' => count(array_intersect($userGroupIds, $excludeGroupList)) > 0,
 			default => true,
 		};
 	}

--- a/tests/unit/Service/GroupSharingServiceTest.php
+++ b/tests/unit/Service/GroupSharingServiceTest.php
@@ -12,7 +12,6 @@ namespace unit\Service;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Contacts\Service\GroupSharingService;
 use OCP\IConfig;
-use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\Share\IManager as IShareManager;
@@ -78,21 +77,15 @@ class GroupSharingServiceTest extends TestCase {
 		string $excludeGroups,
 	): void {
 		$user = $this->createMock(IUser::class);
-		$group1 = $this->createMock(IGroup::class);
-		$group1->method('getGID')
-			->willReturn('group1');
-		$group2 = $this->createMock(IGroup::class);
-		$group2->method('getGID')
-			->willReturn('group2');
 
 		$this->shareManager->expects(self::once())
 			->method('allowGroupSharing')
 			->willReturn($allowGroupSharing);
 		if ($allowGroupSharing) {
 			$this->groupManager->expects(self::once())
-				->method('getUserGroups')
+				->method('getUserGroupIds')
 				->with($user)
-				->willReturn([$group1, $group2]);
+				->willReturn(['group1', 'group2']);
 			$this->config->expects(self::exactly(2))
 				->method('getAppValue')
 				->willReturnMap([
@@ -101,7 +94,7 @@ class GroupSharingServiceTest extends TestCase {
 				]);
 		} else {
 			$this->groupManager->expects(self::never())
-				->method('getUserGroups');
+				->method('getUserGroupIds');
 			$this->config->expects(self::never())
 				->method('getAppValue');
 		}


### PR DESCRIPTION
This is expensive and not needed



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
