### PR TITLE
perf(chart): lazy load the org chart view

### DIFF
--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -65,8 +65,8 @@ import {
 	NcButton,
 } from '@nextcloud/vue'
 import ICAL from 'ical.js'
+import { defineAsyncComponent } from 'vue'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
-import ChartContent from '../components/AppContent/ChartContent.vue'
 import CircleContent from '../components/AppContent/CircleContent.vue'
 import ContactsContent from '../components/AppContent/ContactsContent.vue'
 import RootNavigation from '../components/AppNavigation/RootNavigation.vue'
@@ -89,7 +89,8 @@ export default {
 	components: {
 		NcButton,
 		CircleContent,
-		ChartContent,
+		// Lazy loaded: pulls in d3 and is only rendered on the org chart view
+		ChartContent: defineAsyncComponent(() => import('../components/AppContent/ChartContent.vue')),
 		ContactsContent,
 		ContactsPicker,
 		Content,


### PR DESCRIPTION
contacts-main.mjs      612.33 kB -> 500.79 kB               
ChartContent.chunk.mjs    111.68 kB (lazy) 

It's a rarely used feature no need to always load it 

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
