### PR TITLE
fix: removed references to v-tooltip directive

### DIFF
--- a/src/components/AppNavigation/Settings/SettingsAddressbook.vue
+++ b/src/components/AppNavigation/Settings/SettingsAddressbook.vue
@@ -25,9 +25,8 @@
 			<!-- sharing Ncbutton -->
 			<NcButton
 				v-if="!addressbook.readOnly && !isSharedWithMe"
-				v-tooltip.top="sharedWithTooltip"
+				:title="sharedWithTooltip"
 				:class="{ 'addressbook__share--shared': hasShares }"
-				:name="sharedWithTooltip"
 				href="#"
 				class="addressbook__share"
 				@click="toggleShare">

--- a/src/components/Properties/PropertyGroups.vue
+++ b/src/components/Properties/PropertyGroups.vue
@@ -31,15 +31,6 @@
 					tag-placeholder="create"
 					@option:deselected="updateValue"
 					@close="updateValue">
-					<!-- show how many groups are hidden and add tooltip -->
-					<template #limit>
-						<span v-tooltip.auto="formatGroupsTitle" class="multiselect__limit">
-							+{{ localValue.length - 3 }}
-						</span>
-					</template>
-					<template #no-options>
-						<span>{{ t('contacts', 'No results') }}</span>
-					</template>
 				</NcSelect>
 				<div v-else>
 					<span v-if="localValue.length === 0">{{ t('contacts', 'None') }}</span>


### PR DESCRIPTION
The `Tooltip` directive has been deprecated in `@nextcloud/vue` [in April 2025](https://github.com/nextcloud-libraries/nextcloud-vue/commit/88b1ff51aad493e79e7e0bfe20f5038766a8f42a) and actually no longer inited in Contacts since the migration to Vue3.

Still, there are a few references generating tons of errors in the JS console.

Highlights:
- removed #limit (including `v-tooltip`) and #no-options slots from the `NcSelect` of `PropertyGroups`: those were valid slots for the `NcMultiselect` components, replaced in 4205d1e with `NcSelect`
- using plain `title` in `SettingsAddressbook` for the address books sharing button