### PR TITLE
fix(store): keep new contacts in the sorted index

### DIFF
--- a/src/store/contacts.js
+++ b/src/store/contacts.js
@@ -5,6 +5,7 @@
 
 import { showError } from '@nextcloud/dialogs'
 import ICAL from 'ical.js'
+import { toRaw } from 'vue'
 import Contact from '../models/contact.js'
 import logger from '../services/logger.js'
 import validate from '../services/validate.js'
@@ -27,38 +28,83 @@ ICAL.design.vcard3.param.type.multiValueSeparateDQuote = true
 ICAL.design.vcard.param.type.multiValueSeparateDQuote = true
 
 function sortData(a, b) {
-	const nameA = typeof a.value === 'string'
-		? a.value.toUpperCase() // ignore upper and lowercase
-		: a.value.toUnixTime() // only other sorting we support is a vCardTime
-	const nameB = typeof b.value === 'string'
-		? b.value.toUpperCase() // ignore upper and lowercase
-		: b.value.toUnixTime() // only other sorting we support is a vCardTime
+	// contacts without a value always come last
+	if ((a.value === '') !== (b.value === '')) {
+		return a.value === '' ? 1 : -1
+	}
 
-	const score = nameA.localeCompare
-		? nameA.localeCompare(nameB)
-		: nameB - nameA
+	// a malformed rev is indexed as a string, so never compare a timestamp with text:
+	// that would be non-transitive. Timestamps come first, text keeps its own ordering
+	const aIsTime = typeof a.value === 'number'
+	const bIsTime = typeof b.value === 'number'
+	if (aIsTime !== bIsTime) {
+		return aIsTime ? -1 : 1
+	}
+
+	const score = aIsTime
+		? b.value - a.value // timestamps (rev), most recent first
+		: a.value.toUpperCase().localeCompare(b.value.toUpperCase()) // ignore upper and lowercase
+
 	// if equal, fallback to the key
 	return score !== 0
 		? score
 		: a.key.localeCompare(b.key)
 }
 
