### PR TITLE
fix(circles): avoid attempting to fetch protected resources when user is not a member

### DIFF
--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -905,7 +905,7 @@ export default {
 		},
 
 		async loadAvatarUrl() {
-			if (!this.avatarSupported) {
+			if (!this.avatarSupported || !this.circle.isMember) {
 				return
 			}
 			try {

--- a/src/store/circles.js
+++ b/src/store/circles.js
@@ -168,6 +168,10 @@ const actions = {
 	 */
 	async getCircleMembers(context, circleId) {
 		const circle = context.getters.getCircle(circleId)
+		// skip if current user is not a member (e.g. visible circle)
+		if (!circle.isMember) {
+			return
+		}
 		const members = await getCircleMembers(circleId)
 
 		logger.debug(`${circleId} have ${members.length} member(s)`, { members })


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Related to: https://github.com/nextcloud/circles/pull/2673

## Summary

Clicking on a "visible to everyone" circle as a non-member triggers two backend requests:

- `ocs/v2.php/apps/circles/circles/{circleId}/members`
- `ocs/v2.php/apps/circles/circles/{circleId}/avatar`

Both return `403: Insufficient permissions to perform this action`, since these resources are only accessible to members.

<img width="1884" height="1163" alt="Screenshot from 2026-07-23 07-52-34" src="https://github.com/user-attachments/assets/e554849c-483e-4209-8ced-e9138ce5e4d3" />

Both endpoints have brute-force/throttling protection. If a user repeatedly clicks on the visible circle, the IP can eventually get blocked.

This PR adds a safeguard that skips both fetches when the current user is not a member of the circle, avoiding the unnecessary requests and the throttling.

## TODO

Mentioned permission checks were introduced by [this PR](https://github.com/nextcloud/circles/pull/2522), which was backported down to stable31. meaning we should backport this one to equivalent contacts versions:
https://apps.nextcloud.com/apps/contacts
<img width="893" height="268" alt="image" src="https://github.com/user-attachments/assets/2f65e88b-0fb4-400e-9c87-757e2bfb4dc7" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI