### PR TITLE
fix(contact-details): keep the type select inside the label column

### DIFF
--- a/src/css/Properties/Properties.scss
+++ b/src/css/Properties/Properties.scss
@@ -52,8 +52,12 @@ $property-row-gap: $contact-details-row-gap;
 		@media screen and (max-width: 1024px) {
 			width: fit-content;
 		}
+		// NcSelect enforces a 260px min-width, which overflows the label column
+		> .nc-select.v-select.select {
+			min-width: 0;
+		}
 		// Text label styling
-		> :not(.multiselect):not(.material-design-icon) {
+		> :not(.nc-select):not(.material-design-icon) {
 			overflow: hidden;
 			white-space: nowrap;
 			text-overflow: ellipsis;


### PR DESCRIPTION
caused by 
https://github.com/nextcloud/calendar/pull/8056 && https://github.com/nextcloud/contacts/pull/5647 

| b | a |
|--------|--------|
| <img width="946" height="758" alt="image" src="https://github.com/user-attachments/assets/4953724c-0f0d-4ab4-b069-7d2f4bb13bef" /> | <img width="946" height="758" alt="image" src="https://github.com/user-attachments/assets/6611ac41-3cc9-4ccf-8cad-14ff9b8cd7c6" /> | 



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
