### PR TITLE
fix: label for read-only dates

### DIFF
--- a/src/components/Properties/PropertyDateTime.vue
+++ b/src/components/Properties/PropertyDateTime.vue
@@ -57,7 +57,7 @@
 					v-else
 					:readonly="true"
 					:model-value="formatDateTime()"
-					:label="propModel.readableName" />
+					:label-outside="true" />
 			</div>
 
 			<!-- props actions -->


### PR DESCRIPTION
Totally unrequested graphical fix for read only date properties.

<img width="842" height="344" alt="sample" src="https://github.com/user-attachments/assets/0c07ecce-2cff-4e72-bb3e-b33ba5dde652" />
