### PR TITLE
fix(teams): allow hiding the shared folder button via app config

### DIFF
--- a/lib/ConfigLexicon.php
+++ b/lib/ConfigLexicon.php
@@ -33,6 +33,7 @@ class ConfigLexicon implements ILexicon {
 	public const FEDERATIONS_CACHE = 'federations_cache';
 	public const FEDERATIONS_CACHE_EXPIRES = 'expires';
 	public const FEDERATIONS_CACHE_DELTA_EXPIRES = 'delta_expires';
+	public const HIDE_TEAM_SHARED_FOLDER_CREATION = 'hide_team_shared_folder_creation';
 
 	#[\Override]
 	public function getStrictness(): Strictness {
@@ -105,6 +106,13 @@ class ConfigLexicon implements ILexicon {
 				ValueType::INT,
 				defaultRaw: 0,
 				definition: 'Federations cache update (delta) expiration time.',
+				lazy: true,
+			),
+			new Entry(
+				self::HIDE_TEAM_SHARED_FOLDER_CREATION,
+				ValueType::BOOL,
+				defaultRaw: false,
+				definition: 'Hide the team-page button that creates a personal folder and shares it with the team.',
 				lazy: true,
 			),
 		];

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -9,6 +9,7 @@ namespace OCA\Contacts\Controller;
 
 use OC\App\CompareVersion;
 use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\ConfigLexicon;
 use OCA\Contacts\Service\FederatedInvitesService;
 use OCA\Contacts\Service\GroupSharingService;
 use OCA\Contacts\Service\SocialApiService;
@@ -16,6 +17,7 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -29,6 +31,7 @@ class PageController extends Controller {
 		IRequest $request,
 		private FederatedInvitesService $federatedInvitesService,
 		private IConfig $config,
+		private IAppConfig $appConfig,
 		private IInitialState $initialState,
 		private IFactory $languageFactory,
 		private IUserSession $userSession,
@@ -83,6 +86,10 @@ class PageController extends Controller {
 		$isTalkVersionCompatible = $this->compareVersion->isCompatible($talkVersion ? $talkVersion : '0.0.0', 2);
 		$isOcmInvitesEnabled = $this->federatedInvitesService->isOcmInvitesEnabled();
 		$ocmInvitesConfig = $this->federatedInvitesService->getOcmInvitesConfig();
+		$hideTeamSharedFolderCreation = $this->appConfig->getValueBool(
+			Application::APP_ID,
+			ConfigLexicon::HIDE_TEAM_SHARED_FOLDER_CREATION,
+		);
 
 		$this->initialState->provideInitialState('isGroupSharingEnabled', $isGroupSharingEnabled);
 		$this->initialState->provideInitialState('locales', $locales);
@@ -95,6 +102,7 @@ class PageController extends Controller {
 		$this->initialState->provideInitialState('isTalkEnabled', $isTalkEnabled && $isTalkVersionCompatible);
 		$this->initialState->provideInitialState('isOcmInvitesEnabled', $isOcmInvitesEnabled);
 		$this->initialState->provideInitialState('ocmInvitesConfig', $ocmInvitesConfig);
+		$this->initialState->provideInitialState('hideTeamSharedFolderCreation', $hideTeamSharedFolderCreation);
 
 		Util::addStyle(Application::APP_ID, 'contacts-main');
 		Util::addScript(Application::APP_ID, 'contacts-main');

--- a/src/components/CircleDetails.vue
+++ b/src/components/CircleDetails.vue
@@ -151,7 +151,7 @@
 					</div>
 
 					<!-- Team resource creation shortcuts -->
-					<div v-if="circle.isMember" class="resource-shortcuts">
+					<div v-if="circle.isMember && resourceTypes.length > 0" class="resource-shortcuts">
 						<h3 class="resource-shortcuts__title">
 							{{ t('contacts', 'Create') }}
 						</h3>
@@ -327,6 +327,7 @@ import TeamResourceButton from './CircleDetails/TeamResourceButton.vue'
 import MemberList from './MemberList/MemberList.vue'
 import CircleActionsMixin from '../mixins/CircleActionsMixin.js'
 import { CircleEdit, editCircle } from '../services/circles.ts'
+import hideTeamSharedFolderCreation from '../services/hideTeamSharedFolderCreation.js'
 import logger from '../services/logger.js'
 
 import 'cropperjs/dist/cropper.css'
@@ -541,7 +542,7 @@ export default {
 					helperText: t('contacts', 'This will create a regular folder shared with the team. To create a Team Folder, please contact your {productName} administrator', { productName: OC.theme.name }),
 					icon: 'FolderOutlineIcon',
 					apiPath: 'files',
-					enabled: enabledApps.files !== undefined,
+					enabled: enabledApps.files !== undefined && !hideTeamSharedFolderCreation,
 				},
 				{
 					id: 'talk',

--- a/src/services/hideTeamSharedFolderCreation.js
+++ b/src/services/hideTeamSharedFolderCreation.js
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { loadState } from '@nextcloud/initial-state'
+
+const hideTeamSharedFolderCreation = loadState('contacts', 'hideTeamSharedFolderCreation', false)
+export default hideTeamSharedFolderCreation

--- a/tests/unit/Controller/PageControllerTest.php
+++ b/tests/unit/Controller/PageControllerTest.php
@@ -10,12 +10,14 @@ namespace OCA\Contacts\Controller;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OC\App\CompareVersion;
 use OCA\Contacts\AppInfo\Application;
+use OCA\Contacts\ConfigLexicon;
 use OCA\Contacts\Service\FederatedInvitesService;
 use OCA\Contacts\Service\GroupSharingService;
 use OCA\Contacts\Service\SocialApiService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUser;
@@ -32,6 +34,9 @@ class PageControllerTest extends TestCase {
 
 	/** @var IConfig|MockObject */
 	private $config;
+
+	/** @var IAppConfig|MockObject */
+	private $appConfig;
 
 	/** @var IInitialState|MockObject */
 	private $initialStateService;
@@ -59,6 +64,7 @@ class PageControllerTest extends TestCase {
 
 		$this->request = $this->createMock(IRequest::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->initialStateService = $this->createMock(IInitialState::class);
 		$this->languageFactory = $this->createMock(IFactory::class);
 		$this->userSession = $this->createMock(IUserSession::class);
@@ -76,6 +82,7 @@ class PageControllerTest extends TestCase {
 			$this->request,
 			$this->federatedInvitesService,
 			$this->config,
+			$this->appConfig,
 			$this->initialStateService,
 			$this->languageFactory,
 			$this->userSession,
@@ -97,6 +104,47 @@ class PageControllerTest extends TestCase {
 		$this->assertEquals('main', $result->getTemplateName());
 		$this->assertEquals('user', $result->getRenderAs());
 		$this->assertTrue($result instanceof TemplateResponse);
+	}
+
+	public function testIndexProvidesHideTeamSharedFolderCreation() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUid')->willReturn('mrstest');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$this->appConfig->method('getValueBool')
+			->willReturnCallback(function (string $app, string $key, bool $default = false) {
+				$this->assertSame(Application::APP_ID, $app);
+				if ($key === ConfigLexicon::HIDE_TEAM_SHARED_FOLDER_CREATION) {
+					return true;
+				}
+				return $default;
+			});
+
+		$states = [];
+		$this->initialStateService->method('provideInitialState')
+			->willReturnCallback(function (string $key, mixed $value) use (&$states): void {
+				$states[$key] = $value;
+			});
+
+		$this->controller->index();
+
+		$this->assertTrue($states['hideTeamSharedFolderCreation']);
+	}
+
+	public function testIndexHideTeamSharedFolderCreationDefaultsToFalse() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUid')->willReturn('mrstest');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$states = [];
+		$this->initialStateService->method('provideInitialState')
+			->willReturnCallback(function (string $key, mixed $value) use (&$states): void {
+				$states[$key] = $value;
+			});
+
+		$this->controller->index();
+
+		$this->assertFalse($states['hideTeamSharedFolderCreation']);
 	}
 
 	public static function teamManagementDataProvider(): array {


### PR DESCRIPTION
## Summary


Resolves: https://github.com/nextcloud/contacts/issues/5638

```bash
occ config:app:set contacts hide_team_shared_folder_creation --value=true
```

Default (show create button)
<img width="873" height="480" alt="grafik" src="https://github.com/user-attachments/assets/b5afbdc8-62e6-466c-a3eb-04832c9f509a" />

Now optional (no create button)
<img width="873" height="480" alt="grafik" src="https://github.com/user-attachments/assets/a56e85a4-bf0f-4928-9c26-a10bfded43fc" />

It is still possible to share a personal folder with a team.

## AI
- [x] Partly generated using Cursor Grok 4.6