### PR TITLE
chore: removing unused properties about org chart

### DIFF
--- a/src/components/AppContent/ContactsContent.vue
+++ b/src/components/AppContent/ContactsContent.vue
@@ -56,7 +56,7 @@
 		</template>
 
 		<!-- main contacts details -->
-		<ContactDetails :contact-key="selectedContact" :contacts="sortedContacts" :reload-bus="reloadBus" />
+		<ContactDetails :contact-key="selectedContact" :reload-bus="reloadBus" />
 	</AppContent>
 </template>
 
@@ -117,10 +117,6 @@ export default {
 
 		groups() {
 			return this.$store.getters.getGroups
-		},
-
-		sortedContacts() {
-			return this.$store.getters.getSortedContacts
 		},
 
 		/**

--- a/src/components/ContactDetails.vue
+++ b/src/components/ContactDetails.vue
@@ -284,7 +284,6 @@
 							:property="property"
 							:contact="contact"
 							:local-contact="localContact"
-							:contacts="contacts"
 							:bus="bus"
 							:is-read-only="isReadOnly" />
 					</div>
@@ -485,11 +484,6 @@ export default defineComponent({
 		contactKey: {
 			type: String,
 			default: undefined,
-		},
-
-		contacts: {
-			type: Array,
-			default: () => [],
 		},
 
 		reloadBus: {

--- a/src/components/ContactDetails/ContactDetailsProperty.vue
+++ b/src/components/ContactDetails/ContactDetailsProperty.vue
@@ -79,11 +79,6 @@ export default {
 			default: null,
 		},
 
-		contacts: {
-			type: Array,
-			default: () => [],
-		},
-
 		bus: {
 			type: Object,
 			required: true,


### PR DESCRIPTION
Some minor changes related to the Org Chart:

- fixed the missing reference to `logger` (recently introduced in #5624)
- removed unused properties introduced in #2954. It seems the intention was to bubble the full list of contacts from `ContactsContent` to `ContactDetailsProperty` probably to permit cross-contacts references, then the `otherContacts` mixin's function has been used to draw directly from `$store.getters.getSortedContacts` (this is my own speculation!). I've tested the Chart panel and it works also without those properties (apart for #4454, which has already been fixed but not yet merged in `main`)