### PR TITLE
fix : dont translate first writable addressbook name

### DIFF
--- a/src/views/Contacts.vue
+++ b/src/views/Contacts.vue
@@ -246,7 +246,11 @@ export default {
 
 					// No writeable addressbooks? Create a new one!
 					if (writeableAddressBooks.length === 0) {
-						this.$store.dispatch('appendAddressbook', { displayName: t('contacts', 'Contacts') })
+						// Untranslated on purpose: the DAV URI is derived from the display name,
+						// so translating it here would make the path language dependent
+						// (e.g. /kontakte, or /- for languages without ASCII letters).
+						// The server translates the display name of contacts/Contacts for us.
+						this.$store.dispatch('appendAddressbook', { displayName: 'Contacts' })
 							.then(() => {
 								this.fetchContacts()
 							})


### PR DESCRIPTION
To avoid https://github.com/nextcloud/contacts/issues/4306 happening again . 
the issue was the first login flow was not triggering -> no Contacts addressbook created -> dav paths like https://example.com/remote.php/dav/addressbooks/users/test/-/  were generated

The bug with first login flow was fixed a long time ago https://github.com/nextcloud/server/pull/50369 
## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
