### PR TITLE
handle case-insensitive vCard tags and UID property

### DIFF
--- a/lib/Controller/ImportController.php
+++ b/lib/Controller/ImportController.php
@@ -102,12 +102,12 @@ class ImportController extends OCSController {
 		foreach ($vcfLines as $line) {
 			$line = rtrim($line, "\r");
 
-			if ($line === 'BEGIN:VCARD') {
+			if (strtoupper($line) === 'BEGIN:VCARD') {
 				$currentContact = [$line];
 				continue;
 			}
 
-			if ($line === 'END:VCARD') {
+			if (strtoupper($line) === 'END:VCARD') {
 				$currentContact[] = $line;
 				$contacts[] = [
 					'uid' => $currentContactUid,
@@ -122,8 +122,8 @@ class ImportController extends OCSController {
 				continue;
 			}
 
-			if (str_starts_with($line, self::UID_PREFIX)) {
-				$currentContactUid = substr($line, strlen(self::UID_PREFIX));
+			if (str_starts_with(strtoupper($line), self::UID_PREFIX)) {
+				$currentContactUid = trim(substr($line, strlen(self::UID_PREFIX)));
 			}
 
 			$currentContact[] = $line;


### PR DESCRIPTION
### Summary
This PR resolves an issue in `ImportController` where vCard files containing lowercase or mixed-case property tags (such as `begin:vcard`, `end:vcard`, or `uid:...`) were either skipped entirely or had their UID ignored during import.

### Context & Root Cause
According to [RFC 6350 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6350#section-3.3) and RFC 2426, vCard property and parameter names are case-insensitive. Some contact export utilities output vCard delimiters and properties with lowercase or mixed-case formatting.

In `ImportController.php`:
1. The parser checked `$line === 'BEGIN:VCARD'` and `$line === 'END:VCARD'` with strict case comparison. If a `.vcf` file contained `begin:vcard`, `$currentContact` was never initialized, causing contacts to be silently skipped.
2. The check `str_starts_with($line, self::UID_PREFIX)` checked strictly for uppercase `UID:`. When a contact had `uid:...`, `$currentContactUid` remained `null`, preventing the existing contact deduplication lookup (`$addressBook->search($uid, ...)`) from executing and leading to duplicate entries upon re-import.

### Solution
- Use `strtoupper($line)` when comparing against `BEGIN:VCARD` and `END:VCARD`.
- Use `str_starts_with(strtoupper($line), self::UID_PREFIX)` to reliably extract the UID regardless of casing.

### Changes Made
- `lib/Controller/ImportController.php`: updated `BEGIN:VCARD`, `END:VCARD`, and `UID:` tag checks to be case-insensitive.