### PR TITLE
fix(router): redirect profile details view to internal contacts list

### DIFF
--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -28,6 +28,10 @@ export const MinimalContactProperties = [
 	'EMAIL', 'UID', 'TEL', 'CATEGORIES', 'FN', 'ORG', 'N', 'X-PHONETIC-FIRST-NAME', 'X-PHONETIC-LAST-NAME', 'X-MANAGERSNAME', 'TITLE', 'NOTE', 'RELATED',
 ].concat(ContactKindProperties)
 
+export function generateContactKey(uid, addressbookId) {
+	return Buffer.from(uid + '~' + addressbookId, 'utf8').toString('base64')
+}
+
 export default class Contact {
 	/**
 	 * Creates an instance of Contact
@@ -211,7 +215,7 @@ export default class Contact {
 	 * @memberof Contact
 	 */
 	get key() {
-		return Buffer.from(this.uid + '~' + this.addressbook.id, 'utf8').toString('base64')
+		return generateContactKey(this.uid, this.addressbook.id)
 	}
 
 	/**

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,9 +4,10 @@
  */
 
 import { generateUrl } from '@nextcloud/router'
+import { Buffer } from 'buffer'
 import { createRouter, createWebHistory } from 'vue-router'
 import Contacts from '../views/Contacts.vue'
-import { ROUTE_CHART, ROUTE_CIRCLE, ROUTE_USER_GROUP } from '../models/constants.ts'
+import { GROUP_ALL_CONTACTS, ROUTE_CHART, ROUTE_CIRCLE, ROUTE_USER_GROUP } from '../models/constants.ts'
 
 // if index.php is in the url AND we got this far, then it's working:
 // let's keep using index.php in the url
@@ -56,6 +57,17 @@ export default createRouter({
 					path: `${ROUTE_USER_GROUP}/:selectedUserGroup`,
 					name: 'user_group',
 					component: Contacts,
+				},
+				{
+					path: 'u/:userId',
+					name: 'profile-redirect',
+					redirect: (to) => ({
+						name: 'contact',
+						params: {
+							selectedGroup: GROUP_ALL_CONTACTS,
+							selectedContact: Buffer.from(`${to.params.userId}~z-server-generated--system`, 'utf8').toString('base64'),
+						},
+					}),
 				},
 			],
 		},

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,10 +4,10 @@
  */
 
 import { generateUrl } from '@nextcloud/router'
-import { Buffer } from 'buffer'
 import { createRouter, createWebHistory } from 'vue-router'
 import Contacts from '../views/Contacts.vue'
 import { GROUP_ALL_CONTACTS, ROUTE_CHART, ROUTE_CIRCLE, ROUTE_USER_GROUP } from '../models/constants.ts'
+import { generateContactKey } from '../models/contact.js'
 
 // if index.php is in the url AND we got this far, then it's working:
 // let's keep using index.php in the url
@@ -65,7 +65,7 @@ export default createRouter({
 						name: 'contact',
 						params: {
 							selectedGroup: GROUP_ALL_CONTACTS,
-							selectedContact: Buffer.from(`${to.params.userId}~z-server-generated--system`, 'utf8').toString('base64'),
+							selectedContact: generateContactKey(to.params.userId, 'z-server-generated--system'),
 						},
 					}),
 				},


### PR DESCRIPTION
Fixes https://github.com/nextcloud/contacts/issues/5554

## The bug
When inside the Contacts app one goes to  > Teams > some team > some member > "View profile", the user does not get navigated to the clicked user's profile but to the general "All contacts" list and the following errors appear:
<img width="292" height="281" alt="Screenshot from 2026-07-09 08-56-10" src="https://github.com/user-attachments/assets/362f30fa-24c8-4d7a-b0e8-b42bad8f3636" />

## What seems to be the cause
- The "View profile" link is generated server-side and used by NcAvatar. And NcAvatar only checks if the link matches any route in the current app's router.
- Contacts app's router uses `:selectedGroup/:selectedContact` with no literal prefix, so it matches any two-segment path and treats `/u/alice` like an internal path (but it's not)
- To navigate to the Contact's internal contacts list it should navigate to `cloud.host.com/apps/contacts/All%20contacts/[someLongbase64String]`
<img width="1256" height="430" alt="Screenshot from 2026-07-09 09-30-44" src="https://github.com/user-attachments/assets/a537260a-d797-4d09-a86c-8610f6ee0586" />


## The solution
- Add a profile-redirect in Contacts app's router for `u/:userId` and build the correct url

That solution seems like a workaround though. Maybe `:selectedGroup/:selectedContact` should be less permissive or the NcAvatar needs an adjustment?

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
