### PR TITLE
fix(routes): navigation and not founnd

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -9,12 +9,12 @@ return [
 	'routes' => [
 		['name' => 'contacts#direct', 'url' => '/direct/contact/{contact}', 'verb' => 'GET'],
 		['name' => 'contacts#directcircle', 'url' => '/direct/circle/{singleId}', 'verb' => 'GET'],
-		['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
-		['name' => 'page#index', 'url' => '/{group}', 'verb' => 'GET', 'postfix' => 'group'],
-		['name' => 'page#index', 'url' => '/{group}/{contact}', 'verb' => 'GET', 'postfix' => 'group.contact'],
 		['name' => 'social_api#update_contact',  'url' => '/api/v1/social/avatar/{network}/{addressbookId}/{contactId}', 'verb' => 'PUT'],
 		['name' => 'social_api#set_app_config',	 'url' => '/api/v1/social/config/global/{key}', 'verb' => 'PUT'],
 		['name' => 'social_api#set_user_config', 'url' => '/api/v1/social/config/user/{key}', 'verb' => 'PUT'],
 		['name' => 'social_api#get_user_config', 'url' => '/api/v1/social/config/user/{key}', 'verb' => 'GET'],
+		['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
+		// Catch-all so any client-side route survives a page reload
+		['name' => 'page#index', 'url' => '/{path}', 'verb' => 'GET', 'postfix' => 'path', 'requirements' => ['path' => '.*']],
 	]
 ];

--- a/src/components/AppNavigation/GroupNavigationItem.vue
+++ b/src/components/AppNavigation/GroupNavigationItem.vue
@@ -15,8 +15,7 @@
 			:key="group.key"
 			:to="group.router"
 			:name="group.name"
-			:active="routeState === `group:${group.id}`"
-			@click="$emit('updateRouteState', `group:${group.id}`)">
+			:active="routeState === `group:${group.id}`">
 			<template #icon>
 				<IconContactFilled v-if="routeState === `group:${group.id}`" :size="20" />
 				<IconContact v-else :size="20" />

--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -128,8 +128,7 @@
 				:to="{
 					name: ROUTE_NAME_ALL_OCM_INVITES,
 				}"
-				:active="routeState === 'ocm-invites'"
-				@click="updateRouteState('ocm-invites')">
+				:active="routeState === 'ocm-invites'">
 				<template #icon>
 					<IconAccountSwitchOutline :size="20" />
 				</template>
@@ -362,6 +361,9 @@ export default {
 			}
 			if (this.selectedChart) {
 				return 'orgchart'
+			}
+			if (this.$route.meta.selectedGroup === GROUP_ALL_OCM_INVITES) {
+				return 'ocm-invites'
 			}
 			switch (this.selectedGroup) {
 				case GROUP_ALL_CONTACTS:

--- a/src/components/AppNavigation/RootNavigation.vue
+++ b/src/components/AppNavigation/RootNavigation.vue
@@ -25,8 +25,7 @@
 					name: 'group',
 					params: { selectedGroup: GROUP_ALL_CONTACTS },
 				}"
-				:active="routeState === 'all'"
-				@click="updateRouteState('all')">
+				:active="routeState === 'all'">
 				<template #icon>
 					<IconContactFilled v-if="routeState === 'all'" :size="20" />
 					<IconContact v-else :size="20" />
@@ -48,8 +47,7 @@
 					params: { selectedChart: GROUP_ALL_CONTACTS },
 				}"
 				:active="routeState === 'orgchart'"
-				icon="icon-category-monitoring"
-				@click="updateRouteState('orgchart')" />
+				icon="icon-category-monitoring" />
 
 			<!-- Not grouped group -->
 			<AppNavigationItem
@@ -60,8 +58,7 @@
 					name: 'group',
 					params: { selectedGroup: GROUP_NO_GROUP_CONTACTS },
 				}"
-				:active="routeState === 'notgrouped'"
-				@click="updateRouteState('notgrouped')">
+				:active="routeState === 'notgrouped'">
 				<template #icon>
 					<IconUserFilled v-if="routeState === 'notgrouped'" :size="20" />
 					<IconUser v-else :size="20" />
@@ -92,8 +89,7 @@
 					name: ROUTE_ADDRESSBOOK,
 					params: { selectedAddressbook: addressbook.id },
 				}"
-				:active="routeState === `${ROUTE_ADDRESSBOOK}:${addressbook.id}`"
-				@click="updateRouteState(`${ROUTE_ADDRESSBOOK}:${addressbook.id}`)">
+				:active="routeState === `${ROUTE_ADDRESSBOOK}:${addressbook.id}`">
 				<template #icon>
 					<IconAddressBook :size="20" />
 				</template>
@@ -113,8 +109,7 @@
 					name: 'group',
 					params: { selectedGroup: GROUP_RECENTLY_CONTACTED },
 				}"
-				:active="routeState === 'recentlycontacted'"
-				@click="updateRouteState('recentlycontacted')">
+				:active="routeState === 'recentlycontacted'">
 				<template #icon>
 					<IconRecentlyContacted :size="20" />
 				</template>
@@ -175,8 +170,7 @@
 				v-for="group in ellipsisGroupsMenu"
 				:key="group.key"
 				:route-state="routeState"
-				:group="group"
-				@update-route-state="updateRouteState" />
+				:group="group" />
 
 			<template v-if="isTeamManagementEnabled">
 				<!-- Toggle groups ellipsis -->
@@ -211,8 +205,7 @@
 					<CircleNavigationItem
 						v-for="circle in ellipsisCirclesMenu"
 						:key="circle.key"
-						:circle="circle"
-						@click="updateRouteState(`circle:${circle.id}`)" />
+						:circle="circle" />
 
 					<!-- Toggle circles ellipsis -->
 					<AppNavigationItem
@@ -357,13 +350,32 @@ export default {
 			collapsedCircles: true,
 
 			showSettings: false,
-
-			routeState: 'all',
 			isOcmInvitesEnabled,
 		}
 	},
 
 	computed: {
+		// navigation entry matching the current route
+		routeState() {
+			if (this.selectedAddressbook) {
+				return `${ROUTE_ADDRESSBOOK}:${this.selectedAddressbook}`
+			}
+			if (this.selectedChart) {
+				return 'orgchart'
+			}
+			switch (this.selectedGroup) {
+				case GROUP_ALL_CONTACTS:
+					return 'all'
+				case GROUP_NO_GROUP_CONTACTS:
+					return 'notgrouped'
+				case GROUP_RECENTLY_CONTACTED:
+					return 'recentlycontacted'
+				default:
+				// group ids are built the same way in groupsMenu
+					return this.selectedGroup ? `group:${this.selectedGroup.replace(' ', '_')}` : ''
+			}
+		},
+
 		// store variables
 		addressbooks() {
 			return this.$store.getters.getAddressbooks
@@ -596,9 +608,6 @@ export default {
 			this.showSettings = true
 		},
 
-		updateRouteState(state) {
-			this.routeState = state
-		},
 	},
 }
 </script>


### PR DESCRIPTION
Repro:
1. Select a contact 
2. Refresh 

Before: 
Not found 

With Pr: 
Found with appropriate navigation set 

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Navigation selection now stays synchronized with the current route across contact views, address books, charts, and groups.
  - Active navigation indicators update consistently when navigating between sections or using browser navigation.
  - Group navigation no longer relies on click-specific state updates.

- **Navigation**
  - Added support for arbitrary client-side paths while preserving the home page and social API routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->