### PR TITLE
fix: unused routing parameters, and related usage

### DIFF
--- a/src/models/circle.ts
+++ b/src/models/circle.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { CircleConfigs, MemberLevels, ROUTE_CIRCLE } from './constants.ts'
+import { CircleConfigs, MemberLevels } from './constants.ts'
 import Member from './member.ts'
 
 type MemberList = Record<string, Member>
@@ -306,7 +306,7 @@ export default class Circle {
 	get router() {
 		return {
 			name: 'circle',
-			params: { selectedCircle: this.id, selectedGroup: ROUTE_CIRCLE },
+			params: { selectedCircle: this.id },
 		}
 	}
 

--- a/src/models/userGroup.ts
+++ b/src/models/userGroup.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { ROUTE_USER_GROUP } from './constants.ts'
-
 export default class UserGroup {
 	private _data: object
 	private _members: string[]
@@ -61,7 +59,7 @@ export default class UserGroup {
 	get router(): object {
 		return {
 			name: 'user_group',
-			params: { selectedUserGroup: this.id, selectedGroup: ROUTE_USER_GROUP },
+			params: { selectedUserGroup: this.id },
 		}
 	}
 

--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -9,10 +9,10 @@
 		<RootNavigation
 			:loading="loadingContacts || loadingCircles">
 			<div class="import-and-new-contact-buttons">
-				<SettingsImportContacts v-if="!loadingContacts && isEmptyGroup && !isChartView && !isCirclesView" />
+				<SettingsImportContacts v-if="!loadingContacts && importEnabled" />
 				<!-- new-contact-button -->
 				<NcButton
-					v-if="!loadingContacts"
+					v-if="!loadingContacts && addingContactEnabled"
 					:disabled="!defaultAddressbook"
 					variant="secondary"
 					wide
@@ -20,15 +20,12 @@
 					<template #icon>
 						<IconAdd :size="20" />
 					</template>
-					{{ isCirclesView ? t('contacts', 'Add member') : t('contacts', 'New contact') }}
+					{{ selectedCircle ? t('contacts', 'Add member') : t('contacts', 'New contact') }}
 				</NcButton>
 			</div>
 		</RootNavigation>
 
 		<!-- Main content: circle, chart or contacts -->
-		<UserGroupContent
-			v-if="selectedUserGroup"
-			:loding="loadingCircles" />
 		<CircleContent
 			v-if="selectedCircle || selectedUserGroup"
 			:loading="loadingCircles" />
@@ -75,7 +72,7 @@ import ContactsPicker from '../components/EntityPicker/ContactsPicker.vue'
 import ImportView from './Processing/ImportView.vue'
 import IsMobileMixin from '../mixins/IsMobileMixin.ts'
 import RouterMixin from '../mixins/RouterMixin.js'
-import { GROUP_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS, ROUTE_CIRCLE, ROUTE_USER_GROUP } from '../models/constants.ts'
+import { GROUP_ALL_CONTACTS, GROUP_NO_GROUP_CONTACTS } from '../models/constants.ts'
 import Contact from '../models/contact.js'
 import rfcProps from '../models/rfcProps.js'
 import client from '../services/cdav.js'
@@ -147,14 +144,6 @@ export default {
 			return this.$store.getters.getImportState
 		},
 
-		isEmptyGroup() {
-			return this.contactsList.length === 0
-		},
-
-		isChartView() {
-			return !!this.selectedChart
-		},
-
 		/**
 		 * Are we importing contacts ?
 		 *
@@ -171,6 +160,14 @@ export default {
 		 */
 		isImportDone() {
 			return this.importState.stage === 'done'
+		},
+
+		importEnabled() {
+			return !this.selectedUserGroup && !this.selectedCircle && !this.selectedUserGroup && !this.selectedChart && this.contactsList.length === 0
+		},
+
+		addingContactEnabled() {
+			return !this.selectedUserGroup
 		},
 
 		// first enabled addressbook of the list
@@ -191,18 +188,13 @@ export default {
 				return this.sortedContacts
 			} else if (this.selectedGroup === GROUP_NO_GROUP_CONTACTS) {
 				return this.ungroupedContacts.map((contact) => this.sortedContacts.find((item) => item.key === contact.key))
-			} else if (this.selectedGroup === ROUTE_CIRCLE || this.selectedGroup === ROUTE_USER_GROUP) {
-				return []
 			}
+
 			const group = this.groups.filter((group) => group.name === this.selectedGroup)[0]
 			if (group) {
 				return this.sortedContacts.filter((contact) => group.contacts.indexOf(contact.key) >= 0)
 			}
 			return []
-		},
-
-		isCirclesView() {
-			return this.selectedGroup === ROUTE_CIRCLE || this.selectedGroup === ROUTE_USER_GROUP
 		},
 
 		ungroupedContacts() {
@@ -275,8 +267,8 @@ export default {
 
 	methods: {
 		async newContact() {
-			if (this.isCirclesView) {
-				emit('contacts:circles:append', this.selectedCircle.id)
+			if (this.selectedCircle) {
+				emit('contacts:circles:append', this.selectedCircle)
 				return
 			}
 
@@ -391,9 +383,7 @@ export default {
 					&& !this.selectedUserGroup
 					&& !this.groups.find((group) => group.name === this.selectedGroup)
 					&& GROUP_ALL_CONTACTS !== this.selectedGroup
-					&& GROUP_NO_GROUP_CONTACTS !== this.selectedGroup
-					&& ROUTE_CIRCLE !== this.selectedGroup
-					&& ROUTE_USER_GROUP !== this.selectedGroup) {
+					&& GROUP_NO_GROUP_CONTACTS !== this.selectedGroup) {
 					showError(t('contacts', 'Group {group} not found', { group: this.selectedGroup }))
 					console.error('Group not found', this.selectedGroup)
 


### PR DESCRIPTION
Navigating the app in dev mode, the JS console is filled with warnings like:
```
[Vue Router warn]: Discarded invalid param(s) "selectedGroup" when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.
```

I've investigated a bit, and I've found that `selectedGroup` has been introduced in the routing parameters in a0a80c9 to fix #4090.

With the migration to Vue3, and the upgrade of vue-router, unused routing parameters are discarded by the router ([as described here](https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22)), and the changes introduced in a0a80c9 broke again.

So I have mostly reverted that commit, and introduced a different approach to select how and when display the "Import Contacts" buttons.

Accidentally, this also fix #5257