-function sortByFavoriteAndName(a, b) {
-	// favorites always on top
+/**
+ * Favorites first, then by the current order key.
+ *
+ * @param {object} a a sorted contacts index entry
+ * @param {object} b a sorted contacts index entry
+ * @return {number}
+ */
+function sortByFavoriteAndData(a, b) {
 	if (a.favorite !== b.favorite) {
 		return a.favorite ? -1 : 1
 	}
-	// alphabetical within each group
-	if (!a.value && !b.value) {
-		return 0
+	return sortData(a, b)
+}
+
+/**
+ * Insert an entry at its sorted position in the sorted contacts index
+ *
+ * @param {object} state the store data
+ * @param {object} entry a sorted contacts index entry
+ */
+function insertSortedEntry(state, entry) {
+	const index = state.sortedContacts.findIndex((other) => sortByFavoriteAndData(other, entry) >= 0)
+	if (index === -1) {
+		state.sortedContacts.push(entry)
+	} else {
+		state.sortedContacts.splice(index, 0, entry)
 	}
-	if (!a.value) {
-		return 1
+}
+
+/**
+ * Build an entry of the sorted contacts index
+ *
+ * @param {Contact} contact the contact to index
+ * @param {string} orderKey the contact property to sort on
+ * @return {object}
+ */
+function sortedEntry(contact, orderKey) {
+	let value
+	try {
+		value = contact[orderKey]
+	} catch (error) {
+		// a malformed property (an invalid REV for instance) throws when ical.js decodes it
+		logger.warn('Could not read the sort value of a contact', { key: contact.key, orderKey, error })
+		value = ''
 	}
-	if (!b.value) {
-		return -1
+
+	return {
+		key: contact.key,
+		// vCardTime values (rev) are indexed as timestamps, anything else as a string:
+		// structured name components can be arrays (multiple given names in vCard 4.0).
+		// ical.js reads its own internals, which fails through the reactive proxy, so unwrap first
+		value: value?.toUnixTime ? toRaw(value).toUnixTime() : String(value ?? ''),
+		favorite: contact.favorite || false,
 	}
-	return a.value.localeCompare(b.value)
 }
 
 const state = {
@@ -107,16 +153,8 @@ const mutations = {
 		const sortedContact = state.sortedContacts.find((c) => c.key === contact.key)
 		if (sortedContact) {
 			sortedContact.favorite = contact.favorite || false
+			state.sortedContacts.sort(sortByFavoriteAndData)
 		}
-
-		state.sortedContacts = Object.values(state.contacts)
-			.filter((c) => c.kind !== 'group')
-			.map((c) => ({
-				key: c.key,
-				value: (c[state.orderKey] || '').toString().toLowerCase(),
-				favorite: c.favorite || false,
-			}))
-			.sort(sortByFavoriteAndName)
 	},
 	/**
 	 * Delete a contact from the global contacts list
@@ -127,7 +165,9 @@ const mutations = {
 	deleteContact(state, contact) {
 		if (state.contacts[contact.key] && contact instanceof Contact) {
 			const index = state.sortedContacts.findIndex((search) => search.key === contact.key)
-			state.sortedContacts.splice(index, 1)
+			if (index !== -1) {
+				state.sortedContacts.splice(index, 1)
+			}
 			delete state.contacts[contact.key]
 		} else {
 			logger.error('Error while deleting the following contact', { contact })
@@ -145,37 +185,7 @@ const mutations = {
 		if (contact instanceof Contact) {
 			validate(contact)
 
-			const sortedContact = {
-				key: contact.key,
-				value: (contact[state.orderKey] || '').toString().toLowerCase(),
-				favorite: contact.favorite,
-			}
-
-			// Not using sort, splice has far better performances
-			// https://jsperf.com/sort-vs-splice-in-array
-			for (let i = 0, len = state.sortedContacts.length; i < len; i++) {
-				const other = state.sortedContacts[i]
-
-				// favorite comes before non-favorite
-				const differentFavStatus = other.favorite !== sortedContact.favorite
-				const otherShouldComeFirst = differentFavStatus && other.favorite
-				const sameFavAndSortedFirst = !differentFavStatus && sortData(other, sortedContact) >= 0
-
-				if (otherShouldComeFirst || sameFavAndSortedFirst) {
-					continue
-				}
-
-				if (i + 1 === len) {
-					state.sortedContacts.push(sortedContact)
-				} else {
-					state.sortedContacts.splice(i, 0, sortedContact)
-				}
-				break
-			}
-
-			if (state.sortedContacts.length === 0) {
-				state.sortedContacts.push(sortedContact)
-			}
+			insertSortedEntry(state, sortedEntry(contact, state.orderKey))
 
 			state.contacts[contact.key] = contact
 		} else {
@@ -206,14 +216,13 @@ const mutations = {
 				return
 			}
 
-			const hasValueChanged = sortedContact.value !== contact[state.orderKey]
-			const hasFavoriteChanged = sortedContact.favorite !== (state.contacts[contact.key].dav?.favorite || false)
+			const updatedEntry = sortedEntry(state.contacts[contact.key], state.orderKey)
 
-			if (hasValueChanged || hasFavoriteChanged) {
-				sortedContact.value = contact[state.orderKey]
-				sortedContact.favorite = state.contacts[contact.key].dav?.favorite || false
+			if (sortedContact.value !== updatedEntry.value || sortedContact.favorite !== updatedEntry.favorite) {
+				sortedContact.value = updatedEntry.value
+				sortedContact.favorite = updatedEntry.favorite
 
-				state.sortedContacts.sort(sortByFavoriteAndName)
+				state.sortedContacts.sort(sortByFavoriteAndData)
 			}
 		} else {
 			logger.error('Error while replacing the following contact', { contact })
@@ -247,10 +256,12 @@ const mutations = {
 			// set new key, re-assign reference
 			state.contacts[newContact.key] = newContact
 
-			// Update sorted contacts list, replace at exact same position
+			// the new key can order differently against equal sort values, so reinsert
 			const index = state.sortedContacts.findIndex((search) => search.key === oldKey)
-			state.sortedContacts[index].key = newContact.key
-			state.sortedContacts[index].value = newContact[state.orderKey]
+			if (index !== -1) {
+				state.sortedContacts.splice(index, 1)
+				insertSortedEntry(state, sortedEntry(newContact, state.orderKey))
+			}
 		} else {
 			logger.error('Error while replacing the addressbook of following contact', { contact })
 		}
@@ -285,12 +296,8 @@ const mutations = {
 	sortContacts(state) {
 		state.sortedContacts = Object.values(state.contacts)
 			.filter((contact) => contact.kind !== 'group')
-			.map((contact) => ({
-				key: contact.key,
-				value: contact[state.orderKey],
-				favorite: contact.favorite || false,
-			}))
-			.sort(sortByFavoriteAndName)
+			.map((contact) => sortedEntry(contact, state.orderKey))
+			.sort(sortByFavoriteAndData)
 	},
 
 	/**

--- a/tests/javascript/store/contactsMutations.test.js
+++ b/tests/javascript/store/contactsMutations.test.js
@@ -1,0 +1,296 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+// The store index has to be imported first to avoid a circular import issue
+import store from '../../../src/store/index.js'
+import Contact from '../../../src/models/contact.js'
+
+const addressbook = { id: 'ab1', displayName: 'Address book', enabled: true, contacts: {} }
+
+function contact(fullName) {
+	const c = new Contact(`BEGIN:VCARD
+VERSION:4.0
+FN:${fullName}
+END:VCARD`, addressbook)
+	return c
+}
+
+function contactWithUid(uid, fullName) {
+	return new Contact(`BEGIN:VCARD
+VERSION:4.0
+UID:${uid}
+FN:${fullName}
+END:VCARD`, addressbook)
+}
+
+function contactWithRev(fullName, rev) {
+	return new Contact(`BEGIN:VCARD
+VERSION:3.0
+FN:${fullName}
+REV:${rev}
+END:VCARD`, addressbook)
+}
+
+describe('addContact mutation keeps every contact in the sorted list', () => {
+	beforeEach(() => {
+		store.state.contacts.contacts = {}
+		store.state.contacts.sortedContacts.splice(0)
+	})
+
+	const keys = () => store.state.contacts.sortedContacts.map((c) => c.value)
+
+	test('into an empty list', () => {
+		store.commit('addContact', contact('Name'))
+		expect(keys()).toEqual(['Name'])
+	})
+
+	test('when it sorts after the only existing contact', () => {
+		store.commit('addContact', contact('Alice'))
+		store.commit('addContact', contact('Name'))
+		expect(keys()).toEqual(['Alice', 'Name'])
+	})
+
+	test('when it sorts before the only existing contact', () => {
+		store.commit('addContact', contact('Zoe'))
+		store.commit('addContact', contact('Name'))
+		expect(keys()).toEqual(['Name', 'Zoe'])
+	})
+
+	// The reported regression: the only contacts in the store are account
+	// contacts from another address book, all sorting after the new contact's
+	// default name, and the new contact never made it into the index.
+	// https://github.com/nextcloud/contacts/issues/5681
+	test('when every existing contact sorts before it', () => {
+		for (let i = 0; i < 300; i++) {
+			store.commit('addContact', contact(`User00${700 + i} John (elysee)`))
+		}
+
+		const created = contact('Nom')
+		store.commit('addContact', created)
+
+		expect(store.getters.getSortedContacts.findIndex((c) => c.key === created.key)).toBe(0)
+	})
+
+	test('favorites stay on top', () => {
+		const favorite = contact('Zoe')
+		favorite.dav = { favorite: true }
+		store.commit('addContact', contact('Alice'))
+		store.commit('addContact', favorite)
+		store.commit('addContact', contact('Name'))
+		expect(keys()).toEqual(['Zoe', 'Alice', 'Name'])
+	})
+
+	test('when it sorts in the middle', () => {
+		store.commit('addContact', contact('Alice'))
+		store.commit('addContact', contact('Zoe'))
+		store.commit('addContact', contact('Name'))
+		expect(keys()).toEqual(['Alice', 'Name', 'Zoe'])
+	})
+})
+
+describe('sorting on other order keys', () => {
+	beforeEach(() => {
+		store.state.contacts.contacts = {}
+		store.state.contacts.sortedContacts.splice(0)
+		store.commit('setOrder', 'displayName')
+	})
+
+	const keys = () => store.state.contacts.sortedContacts.map((c) => c.key)
+
+	test('contacts without a value come last', () => {
+		store.commit('addContact', contact('Alice'))
+		const nameless = contact('')
+		store.commit('addContact', nameless)
+		store.commit('addContact', contact('Zoe'))
+		expect(keys()[2]).toBe(nameless.key)
+
+		store.commit('sortContacts')
+		expect(keys()[2]).toBe(nameless.key)
+	})
+
+	test('a structured name with multiple given names', () => {
+		store.commit('setOrder', 'firstName')
+		const multiple = new Contact(`BEGIN:VCARD
+VERSION:4.0
+FN:Peter Parker
+N:Parker;Peter,Pete;;;
+END:VCARD`, addressbook)
+
+		const alice = contact('Alice')
+		store.commit('addContact', multiple)
+		store.commit('addContact', alice)
+		store.commit('sortContacts')
+
+		expect(keys()).toEqual([alice.key, multiple.key])
+	})
+
+	test('last modified sorts the most recent first', () => {
+		store.commit('setOrder', 'rev')
+		const older = contactWithRev('Alice', '20200101T000000Z')
+		const newer = contactWithRev('Zoe', '20260101T000000Z')
+
+		store.commit('addContact', older)
+		store.commit('addContact', newer)
+		expect(keys()).toEqual([newer.key, older.key])
+
+		// contacts fetched from the server end up in reactive state,
+		// where ical.js cannot read its own internals anymore
+		store.commit('appendContacts', [older, newer])
+		store.commit('sortContacts')
+		expect(keys()).toEqual([newer.key, older.key])
+	})
+
+	test('a contact with an unparsable value does not break the sort', () => {
+		store.commit('setOrder', 'rev')
+		const broken = contactWithRev('Alice', 'not a date')
+		const valid = contactWithRev('Zoe', '20260101T000000Z')
+
+		store.commit('appendContacts', [broken, valid])
+		store.commit('sortContacts')
+
+		expect(keys()).toEqual([valid.key, broken.key])
+	})
+
+	test('a rev that decodes to a plain string does not break the sort', () => {
+		store.commit('setOrder', 'rev')
+		const text = new Contact(`BEGIN:VCARD
+VERSION:4.0
+FN:Alice
+REV;VALUE=TEXT:garbage
+END:VCARD`, addressbook)
+		const valid = contactWithRev('Zoe', '20260101T000000Z')
+
+		store.commit('addContact', valid)
+		store.commit('addContact', text)
+
+		expect(keys()).toEqual([valid.key, text.key])
+		expect(store.state.contacts.contacts[text.key]).toBeDefined()
+	})
+
+	test('a text rev does not break the order of the dated revisions', () => {
+		store.commit('setOrder', 'rev')
+		const older = contactWithRev('Alice', '20200101T000000Z')
+		const newer = contactWithRev('Zoe', '20260101T000000Z')
+		// lexically this sits between the two timestamps, which used to make the comparator
+		// non-transitive and left the dated revisions out of order
+		const text = new Contact(`BEGIN:VCARD
+VERSION:4.0
+FN:Bob
+REV;VALUE=TEXT:1700
+END:VCARD`, addressbook)
+
+		store.commit('addContact', older)
+		store.commit('addContact', text)
+		store.commit('addContact', newer)
+		expect(keys()).toEqual([newer.key, older.key, text.key])
+
+		store.commit('appendContacts', [older, text, newer])
+		store.commit('sortContacts')
+		expect(keys()).toEqual([newer.key, older.key, text.key])
+	})
+})
+
+describe('mutations that re-sort an existing contact', () => {
+	const otherAddressbook = { id: 'ab2', displayName: 'Other address book', enabled: true, contacts: {} }
+
+	beforeEach(() => {
+		store.state.contacts.contacts = {}
+		store.state.contacts.sortedContacts.splice(0)
+		store.commit('setOrder', 'displayName')
+	})
+
+	const names = () => store.state.contacts.sortedContacts.map((c) => c.value)
+
+	test('updateContact moves a renamed contact', () => {
+		store.commit('addContact', contact('Bob'))
+		store.commit('addContact', contactWithUid('uid1', 'Alice'))
+		expect(names()).toEqual(['Alice', 'Bob'])
+
+		store.commit('updateContact', contactWithUid('uid1', 'Zoe'))
+		expect(names()).toEqual(['Bob', 'Zoe'])
+	})
+
+	test('updateContact leaves the order alone when nothing sortable changed', () => {
+		store.commit('addContact', contact('Alice'))
+		store.commit('addContact', contactWithUid('uid1', 'Bob'))
+		const before = [...store.state.contacts.sortedContacts]
+
+		store.commit('updateContact', contactWithUid('uid1', 'Bob'))
+		expect(store.state.contacts.sortedContacts).toEqual(before)
+	})
+
+	test('updateContactFavorite moves a contact in and out of the favorites', () => {
+		const zoe = contact('Zoe')
+		zoe.dav = { favorite: false }
+		store.commit('addContact', contact('Alice'))
+		store.commit('addContact', zoe)
+		expect(names()).toEqual(['Alice', 'Zoe'])
+
+		zoe.dav.favorite = true
+		store.commit('updateContactFavorite', zoe)
+		expect(names()).toEqual(['Zoe', 'Alice'])
+
+		zoe.dav.favorite = false
+		store.commit('updateContactFavorite', zoe)
+		expect(names()).toEqual(['Alice', 'Zoe'])
+	})
+
+	test('updateContactAddressbook re-keys the entry at the same position', () => {
+		store.commit('addContact', contact('Alice'))
+		const moved = contact('Bob')
+		store.commit('addContact', moved)
+		store.commit('addContact', contact('Zoe'))
+
+		const oldKey = moved.key
+		store.commit('updateContactAddressbook', { contact: moved, addressbook: otherAddressbook })
+
+		expect(moved.key).not.toBe(oldKey)
+		expect(names()).toEqual(['Alice', 'Bob', 'Zoe'])
+		expect(store.state.contacts.sortedContacts[1].key).toBe(moved.key)
+	})
+
+	// the same contact copied into two address books shares its uid and name,
+	// so the address book part of the key is what orders them
+	test('updateContactAddressbook re-sorts when the new key orders differently', () => {
+		const thirdAddressbook = { id: 'ab3', displayName: 'Third address book', enabled: true, contacts: {} }
+		const moved = new Contact(`BEGIN:VCARD
+VERSION:4.0
+UID:john
+FN:John
+END:VCARD`, addressbook)
+		const copy = new Contact(`BEGIN:VCARD
+VERSION:4.0
+UID:john
+FN:John
+END:VCARD`, otherAddressbook)
+
+		store.commit('addContact', moved)
+		store.commit('addContact', copy)
+		expect(store.state.contacts.sortedContacts.map((c) => c.key)).toEqual([moved.key, copy.key])
+
+		store.commit('updateContactAddressbook', { contact: moved, addressbook: thirdAddressbook })
+
+		expect(store.state.contacts.sortedContacts.map((c) => c.key)).toEqual([copy.key, moved.key])
+	})
+
+	// appendContacts fills the contacts map without indexing them
+	test('updateContactAddressbook ignores a contact that is not indexed yet', () => {
+		const unindexed = contact('Alice')
+		store.commit('appendContacts', [unindexed])
+
+		store.commit('updateContactAddressbook', { contact: unindexed, addressbook: otherAddressbook })
+		expect(names()).toEqual([])
+	})
+
+	test('deleteContact leaves the index alone when the contact is not indexed', () => {
+		store.commit('addContact', contact('Alice'))
+		store.commit('addContact', contact('Zoe'))
+		const unindexed = contactWithUid('unindexed', 'Bob')
+		store.commit('appendContacts', [unindexed])
+
+		store.commit('deleteContact', unindexed)
+		expect(names()).toEqual(['Alice', 'Zoe'])
+	})
+})


### PR DESCRIPTION
Fix #5681
Fix #5158

Assisted-by: ClaudeCode:claude-opus-5



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact sorting with consistent favorite prioritization and secondary ordering.
  * Preserved correct ordering when adding, updating, or replacing contacts in address books.
  * Fixed sorting behavior for large contact lists and contacts with irregular revision values.
  * Prevented errors when deleting contacts that are no longer present.

* **Tests**
  * Expanded coverage for contact insertion, updates, favorites, address book changes, deletion, and re-sorting across different contact fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->