### PR TITLE
fix: description for empty content

### DIFF
--- a/src/components/AppContent/ContactsContent.vue
+++ b/src/components/AppContent/ContactsContent.vue
@@ -17,7 +17,7 @@
 			<template #icon>
 				<IconContact :size="20" />
 			</template>
-			<template #desc>
+			<template #description>
 				<NcButton variant="primary" @click="newContact">
 					{{ t('contacts', 'Create contact') }}
 				</NcButton>
@@ -30,7 +30,7 @@
 			<template #icon>
 				<IconContact :size="20" />
 			</template>
-			<template #desc>
+			<template #description>
 				<NcButton v-if="contacts.length === 0" variant="primary" @click="addContactsToGroup(selectedGroup)">
 					{{ t('contacts', 'Create contacts') }}
 				</NcButton>


### PR DESCRIPTION
The `#desc` slot stopped existing in https://github.com/nextcloud-libraries/nextcloud-vue/commit/70e3966fa9f7aedbdbbf66fcde6f0dd2ffe2e56e and was renamed `#description` in v9.0.0 https://github.com/nextcloud-libraries/nextcloud-vue/commit/87365478bc0f27c8e455367aa53ab2802ca1a54e 