### PR TITLE
feat: using the company name in the subtitle of the main contacts list

### DIFF
--- a/src/components/ContactsList/ContactsListItem.vue
+++ b/src/components/ContactsList/ContactsListItem.vue
@@ -62,7 +62,7 @@
 			<template #subname>
 				<div class="envelope__subtitle">
 					<span class="envelope__subtitle__subject">
-						{{ source.email ? source.email : getTel }}
+						{{ subtitle }}
 					</span>
 				</div>
 				<div v-if="showAddressbook" class="envelope__subtitle">
@@ -168,6 +168,21 @@ export default {
 	computed: {
 		isFavorite() {
 			return this.source.favorite
+		},
+
+		subtitle() {
+			if (this.source.org) {
+				return this.source.org
+			} else if (this.source.email) {
+				return this.source.email
+			} else {
+				const tel = this.getTel
+				if (tel) {
+					return tel
+				}
+			}
+
+			return ''
 		},
 
 		// contact is not draggable when it has not been saved on server as it can't be added to groups/circles before


### PR DESCRIPTION
When not empty, the company name is used in the subtitle of the contact in the main list (instead of email address).

Fixes #2872 

An alternative may be to reuse `ContactDetails::formattedSubtitle()` (moving it in a more convenient place) and display the full text "Position at Company Name", but I this it could become to large for the sidebar.