### PR TITLE
feat(contacts): support pronouns property

### DIFF
--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -26,7 +26,7 @@ function isEmpty(value) {
 export const ContactKindProperties = ['KIND', 'X-ADDRESSBOOKSERVER-KIND']
 
 export const MinimalContactProperties = [
-	'EMAIL', 'UID', 'TEL', 'CATEGORIES', 'FN', 'ORG', 'N', 'X-PHONETIC-FIRST-NAME', 'X-PHONETIC-LAST-NAME', 'X-MANAGERSNAME', 'TITLE', 'NOTE', 'RELATED',
+	'EMAIL', 'UID', 'TEL', 'CATEGORIES', 'FN', 'ORG', 'N', 'X-PHONETIC-FIRST-NAME', 'X-PHONETIC-LAST-NAME', 'X-MANAGERSNAME', 'TITLE', 'NOTE', 'RELATED', 'PRONOUNS',
 ].concat(ContactKindProperties)
 
 export function generateContactKey(uid, addressbookId) {

--- a/src/models/rfcProps.js
+++ b/src/models/rfcProps.js
@@ -362,6 +362,16 @@ const properties = {
 		],
 		primary: false,
 	},
+	pronouns: {
+		multiple: true,
+		readableName: t('contacts', 'Pronouns'),
+		icon: 'icon-gender',
+		force: 'text',
+		defaultValue: {
+			value: '',
+		},
+		primary: false,
+	},
 	tz: {
 		readableName: t('contacts', 'Time zone'),
 		force: 'select',
@@ -420,6 +430,7 @@ const fieldOrder = [
 	'x-phonetic-first-name',
 	'x-phonetic-last-name',
 	'gender',
+	'pronouns',
 	'cloud',
 	'impp',
 	'geo',

--- a/tests/javascript/models/contact.test.js
+++ b/tests/javascript/models/contact.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import Contact from '../../../src/models/contact'
+import Contact, { MinimalContactProperties } from '../../../src/models/contact'
 
 const getPropertyLines = (property, vcard) => {
 	return vcard.match(new RegExp(`^${property}[;:].*`, 'gmi'))
@@ -60,6 +60,10 @@ describe('Test stripping quotes from TYPE', () => {
 		expect(contactWithEmails.hasEmail('first@example.com')).toBe(true)
 		expect(contactWithEmails.hasEmail('second@example.com')).toBe(true)
 		expect(contactWithEmails.hasEmail('third@example.com')).toBe(false)
+	})
+
+	test('Test pronouns are included in the lightweight property list', () => {
+		expect(MinimalContactProperties).toContain('PRONOUNS')
 	})
 
 	test('Test stripping quotes from MULTIPLE SPLIT TYPES and MULTIPLE PROPERTIES', () => {

--- a/tests/javascript/models/rfcProps.test.js
+++ b/tests/javascript/models/rfcProps.test.js
@@ -29,4 +29,14 @@ describe('RFC props', () => {
 		expect(property.getParameter('type')).toEqual(defaultData.type)
 		expect(contact.vCard.toString()).toMatch(/^IMPP;TYPE=.+:$/m)
 	})
+
+	test('pronouns is a serializable RFC 9554 text property', () => {
+		const property = contact.vCard.addPropertyWithValue('pronouns', 'they/them')
+
+		expect(rfcProps.properties.pronouns.readableName).toBe(t('contacts', 'Pronouns'))
+		expect(rfcProps.properties.pronouns.multiple).toBe(true)
+		expect(rfcProps.fieldOrder.indexOf('pronouns')).toBeGreaterThan(rfcProps.fieldOrder.indexOf('gender'))
+		expect(rfcProps.properties.pronouns.force).toBe('text')
+		expect(contact.vCard.toString()).toMatch(/^PRONOUNS:they\/them$/m)
+	})
 })


### PR DESCRIPTION
## Summary
- Add RFC 9554 `PRONOUNS` as a repeatable text contact property.
- Include it in lightweight CardDAV property fetches and cover serialization with Jest.

Closes #5108

## Test plan
- [x] Jest: rfcProps + contact model tests
- [x] `npm run build`
- [ ] UI: add/edit pronouns on a contact and verify round-trip save/reload
